### PR TITLE
Update python-nonlinear-ml-for-wage-prediction.ipynb

### DIFF
--- a/PM3/python-nonlinear-ml-for-wage-prediction.ipynb
+++ b/PM3/python-nonlinear-ml-for-wage-prediction.ipynb
@@ -1313,6 +1313,7 @@
    "source": [
     "automl = make_pipeline(base, AutoML(task='regression', time_budget=60, early_stop=True,\n",
     "                                    eval_method='cv', n_splits=3, metric='r2',\n",
+    "                                    estimator_list=['lgbm', 'xgboost', 'xgb_limitdepth', 'rf', 'extra_tree'],\n",
     "                                    verbose=3,\n",
     "                                    ensemble={'passthrough': False,  # whether stacker will use raw X's or predictions\n",
     "                                              'final_estimator': RLasso()}))"
@@ -1361,6 +1362,7 @@
    "source": [
     "automl = make_pipeline(base, AutoML(task='regression', time_budget=60, early_stop=True,\n",
     "                                    eval_method='cv', n_splits=3, metric='r2',\n",
+    "                                    estimator_list=['lgbm', 'xgboost', 'xgb_limitdepth', 'rf', 'extra_tree'],\n",
     "                                    verbose=3,\n",
     "                                    ensemble={'passthrough': True,  # whether stacker will use raw X's or predictions\n",
     "                                              'final_estimator': RLasso()}))"
@@ -1420,9 +1422,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Some flaml update causes an error during stacking.

They added "sgd" to the class of estimators they select amongst, but there is an incompatibility with stacking, so had to explicitly state the estimator list to exclude "sgd"