### PR TITLE
Update CATE-estimation.ipynb

### DIFF
--- a/T/CATE-estimation.ipynb
+++ b/T/CATE-estimation.ipynb
@@ -14,15 +14,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "g5Ju84HQ3DBe"
-   },
-   "source": [
-    "If the `econml` and `wget` python packages are not installed on your machine install them by running the cells below."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -30,6 +21,15 @@
    "source": [
     "!pip uninstall -y xgboost",
     "!pip install xgboost==2.0.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g5Ju84HQ3DBe"
+   },
+   "source": [
+    "If the `econml` and `wget` python packages are not installed on your machine install them by running the cells below."
    ]
   },
   {

--- a/T/CATE-estimation.ipynb
+++ b/T/CATE-estimation.ipynb
@@ -28,6 +28,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip uninstall -y xgboost",
+    "!pip install xgboost==2.0.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "!pip install econml"
    ]
   },

--- a/T/CATE-estimation.ipynb
+++ b/T/CATE-estimation.ipynb
@@ -19,7 +19,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip uninstall -y xgboost",
     "!pip install xgboost==2.0.1"
    ]
   },


### PR DESCRIPTION
xgboost newest version gives error in ```explainer = shap.TreeExplainer(drlearner)``` line: ```UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb2 in position 1835: invalid start byte.```

Some cursory digging suggested this was an xgboost error, so I just downgraded to !pip install xgboost==2.0.1 in the beginning of the notebook, and everything seems to work fine