### PR TITLE
Update transform-notebooks.yml

### DIFF
--- a/.github/workflows/transform-notebooks.yml
+++ b/.github/workflows/transform-notebooks.yml
@@ -68,14 +68,14 @@ jobs:
             # first we delete all Rmd files and regenerate. This will make sure
             # that if a .irnb file is deleted then the corresponding .Rmd file
             # will also be removed by this script.
-            git rm "$dir"/*.Rmd
+            find "$dir" -maxdepth 1 -type f -name '*.Rmd' -exec git rm {} \;
             R -e "
               files <- list.files(path = '$dir', pattern = '\\\\.irnb$', full.names = TRUE, recursive = FALSE)
               lapply(files, function(input) {
                 rmarkdown::convert_ipynb(input)
               })
             "
-            git add "$dir"/*.Rmd
+            find "$dir" -maxdepth 1 -type f -name '*.Rmd' -exec git add {} \;
         else
             echo "Directory $dir does not exist."
         fi


### PR DESCRIPTION
There was an edge case mistake in the transform yaml file. If a folder did not contain any Rmd file already then the git rm *.Rmd command would fail. Moreover this command would remove files recursively in subfolders too.

fixed these two mistakes