### PR TITLE
Update transform-notebooks.yml

### DIFF
--- a/.github/workflows/transform-notebooks.yml
+++ b/.github/workflows/transform-notebooks.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/checkout@v3
       with:
           fetch-depth: 0
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -98,8 +99,8 @@ jobs:
     - name: Commit and push stripped .ipynb files
       if: steps.verify_diff.outputs.changed == 'true'
       run: |
-        git config --global user.name 'github-actions[bot]'
-        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git config --global user.name 'metricsml-bot'
+        git config --global user.email 'ga.metricsml.bot@gmail.com'
         git pull
         dirs=(PM1 PM2 PM3 PM4 PM5 CM1 CM2 CM3 AC1 AC2 T)
         for dir in "${dirs[@]}"; do
@@ -114,4 +115,4 @@ jobs:
         git commit -m 'Strip outputs from .ipynb files [skip ci]'
         git push --force-with-lease
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.BOT_ACCESS_TOKEN }}


### PR DESCRIPTION
The github bot cannot push to the protected main branch!

i created a new github user and generated a personal access token for that user and now the github action pushes from that user as outlined here in the top response:
https://stackoverflow.com/questions/69263843/how-to-push-to-protected-main-branches-in-a-github-action

Then in the branch protection rule this new user is added to the users that can bypass the protections.
