### PR TITLE
Update CATE-estimation.ipynb

### DIFF
--- a/T/CATE-estimation.ipynb
+++ b/T/CATE-estimation.ipynb
@@ -28,7 +28,7 @@
     "id": "g5Ju84HQ3DBe"
    },
    "source": [
-    "If the `econml` and `wget` python packages are not installed on your machine install them by running the cells below."
+    "If the `econml` python package is not installed on your machine, install them by running the cells below."
    ]
   },
   {
@@ -38,17 +38,6 @@
    "outputs": [],
    "source": [
     "!pip install econml"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "Q18wYNnk3DBg"
-   },
-   "outputs": [],
-   "source": [
-    "!pip install wget"
    ]
   },
   {


### PR DESCRIPTION
!pip install wget breaks the notebook (related to newest release of numpy I think, 3/16/25)

I deleted the wget line as it works fine in colab without it