### PR TITLE
Refactor `DoubleML_and_Feature_Engineering_with_BERT.ipynb`

### DIFF
--- a/PM5/DoubleML_and_Feature_Engineering_with_BERT.ipynb
+++ b/PM5/DoubleML_and_Feature_Engineering_with_BERT.ipynb
@@ -1,1181 +1,3327 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dYwg9btt1wJH"
-   },
-   "source": [
-    "# BERT\n",
-    "\n",
-    "**Bidirectional Encoder Representations from Transformers.**\n",
-    "\n",
-    "_ | _\n",
-    "- | -\n",
-    "![alt](https://pytorch.org/assets/images/bert1.png) | ![alt](https://pytorch.org/assets/images/bert2.png)\n",
-    "\n",
-    "\n",
-    "### **Overview**\n",
-    "\n",
-    "BERT was released together with the paper [BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding](https://arxiv.org/abs/1810.04805) by Jacob Devlin *et al.* The model is based on the Transformer architecture introduced in [Attention Is All You Need](https://arxiv.org/abs/1706.03762) by Ashish Vaswani *et al.* and has led to significant improvements in a wide range of natural language tasks.\n",
-    "\n",
-    "At the highest level, BERT maps from a block of text to a numeric vector which summarizes the relevant information in the text.\n",
-    "\n",
-    "What is remarkable is that numeric summary is sufficiently informative that, for example, the numeric summary of a paragraph followed by a reading comprehension question contains all the information necessary to satisfactorily answer the question.\n",
-    "\n",
-    "#### **Transfer Learning**\n",
-    "\n",
-    "BERT is a great example of a paradigm called *transfer learning*, which has proved very effective in recent years. In the first step, a network is trained on an unsupervised task using massive amounts of data. In the case of BERT, it was trained to predict missing words and to detect when pairs of sentences are presented in reversed order using all of Wikipedia. This was initially done by Google, using intense computational resources.\n",
-    "\n",
-    "Once this network has been trained, it is then used to perform many other supervised tasks using only limited data and computational resources: for example, sentiment classification in tweets or question answering. The network is re-trained to perform these other tasks in such a way that only the final, output parts of the network are allowed to adjust by very much, so that most of the \"information'' originally learned the network is preserved. This process is called *fine tuning*."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "TgWpXdSIl5KL"
-   },
-   "source": [
-    "##Getting to know BERT\n",
-    "\n",
-    "BERT, and many of its variants, are made available to the public by the open source [Huggingface Transformers](https://huggingface.co/transformers/) project. This is an amazing resource, giving researchers and practitioners easy-to-use access to this technology.\n",
-    "\n",
-    "In order to use BERT for modeling, we simply need to download the pre-trained neural network and fine tune it on our dataset, which is illustrated below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "Y7hnE0rbdOmB"
-   },
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "# Install Huggingface Transformers toolkit\n",
-    "!pip install transformers==4.37.2    # Last version of transformers before keras 3\n",
-    "!pip install shap\n",
-    "!pip install tensorflow_addons\n",
-    "!pip install livelossplot\n",
-    "!pip install sqldf\n",
-    "# !pip install auto-sklearn\n",
-    "# !pip install -U scikit-learn"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "1ku5QTraekzt"
-   },
-   "outputs": [],
-   "source": [
-    "gdrive = False  # set to True to save weights to your google drive\n",
-    "if gdrive:\n",
-    "    # Mount google drive so we can save stuff for later\n",
-    "    from google.colab import drive\n",
-    "    drive.mount('/content/gdrive')\n",
-    "    weights_folder = \"/content/gdrive/MyDrive\"\n",
-    "else:\n",
-    "    weights_folder = \"\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "hGRPttHC5WJU"
-   },
-   "outputs": [],
-   "source": [
-    "# Load dependencies\n",
-    "import tensorflow as tf\n",
-    "import os\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import sqldf as sql\n",
-    "import plotnine as p9\n",
-    "p9.theme_set(p9.theme_bw)\n",
-    "\n",
-    "import statsmodels.formula.api as sm\n",
-    "from transformers import TFBertModel, BertTokenizer\n",
-    "\n",
-    "# Formatting tools\n",
-    "from pprint import pformat\n",
-    "np.set_printoptions(threshold=10)\n",
-    "import warnings\n",
-    "warnings.simplefilter('ignore')\n",
-    "\n",
-    "from tensorflow.keras import Model, Input\n",
-    "from tensorflow.keras.layers import Dense, Concatenate\n",
-    "import tensorflow_addons as tfa\n",
-    "from tensorflow.keras import regularizers\n",
-    "from livelossplot import PlotLossesKeras\n",
-    "\n",
-    "from sklearn.linear_model import LassoCV\n",
-    "from sklearn.model_selection import KFold\n",
-    "from sklearn.preprocessing import StandardScaler\n",
-    "from sklearn.pipeline import make_pipeline\n",
-    "from sklearn.model_selection import train_test_split\n",
-    "import matplotlib.pyplot as plt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "tLiPywGO0ZEd"
-   },
-   "outputs": [],
-   "source": [
-    "def ssq(x):\n",
-    "    return np.inner(x, x)\n",
-    "\n",
-    "\n",
-    "def get_r2(y, yhat):\n",
-    "    resids = yhat.reshape(-1) - y\n",
-    "    flucs = y - np.mean(y)\n",
-    "    print('RSS: {}, TSS + MEAN^2: {}, TSS: {}, R^2: {}'.format(ssq(resids),\n",
-    "                                                               ssq(y),\n",
-    "                                                               ssq(flucs),\n",
-    "                                                               1 - ssq(resids) / ssq(flucs)))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "WPY0wQktrZb1"
-   },
-   "outputs": [],
-   "source": [
-    "# Load TensorFlow, and ensure GPU is present\n",
-    "# The GPU will massively speed up neural network training\n",
-    "device_name = tf.test.gpu_device_name()\n",
-    "if device_name != '/device:GPU:0':\n",
-    "    warnings.warn('GPU device not found')\n",
-    "print('Found GPU at: {}'.format(device_name))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "8aNZcJwIcL5T"
-   },
-   "outputs": [],
-   "source": [
-    "# Download text pre-processor (\"tokenizer\")\n",
-    "tokenizer = BertTokenizer.from_pretrained(\"bert-base-uncased\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "K_ljmPI3cEQI"
-   },
-   "outputs": [],
-   "source": [
-    "# Download BERT model\n",
-    "bert = TFBertModel.from_pretrained(\"bert-base-uncased\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "26mRwUFwardQ"
-   },
-   "source": [
-    "### Tokenization\n",
-    "\n",
-    "The first step in using BERT (or any similar text embedding tool) is to *tokenize* the data. This step standardizes blocks of text, so that meaningless differences in text presentation don't affect the behavior of our algorithm.\n",
-    "\n",
-    "Typically the text is transformed into a sequence of 'tokens,' each of which corresponds to a numeric code."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "vnLlb5peTwqM"
-   },
-   "outputs": [],
-   "source": [
-    "# Let's try it out!\n",
-    "s = \"What happens to this string?\"\n",
-    "print('Original String: \\n\\\"{}\\\"\\n'.format(s))\n",
-    "tensors = tokenizer(s)\n",
-    "print('Numeric encoding: \\n' + pformat(tensors))\n",
-    "\n",
-    "# What does this mean?\n",
-    "print('\\nActual tokens:')\n",
-    "tokenizer.convert_ids_to_tokens(tensors['input_ids'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "JJaz6eEocefa"
-   },
-   "source": [
-    "### BERT in a nutshell\n",
-    "\n",
-    "Once we have our numeric tokens, we can simply plug them into the BERT network and get a numeric vector summary. Note that in applications, the BERT summary will be \"fine tuned\" to a particular task, which hasn't happened yet."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "Q1ODAgBMa3Zg"
-   },
-   "outputs": [],
-   "source": [
-    "print('Input: \"What happens to this string?\"\\n')\n",
-    "\n",
-    "# Tokenize the string\n",
-    "tensors_tf = tokenizer(\"What happens to this string?\", return_tensors=\"tf\")\n",
-    "\n",
-    "# Run it through BERT\n",
-    "output = bert(tensors_tf)\n",
-    "\n",
-    "# Inspect the output\n",
-    "_shape = output['pooler_output'].shape\n",
-    "print(\"\"\"Output type: {}\\n\n",
-    "      Output shape: {}\\n\n",
-    "      Output preview: {}\\n\"\"\".format(type(output['pooler_output']),\n",
-    "                                     _shape,\n",
-    "                                     pformat(output['pooler_output'].numpy())))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "y_CnEClsl_1p"
-   },
-   "source": [
-    "# A practical introduction to BERT\n",
-    "\n",
-    "In the next part of the notebook, we are going to explore how a tool like BERT may be useful for causal inference.\n",
-    "\n",
-    "In particular, we are going to apply BERT to a subset of data from the Amazon marketplace consisting of roughly 10,000 listings for products in the toy category. Each product comes with a text description, a price, and a number of times reviewed (which we'll use as a proxy for demand / market share).\n",
-    "\n",
-    "For more information on the dataset, checkout the [Dataset README](https://github.com/CausalAIBook/MetricsMLNotebooks/blob/main/data/amazon_toys.md).\n",
-    "\n",
-    "**For thought**:\n",
-    "What are some issues you may anticipate when using number of reviews as a proxy for demand or market share?\n",
-    "\n",
-    "### Getting to know the data\n",
-    "\n",
-    "First, we'll download and clean up the data, and do some preliminary inspection."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "5kzXygwH0BKw"
-   },
-   "outputs": [],
-   "source": [
-    "DATA_URL = 'https://github.com/CausalAIBook/MetricsMLNotebooks/raw/main/data/amazon_toys.csv'\n",
-    "data = pd.read_csv(DATA_URL)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "NDgWwxUWErnh"
-   },
-   "outputs": [],
-   "source": [
-    "data.columns"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "1Su5vOGhD3Df"
-   },
-   "outputs": [],
-   "source": [
-    "# Clean numeric data fields (remove all non-digit characters and parse as a numeric value)\n",
-    "data['number_of_reviews'] = pd.to_numeric(data\n",
-    "                                          .number_of_reviews\n",
-    "                                          .str.replace(',', '')  # Remove commas\n",
-    "                                          .str.replace(r\"\\D+\", ''))\n",
-    "data['price'] = (data\n",
-    "                 .price\n",
-    "                 .str.extract(r'(\\d+\\.*\\d+)')\n",
-    "                 .astype('float'))\n",
-    "\n",
-    "# Drop products with very few reviews\n",
-    "data = data[data['number_of_reviews'] > 0]\n",
-    "\n",
-    "# Compute log prices\n",
-    "data['ln_p'] = np.log(data.price)\n",
-    "\n",
-    "# Impute market shares from # of reviews\n",
-    "data['ln_q'] = np.log(data['number_of_reviews'] / data['number_of_reviews'].sum())\n",
-    "\n",
-    "# Collect relevant text data\n",
-    "data['text'] = (data[['product_name',\n",
-    "                      'manufacturer',\n",
-    "                      'product_description']]\n",
-    "                .astype('str')\n",
-    "                .agg(' | '.join, axis=1))\n",
-    "\n",
-    "#  Drop irrelevant data and inspect\n",
-    "data = data[['text', 'ln_p', 'ln_q', 'amazon_category_and_sub_category']]\n",
-    "data = data.dropna()\n",
-    "data.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "lovFEHaWp4lC"
-   },
-   "outputs": [],
-   "source": [
-    "# Text lengths\n",
-    "data['text_num_words'] = data['text'].str.split().apply(len)\n",
-    "print(np.nanquantile(data['text_num_words'], 0.99))\n",
-    "(p9.ggplot(data, p9.aes('text_num_words')) + p9.geom_density())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "CDlHPQZfcv7I"
-   },
-   "source": [
-    "Let's make a two-way scatter plot of prices and (proxied) market shares."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "dNujhir1q_0N"
-   },
-   "outputs": [],
-   "source": [
-    "(p9.ggplot(data, p9.aes('ln_p', 'ln_q')) + p9.geom_point() + p9.stat_smooth(color=\"red\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "t7axTjsnq8qI"
-   },
-   "outputs": [],
-   "source": [
-    "(p9.ggplot(data, p9.aes('ln_p', 'ln_q')) + p9.stat_smooth(color=\"red\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "aZPOUT5SvR4o"
-   },
-   "outputs": [],
-   "source": [
-    "result = sm.ols('ln_q ~ ln_p ', data=data).fit()\n",
-    "print('Elasticity: {}, SE: {}, R2: {}'.format(result.params['ln_p'], result.bse['ln_p'], result.rsquared_adj))\n",
-    "result.conf_int(alpha=0.05)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cr2Ha215l4QK"
-   },
-   "source": [
-    "Let's begin with a simple prediction task. We will discover how well can we explain the price of these products using their textual descriptions."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "pGt-G-qpciGd"
-   },
-   "outputs": [],
-   "source": [
-    "main_ind, test_ind = train_test_split(np.arange(data.shape[0]), test_size=.2, shuffle=True, random_state=124)\n",
-    "main = data.iloc[main_ind]\n",
-    "\n",
-    "train_ind, val_ind = train_test_split(np.arange(main.shape[0]), test_size=0.25, random_state=124)  # 0.25 x 0.8 = 0.2\n",
-    "\n",
-    "train = main.iloc[train_ind]\n",
-    "val = main.iloc[val_ind]\n",
-    "holdout = data.iloc[test_ind]\n",
-    "\n",
-    "tensors = tokenizer(\n",
-    "    list(train[\"text\"]),\n",
-    "    padding=True,\n",
-    "    truncation=True,\n",
-    "    max_length=128,\n",
-    "    return_tensors=\"tf\")\n",
-    "\n",
-    "val_tensors = tokenizer(\n",
-    "    list(val[\"text\"]),\n",
-    "    padding=True,\n",
-    "    truncation=True,\n",
-    "    max_length=128,\n",
-    "    return_tensors=\"tf\")\n",
-    "\n",
-    "# Preprocess holdout sample\n",
-    "tensors_holdout = tokenizer(\n",
-    "    list(holdout[\"text\"]),\n",
-    "    padding=True,\n",
-    "    truncation=True,\n",
-    "    max_length=128,\n",
-    "    return_tensors=\"tf\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "XQ4DMJQ0drZm"
-   },
-   "outputs": [],
-   "source": [
-    "ln_p = train[\"ln_p\"]\n",
-    "ln_q = train[\"ln_q\"]\n",
-    "val_ln_p = val[\"ln_p\"]\n",
-    "val_ln_q = val[\"ln_q\"]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "gPYEMuKZ7ylj"
-   },
-   "source": [
-    "# Using BERT as Feature Extractor"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "AJu0FlEcu6Zj"
-   },
-   "outputs": [],
-   "source": [
-    "input_ids = Input(shape=(128,), dtype=tf.int32)\n",
-    "token_type_ids = Input(shape=(128,), dtype=tf.int32)\n",
-    "attention_mask = Input(shape=(128,), dtype=tf.int32)\n",
-    "\n",
-    "Z = bert(input_ids, token_type_ids, attention_mask)[1]\n",
-    "\n",
-    "embedding_model = Model([input_ids, token_type_ids, attention_mask], Z)\n",
-    "\n",
-    "embeddings = embedding_model.predict([tensors['input_ids'], tensors['token_type_ids'], tensors['attention_mask']])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "-SSqzkf3vx8I"
-   },
-   "outputs": [],
-   "source": [
-    "lcv = make_pipeline(StandardScaler(), LassoCV(cv=KFold(n_splits=5, shuffle=True, random_state=123), random_state=123))\n",
-    "lcv.fit(embeddings, ln_p)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "hLEZ1JL2weU9"
-   },
-   "outputs": [],
-   "source": [
-    "embeddings_val = embedding_model.predict([val_tensors['input_ids'],\n",
-    "                                          val_tensors['token_type_ids'],\n",
-    "                                          val_tensors['attention_mask']])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "4Aez3Il1wp4x"
-   },
-   "outputs": [],
-   "source": [
-    "get_r2(val_ln_p, lcv.predict(embeddings_val))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "u1aRxiWsBO-V"
-   },
-   "outputs": [],
-   "source": [
-    "embeddings_holdout = embedding_model.predict([tensors_holdout['input_ids'],\n",
-    "                                              tensors_holdout['token_type_ids'],\n",
-    "                                              tensors_holdout['attention_mask']])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "899QoDe0BVId"
-   },
-   "outputs": [],
-   "source": [
-    "get_r2(holdout['ln_p'], lcv.predict(embeddings_holdout))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "RwzWK34wBY9I"
-   },
-   "outputs": [],
-   "source": [
-    "ln_p_hat_holdout = lcv.predict(embeddings_holdout)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "mOc1_C5p7ta7"
-   },
-   "source": [
-    "# Linear Probing: Training Only Final Layer after BERT"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "Ck1xqRIrmx8I"
-   },
-   "outputs": [],
-   "source": [
-    "# Now let's prepare our model\n",
-    "tf.keras.utils.set_random_seed(123)\n",
-    "\n",
-    "input_ids = Input(shape=(128,), dtype=tf.int32)\n",
-    "token_type_ids = Input(shape=(128,), dtype=tf.int32)\n",
-    "attention_mask = Input(shape=(128,), dtype=tf.int32)\n",
-    "\n",
-    "# First we compute the text embedding\n",
-    "Z = bert(input_ids, token_type_ids, attention_mask)\n",
-    "\n",
-    "for layer in bert.layers:\n",
-    "    layer.trainable = False\n",
-    "    for w in layer.weights:\n",
-    "        w._trainable = False\n",
-    "\n",
-    "# We want the \"pooled / summary\" embedding, not individual word embeddings\n",
-    "Z = Z[1]\n",
-    "\n",
-    "# Then we do a regular regression\n",
-    "ln_p_hat = Dense(1, activation='linear',\n",
-    "                 kernel_regularizer=regularizers.L2(1e-3))(Z)\n",
-    "\n",
-    "PricePredictionNetwork = Model([input_ids,\n",
-    "                                token_type_ids,\n",
-    "                                attention_mask], ln_p_hat)\n",
-    "PricePredictionNetwork.compile(\n",
-    "    optimizer=tf.keras.optimizers.Adam(learning_rate=1e-3),\n",
-    "    loss=tf.keras.losses.MeanSquaredError(),\n",
-    "    metrics=tfa.metrics.RSquare(),\n",
-    ")\n",
-    "PricePredictionNetwork.summary()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "XhTREb3NcZhH"
-   },
-   "outputs": [],
-   "source": [
-    "tf.keras.utils.set_random_seed(123)\n",
-    "earlystopping = tf.keras.callbacks.EarlyStopping(monitor='val_loss', patience=5, restore_best_weights=True)\n",
-    "modelcheckpoint = tf.keras.callbacks.ModelCheckpoint(os.path.join(weights_folder, \"pweights.hdf5\"),\n",
-    "                                                     monitor='val_loss',\n",
-    "                                                     save_best_only=True,\n",
-    "                                                     save_weights_only=True)\n",
-    "\n",
-    "PricePredictionNetwork.fit(x=[tensors['input_ids'],\n",
-    "                              tensors['token_type_ids'],\n",
-    "                              tensors['attention_mask']],\n",
-    "                           y=ln_p,\n",
-    "                           validation_data=([val_tensors['input_ids'],\n",
-    "                                             val_tensors['token_type_ids'],\n",
-    "                                             val_tensors['attention_mask']], val_ln_p),\n",
-    "                           epochs=5,\n",
-    "                           callbacks=[earlystopping, modelcheckpoint,\n",
-    "                                      PlotLossesKeras(groups={'train_loss': ['loss'],\n",
-    "                                                              'train_rsq':['r_square'],\n",
-    "                                                              'val_loss': ['val_loss'],\n",
-    "                                                              'val_rsq': ['val_r_square']})],\n",
-    "                           batch_size=16,\n",
-    "                           shuffle=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "MyFxR5GC8C3K"
-   },
-   "source": [
-    "# Fine Tuning starting from the Linear Probing Trained Weights\n",
-    "\n",
-    "Now we train the whole network, initializing the weights based on the result of the linear probing phase in the previous section."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "NzWCkTY87luH"
-   },
-   "outputs": [],
-   "source": [
-    "# Now let's prepare our model\n",
-    "tf.keras.utils.set_random_seed(123)\n",
-    "\n",
-    "input_ids = Input(shape=(128,), dtype=tf.int32)\n",
-    "token_type_ids = Input(shape=(128,), dtype=tf.int32)\n",
-    "attention_mask = Input(shape=(128,), dtype=tf.int32)\n",
-    "\n",
-    "# First we compute the text embedding\n",
-    "Z = bert(input_ids, token_type_ids, attention_mask)\n",
-    "\n",
-    "for layer in bert.layers:\n",
-    "    layer.trainable = True\n",
-    "    for w in layer.weights:\n",
-    "        w._trainable = True\n",
-    "\n",
-    "# We want the \"pooled / summary\" embedding, not individual word embeddings\n",
-    "Z = Z[1]\n",
-    "\n",
-    "# Then we do a regularized linear regression\n",
-    "ln_p_hat = Dense(1, activation='linear',\n",
-    "                 kernel_regularizer=regularizers.L2(1e-3))(Z)\n",
-    "\n",
-    "PricePredictionNetwork = Model([input_ids,\n",
-    "                                token_type_ids,\n",
-    "                                attention_mask], ln_p_hat)\n",
-    "PricePredictionNetwork.compile(\n",
-    "    optimizer=tf.keras.optimizers.Adam(learning_rate=1e-5),\n",
-    "    loss=tf.keras.losses.MeanSquaredError(),\n",
-    "    metrics=tfa.metrics.RSquare(),\n",
-    ")\n",
-    "PricePredictionNetwork.summary()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "PWauCl0T7nUo"
-   },
-   "outputs": [],
-   "source": [
-    "PricePredictionNetwork.load_weights(os.path.join(weights_folder, \"pweights.hdf5\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "iDSBZWAe8nhE"
-   },
-   "outputs": [],
-   "source": [
-    "tf.keras.utils.set_random_seed(123)\n",
-    "\n",
-    "earlystopping = tf.keras.callbacks.EarlyStopping(monitor='val_loss', patience=5, restore_best_weights=True)\n",
-    "modelcheckpoint = tf.keras.callbacks.ModelCheckpoint(os.path.join(weights_folder, \"pweights.hdf5\"),\n",
-    "                                                     monitor='val_loss',\n",
-    "                                                     save_best_only=True,\n",
-    "                                                     save_weights_only=True)\n",
-    "\n",
-    "PricePredictionNetwork.fit(x=[tensors['input_ids'],\n",
-    "                              tensors['token_type_ids'],\n",
-    "                              tensors['attention_mask']],\n",
-    "                           y=ln_p,\n",
-    "                           validation_data=([val_tensors['input_ids'],\n",
-    "                                             val_tensors['token_type_ids'],\n",
-    "                                             val_tensors['attention_mask']], val_ln_p),\n",
-    "                           epochs=10,\n",
-    "                           callbacks=[earlystopping, modelcheckpoint,\n",
-    "                                      PlotLossesKeras(groups={'train_loss': ['loss'],\n",
-    "                                                              'train_rsq':['r_square'],\n",
-    "                                                              'val_loss': ['val_loss'],\n",
-    "                                                              'val_rsq': ['val_r_square']})],\n",
-    "                           batch_size=16,\n",
-    "                           shuffle=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "wchpbXoqBAJu"
-   },
-   "outputs": [],
-   "source": [
-    "PricePredictionNetwork.load_weights(os.path.join(weights_folder, \"pweights.hdf5\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "jpUmDHYfkJEZ"
-   },
-   "outputs": [],
-   "source": [
-    "# Compute predictions\n",
-    "ln_p_hat_holdout = PricePredictionNetwork.predict([tensors_holdout['input_ids'],\n",
-    "                                                   tensors_holdout['token_type_ids'],\n",
-    "                                                   tensors_holdout['attention_mask']])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "g_XK81hpkQMN"
-   },
-   "outputs": [],
-   "source": [
-    "print('Neural Net R^2, Price Prediction:')\n",
-    "get_r2(holdout['ln_p'], ln_p_hat_holdout)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "GR4QP4DJPQk0"
-   },
-   "outputs": [],
-   "source": [
-    "plt.hist(ln_p_hat_holdout)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bafy9ftcoBed"
-   },
-   "source": [
-    "Now, let's go one step further and construct a DML estimator of the price elasticity in a partially linear model. In particular, we will model market share $q_i$ as\n",
-    "$$\\ln q_i = \\alpha + \\beta \\ln p_i + \\psi(d_i) + \\epsilon_i,$$ where $d_i$ denotes the description of product $i$ and $\\psi$ is the composition of text embedding and a linear layer."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "Qiteu6FaoctV"
-   },
-   "outputs": [],
-   "source": [
-    "# Build the quantity prediction network\n",
-    "tf.keras.utils.set_random_seed(123)\n",
-    "\n",
-    "# Initialize new BERT model from original\n",
-    "bert2 = TFBertModel.from_pretrained(\"bert-base-uncased\")\n",
-    "\n",
-    "# for layer in bert2.layers:\n",
-    "#     layer.trainable=False\n",
-    "#     for w in layer.weights: w._trainable=False\n",
-    "\n",
-    "# Define inputs\n",
-    "input_ids = Input(shape=(128,), dtype=tf.int32)\n",
-    "token_type_ids = Input(shape=(128,), dtype=tf.int32)\n",
-    "attention_mask = Input(shape=(128,), dtype=tf.int32)\n",
-    "\n",
-    "# First we compute the text embedding\n",
-    "Z = bert2(input_ids, token_type_ids, attention_mask)\n",
-    "\n",
-    "# We want the \"pooled / summary\" embedding, not individual word embeddings\n",
-    "Z = Z[1]\n",
-    "\n",
-    "ln_q_hat = Dense(1, activation='linear', kernel_regularizer=regularizers.L2(1e-3))(Z)\n",
-    "\n",
-    "# Compile model and optimization routine\n",
-    "QuantityPredictionNetwork = Model([input_ids,\n",
-    "                                   token_type_ids,\n",
-    "                                   attention_mask], ln_q_hat)\n",
-    "QuantityPredictionNetwork.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=1e-5),\n",
-    "                                  loss=tf.keras.losses.MeanSquaredError(),\n",
-    "                                  metrics=tfa.metrics.RSquare())\n",
-    "QuantityPredictionNetwork.summary()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "aaxHV0gGMqpw"
-   },
-   "outputs": [],
-   "source": [
-    "# Fit the quantity prediction network in the main sample\n",
-    "tf.keras.utils.set_random_seed(123)\n",
-    "\n",
-    "earlystopping = tf.keras.callbacks.EarlyStopping(monitor='val_loss', patience=5, restore_best_weights=True)\n",
-    "modelcheckpoint = tf.keras.callbacks.ModelCheckpoint(os.path.join(weights_folder, \"qweights.hdf5\"),\n",
-    "                                                     monitor='val_loss',\n",
-    "                                                     save_best_only=True,\n",
-    "                                                     save_weights_only=True)\n",
-    "\n",
-    "QuantityPredictionNetwork.fit([tensors['input_ids'],\n",
-    "                               tensors['token_type_ids'],\n",
-    "                               tensors['attention_mask']],\n",
-    "                              ln_q,\n",
-    "                              validation_data=([val_tensors['input_ids'],\n",
-    "                                                val_tensors['token_type_ids'],\n",
-    "                                                val_tensors['attention_mask']], val_ln_q),\n",
-    "                              epochs=10,\n",
-    "                              callbacks=[earlystopping, modelcheckpoint,\n",
-    "                                         PlotLossesKeras(groups={'train_loss': ['loss'],\n",
-    "                                                                 'train_rsq':['r_square'],\n",
-    "                                                                 'val_loss': ['val_loss'],\n",
-    "                                                                 'val_rsq': ['val_r_square']})],\n",
-    "                              batch_size=16,\n",
-    "                              shuffle=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "TfyQV3lw-xf2"
-   },
-   "outputs": [],
-   "source": [
-    "QuantityPredictionNetwork.load_weights(os.path.join(weights_folder, \"qweights.hdf5\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "YADpNj0jMygZ"
-   },
-   "outputs": [],
-   "source": [
-    "# Predict in the holdout sample, residualize and regress\n",
-    "ln_q_hat_holdout = QuantityPredictionNetwork.predict([tensors_holdout['input_ids'],\n",
-    "                                                      tensors_holdout['token_type_ids'],\n",
-    "                                                      tensors_holdout['attention_mask']])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "jh4criU1hGIP"
-   },
-   "outputs": [],
-   "source": [
-    "print('Neural Net R^2, Quantity Prediction:')\n",
-    "get_r2(holdout['ln_q'], ln_q_hat_holdout)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "ir-_yAfkPM6f"
-   },
-   "outputs": [],
-   "source": [
-    "# Compute residuals\n",
-    "r_p = holdout[\"ln_p\"] - ln_p_hat_holdout.reshape((-1,))\n",
-    "r_q = holdout[\"ln_q\"] - ln_q_hat_holdout.reshape((-1,))\n",
-    "\n",
-    "# Regress to obtain elasticity estimate\n",
-    "beta = np.mean(r_p * r_q) / np.mean(r_p * r_p)\n",
-    "\n",
-    "# standard error on elastiticy estimate\n",
-    "se = np.sqrt(np.mean((r_p * r_q)**2) / (np.mean(r_p * r_p)**2) / holdout[\"ln_p\"].size)\n",
-    "\n",
-    "print('Elasticity of Demand with Respect to Price: {}'.format(beta))\n",
-    "print('Standard Error: {}'.format(se))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "VCqeRTB_BNEH"
-   },
-   "source": [
-    "# Heterogeneous Elasticities within Major Product Categories\n",
-    "\n",
-    "We now look at the major product categories that have many products, and we investigate whether the \"within group\" price elasticities vary."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "XRUZEXqc8HPG"
-   },
-   "outputs": [],
-   "source": [
-    "holdout['category'] = holdout['amazon_category_and_sub_category'].str.split('>').apply(lambda x: x[0])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "ymWJv4Ej7lt9"
-   },
-   "outputs": [],
-   "source": [
-    "# Elasticity within the main product categories\n",
-    "sql.run(\"\"\"\n",
-    "  SELECT category, COUNT(*)\n",
-    "  FROM holdout\n",
-    "  GROUP BY 1\n",
-    "  HAVING COUNT(*)>=100\n",
-    "  ORDER BY 2 desc\n",
-    "\"\"\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "E3ncPtwt8nJi"
-   },
-   "outputs": [],
-   "source": [
-    "main_cats = sql.run(\"\"\"\n",
-    "  SELECT category\n",
-    "  FROM holdout\n",
-    "  GROUP BY 1\n",
-    "  HAVING COUNT(*)>=100\n",
-    "\"\"\")['category']\n",
-    "\n",
-    "dfs = []\n",
-    "for cat in main_cats:\n",
-    "    r_p = holdout[holdout['category'] == cat][\"ln_p\"] - ln_p_hat_holdout.reshape((-1,))[holdout['category'] == cat]\n",
-    "    r_q = holdout[holdout['category'] == cat][\"ln_q\"] - ln_q_hat_holdout.reshape((-1,))[holdout['category'] == cat]\n",
-    "    # Regress to obtain elasticity estimate\n",
-    "    beta = np.mean(r_p * r_q) / np.mean(r_p * r_p)\n",
-    "\n",
-    "    # standard error on elastiticy estimate\n",
-    "    se = np.sqrt(np.mean((r_p * r_q)**2) / (np.mean(r_p * r_p)**2) / holdout[\"ln_p\"].size)\n",
-    "\n",
-    "    df = pd.DataFrame({'point': beta, 'se': se, 'lower': beta - 1.96 * se, 'upper': beta + 1.96 * se}, index=[0])\n",
-    "    df['category'] = cat\n",
-    "    df['N'] = holdout[holdout['category'] == cat].shape[0]\n",
-    "    dfs.append(df)\n",
-    "\n",
-    "df = pd.concat(dfs)\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "QFTjf9vP6Zfu"
-   },
-   "source": [
-    "## Clustering Products\n",
-    "\n",
-    "In this final part of the notebook, we'll illustrate how the BERT text embeddings can be used to cluster products based on their  descriptions.\n",
-    "\n",
-    "Intiuitively, our neural network has now learned which aspects of the text description are relevant to predict prices and market shares.\n",
-    "We can therefore use the embeddings produced by our network to cluster products, and we might expect that the clusters reflect market-relevant information.\n",
-    "\n",
-    "In the following block of cells, we compute embeddings using our learned models and cluster them using $k$-means clustering with $k=10$. Finally, we will explore how the estimated price elasticity differs across clusters.\n",
-    "\n",
-    "### Overview of **$k$-means clustering**\n",
-    "The $k$-means clustering algorithm seeks to divide $n$ data vectors into $k$ groups, each of which contain points that are \"close together.\"\n",
-    "\n",
-    "In particular, let $C_1, \\ldots, C_k$ be a partitioning of the data into $k$ disjoint, nonempty subsets (clusters), and define\n",
-    "$$\\bar{C_i}=\\frac{1}{\\#C_i}\\sum_{x \\in C_i} x$$\n",
-    "to be the *centroid* of the cluster $C_i$. The $k$-means clustering score $\\mathrm{sc}(C_1 \\ldots C_k)$ is defined to be\n",
-    "$$\\mathrm{sc}(C_1 \\ldots C_k) = \\sum_{i=1}^k \\sum_{x \\in C_i} \\left(x - \\bar{C_i}\\right)^2.$$\n",
-    "\n",
-    "The $k$-means clustering is then defined to be any partitioning $C^*_1 \\ldots C^*_k$ that minimizes the score $\\mathrm{sc}(-)$.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "Mc7I00JPK6wJ"
-   },
-   "outputs": [],
-   "source": [
-    "# STEP 1: Compute embeddings\n",
-    "\n",
-    "input_ids = Input(shape=(128,), dtype=tf.int32)\n",
-    "token_type_ids = Input(shape=(128,), dtype=tf.int32)\n",
-    "attention_mask = Input(shape=(128,), dtype=tf.int32)\n",
-    "\n",
-    "Y1 = bert(input_ids, token_type_ids, attention_mask)[1]\n",
-    "Y2 = bert2(input_ids, token_type_ids, attention_mask)[1]\n",
-    "Y = Concatenate()([Y1, Y2])\n",
-    "\n",
-    "embedding_model = Model([input_ids, token_type_ids, attention_mask], Y)\n",
-    "\n",
-    "embeddings = embedding_model.predict([tensors_holdout['input_ids'],\n",
-    "                                      tensors_holdout['token_type_ids'],\n",
-    "                                      tensors_holdout['attention_mask']])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "hCG2MunU6iF-"
-   },
-   "source": [
-    "### Dimension reduction and the **Johnson-Lindenstrauss transform**\n",
-    "\n",
-    "Our learned embeddings have dimension in the $1000$s, and $k$-means clustering is often an expensive operation. To improve the situation, we will use a neat trick that is used extensively in machine learning applications: the *Johnson-Lindenstrauss transform*.\n",
-    "\n",
-    "This trick involves finding a low-dimensional linear projection of the embeddings that approximately preserves pairwise distances.\n",
-    "\n",
-    "In fact, Johnson and Lindenstrauss proved a much more interesting statement: a Gaussian random matrix will *almost always* approximately preserve pairwise distances.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "afGiLR7v6ecJ"
-   },
-   "outputs": [],
-   "source": [
-    "# STEP 2 Make low-dimensional projections\n",
-    "from sklearn.random_projection import GaussianRandomProjection\n",
-    "\n",
-    "jl = GaussianRandomProjection(eps=.25)\n",
-    "embeddings_lowdim = jl.fit_transform(embeddings)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "9Tl9AM3J6j3X"
-   },
-   "outputs": [],
-   "source": [
-    "# STEP 3 Compute clusters\n",
-    "from sklearn.cluster import KMeans\n",
-    "\n",
-    "k_means = KMeans(n_clusters=10)\n",
-    "k_means.fit(embeddings_lowdim)\n",
-    "cluster_ids = k_means.labels_"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "0l7De-Do6mD0"
-   },
-   "outputs": [],
-   "source": [
-    "# STEP 4 Regress within each cluster\n",
-    "\n",
-    "betas = np.zeros(10)\n",
-    "ses = np.zeros(10)\n",
-    "\n",
-    "r_p = holdout[\"ln_p\"] - ln_p_hat_holdout.reshape((-1,))\n",
-    "r_q = holdout[\"ln_q\"] - ln_q_hat_holdout.reshape((-1,))\n",
-    "\n",
-    "for c in range(10):\n",
-    "\n",
-    "    r_p_c = r_p[cluster_ids == c]\n",
-    "    r_q_c = r_q[cluster_ids == c]\n",
-    "\n",
-    "    # Regress to obtain elasticity estimate\n",
-    "    betas[c] = np.mean(r_p_c * r_q_c) / np.mean(r_p_c * r_p_c)\n",
-    "\n",
-    "    # standard error on elastiticy estimate\n",
-    "    ses[c] = np.sqrt(np.mean((r_p_c * r_q_c)**2) / (np.mean(r_p_c * r_p_c)**2) / r_p_c.size)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "oXoe98f06njT"
-   },
-   "outputs": [],
-   "source": [
-    "# STEP 5 Plot\n",
-    "from matplotlib import pyplot as plt\n",
-    "\n",
-    "plt.bar(range(10), betas, yerr=1.96 * ses)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "8tTqUNeH6sxi"
-   },
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "gpuClass": "premium",
-   "machine_shape": "hm",
-   "provenance": [],
-   "toc_visible": true
-  },
-  "gpuClass": "premium",
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.5"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dYwg9btt1wJH"
+      },
+      "source": [
+        "# BERT\n",
+        "\n",
+        "**Bidirectional Encoder Representations from Transformers.**\n",
+        "\n",
+        "_ | _\n",
+        "- | -\n",
+        "![alt](https://pytorch.org/assets/images/bert1.png) | ![alt](https://pytorch.org/assets/images/bert2.png)\n",
+        "\n",
+        "\n",
+        "### **Overview**\n",
+        "\n",
+        "BERT was released together with the paper [BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding](https://arxiv.org/abs/1810.04805) by Jacob Devlin *et al.* The model is based on the Transformer architecture introduced in [Attention Is All You Need](https://arxiv.org/abs/1706.03762) by Ashish Vaswani *et al.* and has led to significant improvements in a wide range of natural language tasks.\n",
+        "\n",
+        "At the highest level, BERT maps from a block of text to a numeric vector which summarizes the relevant information in the text.\n",
+        "\n",
+        "What is remarkable is that numeric summary is sufficiently informative that, for example, the numeric summary of a paragraph followed by a reading comprehension question contains all the information necessary to satisfactorily answer the question.\n",
+        "\n",
+        "#### **Transfer Learning**\n",
+        "\n",
+        "BERT is a great example of a paradigm called *transfer learning*, which has proved very effective in recent years. In the first step, a network is trained on an unsupervised task using massive amounts of data. In the case of BERT, it was trained to predict missing words and to detect when pairs of sentences are presented in reversed order using all of Wikipedia. This was initially done by Google, using intense computational resources.\n",
+        "\n",
+        "Once this network has been trained, it is then used to perform many other supervised tasks using only limited data and computational resources: for example, sentiment classification in tweets or question answering. The network is re-trained to perform these other tasks in such a way that only the final, output parts of the network are allowed to adjust by very much, so that most of the \"information'' originally learned the network is preserved. This process is called *fine tuning*."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TgWpXdSIl5KL"
+      },
+      "source": [
+        "## Getting to know BERT\n",
+        "\n",
+        "BERT, and many of its variants, are made available to the public by the open source [Huggingface Transformers](https://huggingface.co/transformers/) project. This is an amazing resource, giving researchers and practitioners easy-to-use access to this technology.\n",
+        "\n",
+        "In order to use BERT for modeling, we simply need to download the pre-trained neural network and fine tune it on our dataset, which is illustrated below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "Y7hnE0rbdOmB"
+      },
+      "outputs": [],
+      "source": [
+        "%%capture\n",
+        "# Install dependencies\n",
+        "!pip install torch transformers plotnine statsmodels scikit-learn matplotlib pandas pyarrow requests sqldf"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "1ku5QTraekzt"
+      },
+      "outputs": [],
+      "source": [
+        "weights_folder = \"weights\"\n",
+        "import os\n",
+        "os.makedirs(weights_folder, exist_ok=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "hGRPttHC5WJU"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "c:\\Users\\Work\\Documents\\GitHub\\MetricsMLNotebooks\\.venv\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Load dependencies\n",
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "from torch.utils.data import TensorDataset, DataLoader\n",
+        "import os\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import sqldf as sql\n",
+        "import plotnine as p9\n",
+        "p9.theme_set(p9.theme_bw)\n",
+        "\n",
+        "import statsmodels.formula.api as sm\n",
+        "from transformers import BertModel, BertTokenizer\n",
+        "import datasets\n",
+        "\n",
+        "# Formatting tools\n",
+        "from pprint import pformat\n",
+        "np.set_printoptions(threshold=10)\n",
+        "import warnings\n",
+        "warnings.simplefilter('ignore')\n",
+        "\n",
+        "from sklearn.linear_model import LassoCV\n",
+        "from sklearn.model_selection import KFold\n",
+        "from sklearn.preprocessing import StandardScaler\n",
+        "from sklearn.pipeline import make_pipeline\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "import matplotlib.pyplot as plt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "tLiPywGO0ZEd"
+      },
+      "outputs": [],
+      "source": [
+        "def ssq(x):\n",
+        "    return np.inner(x, x)\n",
+        "\n",
+        "\n",
+        "def get_r2(y, yhat):\n",
+        "    resids = yhat.reshape(-1) - y\n",
+        "    flucs = y - np.mean(y)\n",
+        "    print('RSS: {}, TSS + MEAN^2: {}, TSS: {}, R^2: {}'.format(ssq(resids),\n",
+        "                                                               ssq(y),\n",
+        "                                                               ssq(flucs),\n",
+        "                                                               1 - ssq(resids) / ssq(flucs)))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "WPY0wQktrZb1",
+        "outputId": "0b7a4440-f8ac-4e6e-932e-81fbf24a6716"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Using device: cuda\n",
+            "GPU: NVIDIA GeForce RTX 4050 Laptop GPU\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Check for GPU\n",
+        "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+        "print(f'Using device: {device}')\n",
+        "if device.type == 'cuda':\n",
+        "    print(f'GPU: {torch.cuda.get_device_name(0)}')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "8aNZcJwIcL5T",
+        "outputId": "9b699177-8b3a-4a5b-de0e-aba7e2e08598"
+      },
+      "outputs": [],
+      "source": [
+        "# Download text pre-processor (\"tokenizer\")\n",
+        "tokenizer = BertTokenizer.from_pretrained(\"bert-base-uncased\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 307,
+          "referenced_widgets": [
+            "f36b2f4a6b1e416d80b480c4e928b3b4",
+            "6cb6486d94a6441dbfbbe2d7f8406522",
+            "fc0c558eaf1f4713b5f58fdf20f501c4",
+            "d199dafd23444e40aa47a1fa0c79d7e4",
+            "dc01248927d74c138456e3cab92d47b4",
+            "ce0b6b372d7d4a1bb7470218cb9d5ad1",
+            "b27378c804464461ab2529474e62fdb0",
+            "0d455b129aa94e66acf068b361832e10",
+            "65881a1554d84ee6b898b5e7a91f5049",
+            "a526a69c96d143778f9d2e166676d54e",
+            "5827d74baf2a42888a162f8f6eb0f374"
+          ]
+        },
+        "id": "K_ljmPI3cEQI",
+        "outputId": "3139cab2-3958-4faa-ee02-ad509a4b3084"
+      },
+      "outputs": [],
+      "source": [
+        "# Download BERT model\n",
+        "bert = BertModel.from_pretrained(\"bert-base-uncased\").to(device)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "26mRwUFwardQ"
+      },
+      "source": [
+        "### Tokenization\n",
+        "\n",
+        "The first step in using BERT (or any similar text embedding tool) is to *tokenize* the data. This step standardizes blocks of text, so that meaningless differences in text presentation don't affect the behavior of our algorithm.\n",
+        "\n",
+        "Typically the text is transformed into a sequence of 'tokens,' each of which corresponds to a numeric code."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "vnLlb5peTwqM",
+        "outputId": "d4cc9176-5dd3-4376-bb9d-c240750b4bd7"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Original String: \n",
+            "\"What happens to this string?\"\n",
+            "\n",
+            "Numeric encoding: \n",
+            "{'attention_mask': [1, 1, 1, 1, 1, 1, 1, 1],\n",
+            " 'input_ids': [101, 2054, 6433, 2000, 2023, 5164, 1029, 102],\n",
+            " 'token_type_ids': [0, 0, 0, 0, 0, 0, 0, 0]}\n",
+            "\n",
+            "Actual tokens:\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "['[CLS]', 'what', 'happens', 'to', 'this', 'string', '?', '[SEP]']"
+            ]
+          },
+          "execution_count": 8,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Let's try it out!\n",
+        "s = \"What happens to this string?\"\n",
+        "print('Original String: \\n\\\"{}\\\"\\n'.format(s))\n",
+        "tensors = tokenizer(s)\n",
+        "print('Numeric encoding: \\n' + pformat(tensors))\n",
+        "\n",
+        "# What does this mean?\n",
+        "print('\\nActual tokens:')\n",
+        "tokenizer.convert_ids_to_tokens(tensors['input_ids'])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JJaz6eEocefa"
+      },
+      "source": [
+        "### BERT in a nutshell\n",
+        "\n",
+        "Once we have our numeric tokens, we can simply plug them into the BERT network and get a numeric vector summary. Note that in applications, the BERT summary will be \"fine tuned\" to a particular task, which hasn't happened yet."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Q1ODAgBMa3Zg",
+        "outputId": "cff5fab6-5e08-4f0a-b726-5b07352630bc"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Input: \"What happens to this string?\"\n",
+            "\n",
+            "Output type: <class 'torch.Tensor'>\n",
+            "\n",
+            "      Output shape: torch.Size([1, 768])\n",
+            "\n",
+            "      Output preview: array([[-0.96921396, -0.5247468 , -0.9211328 , ..., -0.75528705,\n",
+            "        -0.82799256,  0.9674912 ]], shape=(1, 768), dtype=float32)\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "print('Input: \"What happens to this string?\"\\n')\n",
+        "\n",
+        "# Tokenize the string\n",
+        "tensors_pt = tokenizer(\"What happens to this string?\", return_tensors=\"pt\").to(device)\n",
+        "\n",
+        "# Run it through BERT\n",
+        "with torch.no_grad():\n",
+        "    output = bert(**tensors_pt)\n",
+        "\n",
+        "# Inspect the output\n",
+        "pooled = output.pooler_output\n",
+        "_shape = pooled.shape\n",
+        "print(\"\"\"Output type: {}\\n\n",
+        "      Output shape: {}\\n\n",
+        "      Output preview: {}\\n\"\"\".format(type(pooled),\n",
+        "                                     _shape,\n",
+        "                                     pformat(pooled.cpu().numpy())))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "y_CnEClsl_1p"
+      },
+      "source": [
+        "# A practical introduction to BERT\n",
+        "\n",
+        "In the next part of the notebook, we are going to explore how a tool like BERT may be useful for causal inference.\n",
+        "\n",
+        "In particular, we are going to apply BERT to data from the Amazon marketplace consisting of product listings in the toy category. Each product comes with a text description, a price, and a sales rank (which we'll use as a proxy for demand / market share).\n",
+        "\n",
+        "The data is sourced from [demand-analysis-repro](https://github.com/JanTeichertKluge/demand-analysis-repro) and comes pre-split into train and validation sets.\n",
+        "\n",
+        "**For thought**:\n",
+        "What are some issues you may anticipate when using sales rank as a proxy for demand or market share?\n",
+        "\n",
+        "### Getting to know the data\n",
+        "\n",
+        "First, we'll download and clean up the data, and do some preliminary inspection."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "5kzXygwH0BKw",
+        "outputId": "6038a418-4634-4b2b-a51b-8b2bd15c09cc"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Train shape: (3717, 75), Holdout shape: (3708, 75)\n"
+          ]
+        }
+      ],
+      "source": [
+        "ds = datasets.load_dataset(\"janteichertkluge/demand-analysis-repro\")\n",
+        "train_full = ds[\"train\"].to_pandas().drop_duplicates(subset=\"ASIN\") # only one observation per ASIN\n",
+        "holdout  = ds[\"test\"].to_pandas().drop_duplicates(subset=\"ASIN\")\n",
+        "print(f\"Train shape: {train_full.shape}, Holdout shape: {holdout.shape}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "NDgWwxUWErnh",
+        "outputId": "d1a05f5a-6339-4400-ead8-05decec6be61"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "Index(['ASIN', 'date', 'index', 'Q_t', 'PRICE', 'P_bb_t', 'text', 'window',\n",
+              "       'REVIEW_COUNT', 'RATING', 'New Offer Count: Current',\n",
+              "       'Count of retrieved live offers: New, FBA',\n",
+              "       'Count of retrieved live offers: New, FBM',\n",
+              "       'Lightning Deals: Upcoming Deal', 'Buy Box: Is FBA',\n",
+              "       'subcat_aggregated', 'date_t', 'Airplanes', 'Cars & Race Cars',\n",
+              "       'Motor Vehicles', 'Race Tracks', 'Residual', 'Skateboards', 'Tractors',\n",
+              "       'Train Sets', 'Trains & Trams', 'Trucks', 'Vehicle Playsets',\n",
+              "       '2023-01-30', '2023-02-27', '2023-03-27', '2023-04-24', '2023-05-22',\n",
+              "       '2023-06-19', '2023-07-17', '2023-08-14', '2023-09-11', '2023-10-09',\n",
+              "       '2023-11-06', '2023-12-04', '2024-01-01', '2024-01-29', 'Airplanes.1',\n",
+              "       'Cars & Race Cars.1', 'Motor Vehicles.1', 'Race Tracks.1', 'Residual.1',\n",
+              "       'Skateboards.1', 'Tractors.1', 'Train Sets.1', 'Trains & Trams.1',\n",
+              "       'Trucks.1', 'Vehicle Playsets.1', 'pred_ml_l', 'pred_ml_m',\n",
+              "       'embedding_feature_0', 'embedding_feature_1', 'embedding_feature_2',\n",
+              "       'embedding_feature_3', 'embedding_feature_4', 'emb_0', 'emb_1', 'emb_2',\n",
+              "       'emb_3', 'emb_4', 'Q_t-1', 'P_bb_t-1', 'REVIEW_COUNT_t-1', 'RATING_t-1',\n",
+              "       'Q_t-2', 'P_bb_t-2', 'REVIEW_COUNT_t-2', 'RATING_t-2', 'Delta_Q_t',\n",
+              "       'Delta_P_bb_t'],\n",
+              "      dtype='str')"
+            ]
+          },
+          "execution_count": 11,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "train_full.columns"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 293
+        },
+        "id": "1Su5vOGhD3Df",
+        "outputId": "ee3abab1-2f63-4a79-9b49-9deca2fa3365"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>text</th>\n",
+              "      <th>ln_p</th>\n",
+              "      <th>ln_q</th>\n",
+              "      <th>category</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Catalyst Game Labs Battletech: Technical Reado...</td>\n",
+              "      <td>3.555062</td>\n",
+              "      <td>-12.600586</td>\n",
+              "      <td>Trucks</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13</th>\n",
+              "      <td>Playmaker Toys 5\" Diecast Snow Plow Trucks (Bl...</td>\n",
+              "      <td>2.156527</td>\n",
+              "      <td>-11.511635</td>\n",
+              "      <td>Trucks</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>26</th>\n",
+              "      <td>BRIO World - 33361 Mechanical Turntable | Trai...</td>\n",
+              "      <td>3.215484</td>\n",
+              "      <td>-11.590167</td>\n",
+              "      <td>Trains &amp; Trams</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>39</th>\n",
+              "      <td>BRIO World 33388 - Railway Crossing - 4 Piece ...</td>\n",
+              "      <td>2.707383</td>\n",
+              "      <td>-10.975106</td>\n",
+              "      <td>Trains &amp; Trams</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>52</th>\n",
+              "      <td>BRIO World - 33594 Two-Way Battery-Operated En...</td>\n",
+              "      <td>3.153194</td>\n",
+              "      <td>-10.495397</td>\n",
+              "      <td>Residual</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                                                 text      ln_p       ln_q  \\\n",
+              "0   Catalyst Game Labs Battletech: Technical Reado...  3.555062 -12.600586   \n",
+              "13  Playmaker Toys 5\" Diecast Snow Plow Trucks (Bl...  2.156527 -11.511635   \n",
+              "26  BRIO World - 33361 Mechanical Turntable | Trai...  3.215484 -11.590167   \n",
+              "39  BRIO World 33388 - Railway Crossing - 4 Piece ...  2.707383 -10.975106   \n",
+              "52  BRIO World - 33594 Two-Way Battery-Operated En...  3.153194 -10.495397   \n",
+              "\n",
+              "          category  \n",
+              "0           Trucks  \n",
+              "13          Trucks  \n",
+              "26  Trains & Trams  \n",
+              "39  Trains & Trams  \n",
+              "52        Residual  "
+            ]
+          },
+          "execution_count": 12,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# PRICE and SALES_RANK are already in log scale\n",
+        "def prepare_data(df):\n",
+        "    df = df.copy()\n",
+        "    df['ln_p'] = df['P_bb_t']\n",
+        "    df['ln_q'] = df['Q_t']\n",
+        "    df['category'] = df['subcat_aggregated']\n",
+        "    df = df[['text', 'ln_p', 'ln_q', 'category']].dropna()\n",
+        "    return df\n",
+        "\n",
+        "train_full = prepare_data(train_full)\n",
+        "holdout = prepare_data(holdout)\n",
+        "\n",
+        "train_full.head()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 514
+        },
+        "id": "lovFEHaWp4lC",
+        "outputId": "638f4397-88b7-4231-acf6-058ef53569bc"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "621.6800000000003\n"
+          ]
+        },
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAABQAAAAPACAYAAABq3NR5AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAewgAAHsIBbtB1PgAAyJpJREFUeJzs3QeUVEX+P+wasiAIYsQAiFkBI2YxYsQsomDOWTGsOa1pV9e86poD5iwqYhYDGFBUMGBWTKiIJMm8p+r/634RB5wZZuZOdz/POX1udaSmZubS8+mq+pbNnDlzZgAAAAAAilK9rDsAAAAAANQcASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFLEGWXeAuu9///tfGD9+fNbdAAAAACCEMP/884dDDz20wmMhAORvxfBv3LhxRgoAAACgAAkAqbCysrKUMM9qxowZ+Xa9elaUA84LQPm8ZwCcF4CK8J7h7ydpzZw5M1SWAJAKi+HfCSec8Kfbfvzxx/TLGcO/xRZbzGiWsHgCmjZtWmjQoEEKiyldzgvMyrkB5wZm57yA8wLlcW7AuaFi/vOf/1RplaYpWwAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxASAAAAAAFDEBIAAAAAAUMQEgAAAAABQxBpk3QEAStt3330Xnn766TBs2LAwbty40LJly9CxY8ew1VZbhcUWWyzr7gEAABQ8ASAAmfjkk0/C6aefHh555JEwY8aMv9xfr1690LNnz3DKKaekQBAAAICqsQQYgFo1c+bMcNVVV4XOnTuHhx56KB/+tWrVKnTo0CE0b948XY+333333elxJ5xwQpg0aZLvFAAAQBUIAAGoNTHUO+KII8Kxxx4bJk+eHBo0aBAOP/zw8P7774dff/01fPbZZ+H3338P77zzTjjwwANDw4YNU2B42WWXhbXWWiuMGDHCdwsAAKCSBIAA1IoY5MWw7/rrr0/X42y/N954I1x77bVpiW9ZWVm6PR5XX331cNNNN6Vlwl27dk23Dx8+PKy//vph8ODBvmMAAACVIAAEoFZcffXV4YYbbkjtNdZYIwV58Tg37du3Dy+88EK44IIL0vU4S3CzzTYLzz77bK30GQAAoBgoAkKlZ/DMqn79+mmj/jhjZ/b7KC2577+fA8o7L7z88suhT58++Zl/AwYMCK1bt67Qz0t8nVNPPTW0bds27L///uGPP/4IO+20U3qNDTbYwIDXcc4N5HjPgPMCs3NewHsGyuPcUDMEgFTKtGnT/nS9ZcuWc7yP0jR9+vSsu0DGZj8vjB49OlXzjT8bzZo1Cw888EBYYIEFKn3O6NGjRyoQsttuu4WJEyeG7bbbLjz//POpSAh1n3MD3jPgvMDsnBfwnoHyODfUDAEglfuBafDnH5lffvklze6IM3QWWmgho1nC4s9B/AM/flqT28uN0jT7eeG0004LP/30U7ov7uu32mqrVfm1u3fvHu66664UKI4dOzbssssu4c033wyLLrpoNX4FVCfnBnK8Z8B5gdk5L+A9A+VxbqgZAkAqZfZgJwY+sapnbrkfxJ8DPwulbdbzwiuvvBJuueWWdPuuu+6agrt5tfvuu6e9AGNBkW+//TaFgHGfwCZNmlRD76kpzg14z4DzArNzXsB7Bsrj3FAzFAEBoEZMnTo1HHrooandokWLcNVVV1Xbax922GHhqKOOSu1Bgwbl9xcEAADgrwSAANSI+++/P3z88cepfeGFF4Y2bdpU6+tffvnlqSJwdN1116V/DwAAgL8SAAJQ7SZPnhwuu+yy1F5++eXzMwGre0/SuB9gbv+/gw8+OHz++efV/u8AAAAUOgEgANWub9++4fvvv0/tc8899y8FhKrLYostlkLAuL9cLAqyxx57pPARAACA/58AEIBq9ccff4Srr746tTt27Bh69OhRoyO8+eabhzPOOCO1hwwZEs4666wa/fcAAAAKjQAQgGr18MMPh59//jk/+y9WA65pMfTbcMMNU/vSSy8Nr7/+eo3/mwAAAIVCAAhAtZk5c2a48cYbU7t9+/Zhxx13rJXRjUuMb7vtttCsWbMwY8aMsO+++4YJEybUyr8NAABQ1wkAAag2zz33XPjkk09S+6CDDqqV2X85HTp0SLP/os8++yyceuqptfZvAwAA1GUCQACqzeWXX56OCyywQCrIUdtiteEtt9wyteM+hC+++GKt9wEAAKCuEQACUC0+//zz0L9//9Tea6+90nLc2harAd98882hRYsW6frBBx+cipIAAACUMgEgANXi1ltvzbf32WefzEZ1qaWWyi8FjqHkeeedl1lfAAAA6gIBIADzbPr06akIRxSr8S699NKZjuqBBx4YNt5449S+5JJLwnvvvZdpfwAAALIkAARgnj3zzDPhu+++S+0999wz8xGNxUduuOGG0Lhx4xROxoIk8QgAAFCKBIAAzLNbbrklX/xjm222qRMjusIKK4Qzzjgjtd9+++1w1VVXZd0lAACATAgAAZgno0ePDo899lhq9+rVK8w333x1ZkRPPvnksOqqq6Z2DAO/+uqrrLsEAABQ6wSAAMyThx9+OEydOjXz4h/ladSoUbjppptSdeCJEyeGww47LMycOTPrbgEAANQqASAA8+S+++5Lx/bt24cuXbrUudFcZ511wlFHHZXaAwYMCHfffXfWXQIAAKhVAkAAquynn34KL7zwQmrvscceaaZdXXTBBReEpZZaKrWPP/748Ouvv2bdJQAAgFojAASgyh566KEwY8aMfABYVzVv3jz897//Te2ff/45nHTSSVl3CQAAoNYIAAGY5+W/yy+/fOjcuXOdHsnu3buH3XffPbVvvfXW/MxFAACAYicABKBKfvjhh/DKK6+kds+ePevs8t9ZXXnllWGBBRZI7VgQZNKkSVl3CQAAoMYJAAGokn79+uUr6u66664FMYqLL754+Ne//pXan376adobEAAAoNgJAAGoksceeywd27VrFzp27Fgwo3jwwQeHDTbYILUvvvjiMGzYsKy7BAAAUKMEgABU2vjx48Pzzz+f2jvuuGNBLP/NqVevXrjhhhtCw4YNw7Rp08IhhxySL2QCAABQjASAAFTagAEDwuTJk/MBYKFZeeWVw6mnnpragwYNCv/73/+y7hIAAECNEQACUGmPP/54OrZq1SpstNFGBTmCMQCM1YujU045JXz33XdZdwkAAKBGCAABqJS4bPaJJ55I7e222y40aNCgIEewSZMmaSlwNHbs2HDMMcdk3SUAAIAaIQAEoFLeeOONMHr06NTu3r17QY9e165dw4EHHpjaDz/8cL6wCQAAQDERAAJQKU8//XQ61q9fP3Tr1q3gR+/f//53WGSRRVL7yCOPTLMBAQAAiokAEIAqBYDrrbdeaNmyZcGP3oILLhiuvPLK1I77AJ5xxhlZdwkAAKBaCQABqLBRo0aFt99+O7W33nrrohm5PfbYI//1XHPNNWHw4MFZdwkAAKDaCAABqLBnn3023y6mALCsrCxce+21oWnTpmHmzJnhgAMOCJMmTcq6WwAAANVCAAhAhfXv3z8dF1544bD66qsX1ci1b98+XHjhhan90UcfhXPOOSfrLgEAAFQLASAAFTJjxowwYMCA1N5qq61CvXrF91/I0UcfHTbaaKPUvuSSS1LFYwAAgEJXfH+9AVAj3nvvvfDLL78U3fLfWcVQ85ZbbgnzzTdfCjz3228/S4EBAICCJwAEoEJeeOGFfHuzzTYr2lFbdtllw8UXX5zaH3/8cTj77LOz7hIAAMA8EQACUKkAcKWVVgqLL754UY/aUUcdFTbeeOPUvvTSS1UFBgAACpoAEIC/NXXq1DBw4MCin/03+1LgWBU4LgXef//9LQUGAAAKlgAQgL81ZMiQMH78+JIJAKMOHTr8aSnw6aefnnWXAAAAqkQACECFl/+WlZWFrl27lsyIHXnkkfmv97LLLvvTPogAAACFQgAIwN/KBV+dO3cOrVu3LpkRi0uBb7/99tCiRYt0fd999w2//fZb1t0CAACoFAEgAHM1efLk8Nprr5XU8t9ZtW3bNlx77bWpPXLkyHD44YeHmTNnZt0tAACAChMAAjBXgwcPzhfA2HTTTUtytPbaa6/Qs2fP1L7vvvvC3XffnXWXAAAAKkwACECFlv/Wr18/bLzxxiU5WnHvwzgLcMkll0zXjzjiiPD1119n3S0AAIAKEQACUKEAcK211srvhVeKWrVqFe64444UBo4dOzbss88+Yfr06Vl3CwAA4G8JAAGYowkTJoQ33nijZPf/m11cAn3CCSek9sCBA8Mll1ySdZcAAAD+lgAQgDmK4d/UqVNTe5NNNjFSIYTzzz8/dOrUKY3FmWeeGd566y3jAgAA1GkCQADm6NVXX/1//1nUqxfWW289IxVCaNy4cSoC0qRJkzBt2rTQq1evMH78eGMDAADUWQJAAP42AOzcuXNo3ry5kfo/q6yySvjPf/6T2p9++mk49thjjQ0AAFBnCQABKFec3TZo0KDU3nDDDY3SbA4//PDQvXv31L7lllvCAw88YIwAAIA6SQAIQLk++OCD/NJWAeBfxWrAN998c1hsscXS9UMOOSR88803fpoAAIA6RwAIwFyX/0YbbLCBUSrHwgsvHG6//fbUHjNmTNh7773D9OnTjRUAAFCnCAABmGsA2L59+7DEEksYpTno1q1b6NOnT2oPHDgwXHzxxcYKAACoUwSAAPzFzJkz8wGg5b9/78ILLwyrrbZaap999tnhjTfe8FMFAADUGQJAAP7iq6++Ct9//31qCwD/XuPGjcPdd98d5ptvvrQEeK+99grjxo3zkwUAANQJAkAA/sL+f5W30korhcsvvzy1v/jii3DUUUf5yQIAAOoEASAAcwwAW7VqlYItKiZWAt5xxx1T+4477gj33HOPoQMAADInAARgjgFgrP5br57/KiqqrKws3HTTTaFNmzbp+mGHHZaWUwMAAGTJX3UA/Mno0aPDhx9+mNr2/6u8hRZaKM3+i2Hg2LFjQ+/evcO0adP8lAEAAJkRAALwJ7NWsF1//fWNThVsvvnm4cQTT0zt1157LVUJBgAAyIoAEIA/GTx4cDrWr18/rLnmmkanis4///ywxhprpPa5554bXn/9dWMJAABkQgAIQLkzADt37hyaNm1qdKqoUaNG4e67705jOGPGjNCrV6/w+++/G08AAKDWCQAByItBVS4AXHfddY3MPFphhRXClVdemdqxGMiRRx5pTAEAgFonAAQgb8SIEWHMmDGpvc466xiZanDggQeGXXfdNbXvuuuu0LdvX+MKAADUKgEgAOUWADEDsHrEasA33HBDWHLJJdP1I444InzxxRd+6gAAgFojAATgLwVAWrVqFZZbbjkjU00WXHDBcOedd6YwcNy4cWk/wGnTphlfAACgVggAAfhLABiX/8awiuqzySabhFNOOSU/zhdccIHhBQAAaoUAEIBkwoQJ4YMPPkhty39rxrnnnhvWWmut1I4B4PDhw/30AQAANU4ACEAyZMiQMH369NQWANaMhg0bhltvvTUdp06dmgqE5MYcAACgpggAAfjT8t+oS5cuRqWGrLrqquG0007LF13573//a6wBAIAaJQAE4E8B4AorrJCKgFBzTj311LDyyiundgwDv/76a8MNAADUGAEgAGHmzJn5ANDy35rXuHHjcNNNN6VCK3HvxUMPPTR9DwAAAGqCABCAMHLkyPDDDz/kKwBT89Zbb71w9NFHp/aAAQNC3759DTsAAFAjBIAAhLfffjs/Cvb/qz2xEnDbtm1T+8QTTwxjxozx0wgAAFQ7ASAA4a233kqj0KhRo9CxY0cjUkvmn3/+cNVVV6X2qFGjwtlnn23sAQCAaicABCA/A7Bz584pBKT2dO/ePWy77bapfc0114T333/f8AMAANVKAAhQ4mLxiVwAuNZaa2XdnZITC4FceeWVKXidMWNGOPLIIxUEAQAAqpUAEKDEffHFF+G3335L7bXXXjvr7pSkZZddNpx88smp/eqrr4a777476y4BAABFRAAIUOJmLQBiBmB2Tj311HxBkFNOOSVMnDgxw94AAADFRAAIUOJyAWDTpk3DSiutlHV3SlYc/3/961+pPXLkyHDFFVdk3SUAAKBICAABSlyuAvDqq68eGjRokHV3SlqPHj3COuusk9oXXXRR+Omnn7LuEgAAUAQEgAAlLBadGDJkSGpb/ls3CoJceumlqT1+/Phw7rnnZt0lAACgCAgAAUrYiBEjUtAUKQBSN2y44YZhl112Se0bbrghfPTRR1l3CQAAKHACQIASllv+G5kBWHdcfPHFaTn29OnTw2mnnZZ1dwAAgAInAAQoYbkCIC1atAjLLbdc1t3h/8TvxWGHHZbajz76aH6ZNgAAQFUIAAFKWC4AXHPNNUO9ev5LqEvizL8mTZqk9plnnpl1dwAAgALmrz2AEjVt2rTw7rvvprblv3XP4osvHo488sjU7t+/fxg0aFDWXQIAAAqUABCgRH344Yfhjz/+SG0FQOqmf/zjH6FZs2apbRYgAABQVQJAgBJf/huZAVg3LbzwwuHYY49N7eeffz689NJLWXcJAAAoQAJAgBKvANy6devQrl27rLvDHJxwwgmpSEt07rnnGicAAKDSBIAAJT4DMM7+Kysry7o7zMGCCy6YnwUYZwAOHjzYWAEAAJUiAAQoQZMnTw7vvfdealv+W/cdc8wxoWnTpql90UUXZd0dAACgwAgAAUrQsGHDwtSpU1NbAFj3LbTQQuGQQw5J7ccffzx9/wAAACpKAAhQgt555518e4011si0L1R8L8CGDRum9sUXX2zYAACAChMAApSgd999N18AZKmllsq6O1TAkksuGfbee+/Uvueee8IXX3xh3AAAgAoRAAKU8AzAOPtPAZDC8Y9//CN9v2bMmBEuvfTSrLsDAAAUCAEgQImZNm1avgDI6quvnnV3qITll18+7Lrrrql92223hdGjRxs/AADgbwkAAUrMJ598EiZNmpTa9v8rPH369EnHP/74I9xwww1ZdwcAACgAAkCAEqMASGFbd911Q5cuXVL7mmuuyVdzBgAAmJMGoYT8/vvv4cEHHwxvvvlm+PXXX0Pjxo1Dhw4dwrbbbpv+oJqX5XRPPPFEePnll8P333+fbltiiSVC165dw3bbbRcaNJj7MMeN3B955JHwwQcfhLFjx4YFFlggrLrqqmGXXXYJ7du3L/c5sf8DBw4Mn376afjmm2/CmDFjwoQJE8J8882XNopfZ511wjbbbBOaNm1a5a8LKO4AsHnz5ukcSGGJewAef/zxYc899wzfffddeOCBB8Jee+2VdbcAAIA6rGQCwBiSnX766SkEjGJQFgOzoUOHpkv37t3DwQcfXOnXjUuwzjzzzDBixIh0vVGjRun42Wefpctrr70WzjvvvNCkSZNynx9DwyuvvDKFiFGzZs1SuBdvj8+Nf+RttNFGf3ne8OHDw6233pq/HkPG+G+MHz8+fPzxx+ny5JNPhnPOOScsvfTSlf66gOKvALzaaquFevVMBC9EcR/A+GHPyJEjw+WXX57CQMVcAACAkg4A4/Ko888/P4V/bdu2TfsnxZl1kydPDo899li46667Qr9+/dJtW2yxRaVe+9prr03hXwzujjnmmPxMwsGDB4errroqBXHXXXddCvLKCyVz4d+GG24YDjrooLDgggumTd1vvPHGFABeccUVqV/xD71ZLbzwwqFnz55hlVVWSfe3aNEi3R6/pvhv33zzzeGXX34JF110UVoiVr9+/XkaQ6A4xOqxuQDQ/n+Fq2HDhuGoo44Kp5xySnj77bfD66+/HjbYYIOsuwUAANRRJTH1Y8CAAeHHH39MS37POuus/LLaeL1Hjx5pqWzUt2/f/Ey8ivjyyy/TMtzo6KOPDuutt16agREvsR3/OIteeuml8PXXX//l+TF4jP9e7M8JJ5yQwr8oHk888cR0ewwv4+Nmt9JKK6UlX507d86Hf7mvKS49zm0SH5eHxQ3/AXJbDsStBiIVgAtbnLWe2+YhflgEAABQ0gFgDOCijTfeOM2cK28pVQzt4sy7uA9fRcVlujNnzgyLL754Cvxmt/7666f74mPiY2cVlx+/9dZbqb3TTjv9ZYZevB5vj+KehRMnTgyVsfzyy+fbcUkxQJSb/ReZAVjY4odF++yzT2o/+uij4Ycffsi6SwAAQB1V9AFg3KMvFsqY2x+7MRTMLbF97733Kvza77//fn4WTXl7L8XbcjNsco/N+fDDD/OzDefUr9ztcRbgRx99FCpj1scvtthilXouUPwFQOKeoXEmMYXt8MMPT8f4/0nc+gEAAKAkA8C4QXqcgRfF/f/mJHfft99+W6HXja8ZX/vvXjdXgGP2181db9myZar6W554e+6+uF/g34l/AP7888/h6aefTpvCRyuuuGJYbrnlKvQ1AaUTAHbs2PFvK5RT93Xq1CnNNo9uuOGGMH369Ky7BAAA1EFF/9dfXNabk9tjrzy5+3777bcKzyycNGlShV83Pj5eYvXhWf+duT03d38sXjK3fh177LFpP8LZxdmHub0A/07c//Duu+8u975YKTRWN47FA+JeirOKt+WOs98H1C3xg4shQ4bkPxyoqd9Z54XaFSsAxyIg8YOleC7faqutarkHUDHODYDzAuA9Q/W9p6qsog8AcyFdrkDGnOTuiyFdRcz6uIq8bu45uQAw9/y5Pbei/YpFQOJMwilTpuT3ClxzzTXDvvvuO8fZhbOLexKOGjWq3PtmnVEytx+0qv4QArXj+++/z+8Juuqqq9bK76zzQs3bdtttU4Gr+EHR7bffHrbccsta+Fdh3jg3AM4LgPcMtavoA8BS8M9//jPfjtU9Y2Xie+65Jxx33HHhoIMOCttvv/3fvkazZs3CIossUu59sxYoqVev3hzfwM9+H1C3DB8+/E9LR2vqd9Z5oXbFSsBxFuC1116bil7FmYBz25oCsuLcADgvAN4zZKfoA8C40X3O5MmT0x9K5Yn3RbkZen9n1sflnju31539Obn23J5blX7F2YAx8Iub+59wwgnhpptuSu0OHTrM9Xm9e/dOl/L85z//CePGjUthwewFReISwviGvrz7KL3lpXEfyrivXHlFccjeV199lQ/1N9lkkz+dH6uT80Lti9s9xAAw/h4+/PDD4V//+leoK5wbyHFuwHmB2Tkv4D0D5XFumLuqTuQo+ilbs+6xN+t+gLPL3deqVasKvW4M5HKhXEVed9bHz9qvuT23Kv3KiYHfyiuvnMK55557rlLPBYq7AMgqq6xSY+Ef2Yjn/G7duqV2XAYcq8cDAACUTAC45JJL5mcjza2Sbu6+pZZaqkKvG18zvnZVXzd3fcyYMWnZbnli8Y94mbWacGW0bt06HRXnAGYNAGOBIIpP3PIh+umnn8JTTz2VdXcAAIA6pOgDwDjrbrnllvvTH7+z++WXX9KeSVHnzp0r/NpxD63o3XffneNjhg4d+qfH5sTZeXGp5Nz6lXvdhg0bpmW8lZUL/sz0AX7++ecwcuTINBBrrLGGASlCO+ywQ/6Dn1tuuSXr7gAAAHVI0QeAUdzrKorFMeIfwbOL+yXFPYristyOHTtW+HU33njjNBMwVtYcNGjQX+5//fXX033xMbk+5MS9CNdee+3Ufuyxx/5UaTeK1+PtUZcuXf6yd+Hsj5/dsGHDwogRI/LL/YDSNusHFQLA4hSrxuf2cn3yySfN/gYAAEorANxqq61SgYpJkyalirlffvllvsDGgw8+mP5QiuIfTrlZebMuqYqzKq644oq/vG779u1TCBhdffXVYfDgwSlIjJfYvuaaa9J9Mfwrbwlvr1690r/3+eefh8suuyz89ttv6fZ4jNfj7XH2X3zc7E455ZRw//33pyXGs4aBcc/ARx55JH2dsR8LL7xw2HzzzedxBIFCl5tpHD+QqMxMZwrL/vvvn47x/4U77rgj6+4AAAB1RNFXAY5iiHbGGWeE008/PVXBPPbYY9OMuhgIxiIZUaycu8UWW1T6tY844ojwww8/pNl2F154YWjUqFG6fcqUKem44oorhsMPP7zc58ZQMPblyiuvDK+88kp49dVXU78mTJiQ7o/hYLw/t9fgrGJI2Ldv33SJFT3j82IF1j/++CP/mCWWWCJ9zRWtIAwU/wzAuCVC8+bNs+4ONSSGu2uuuWYYMmRIWgZ80kknqcoNAACURgCYC9viLL2HHnoovPnmm2nfv2bNmoVlllkmbLfddmHdddet0uvGcO3iiy8OTzzxRHj55ZfTkt9cRcY48y++9uyzCmfVtWvXVBAkLkOOy3ZjQZDcUuRddtklzTIsz3HHHZf+wPvwww/TsuZcIZGFFloofU3x64mvHcNPgNwMQMt/i9+BBx6Y/n/45JNP0lYUG2ywQdZdAgAAMlYyAWDUsmXL9IdRvFTUTTfd9LePiQHfTjvtlC5VEQO7E088sVLPWXXVVdMF4O/EauKfffZZaqsAXPz23HPP0KdPnzTLPc4CFAACAAAlsQcgQCl777338m0zAEvjw66dd945teM+t7NuDQEAAJQmASBAiSz/jcwALA177713OsbtIfr165d1dwAAgIwJAAFKJACMe6G2bt066+5QC7bccsuwyCKLpHYsFgUAAJQ2ASBAiVQAtvy3dMS9aeNegFH//v1TsSgAAKB0CQABitjEiRNTtfBIAFhaevfunY7Tpk0L999/f9bdAQAAMiQABChiH3zwQZgxY0Zq2/+vtKy55pphxRVXTG3LgAEAoLQJAAFKYPlvJAAsLWVlZflZgIMHDw6ffvpp1l0CAAAyIgAEKIEAcOGFFw5t2rTJujvUsr322ivfvuuuu4w/AACUKAEgQAkEgHH2X5wRRmlp37592HDDDfPLgGfOnJl1lwAAgAwIAAGKVCz+EPcAjCz/LV177713On7++edpKTAAAFB6BIAARerjjz8OkyZNSm0BYOnafffdQ6NGjVJbMRAAAChNAkCAIqUACFGrVq3Cdtttl9oPPPBAmhkKAACUFgEgQJEHgPPPP39Ydtlls+4OGdpjjz3S8eeffw4vvfSS7wUAAJQYASBAkQeAnTt3DvXqOd2Xsu233z40bdo0te+7776suwMAANQyfxECFKFY7XXo0KGpbf8/mjVrFrp3754G4uGHHw5TpkwxKAAAUEIEgABF6KuvvgpjxoxJbQEgsy4DHj16dHjuuecMCgAAlBABIEARUgCE2W2zzTahefPmqW0ZMAAAlBYBIEARB4ANGzYMq6yyStbdoQ5o0qRJ2HHHHVP70UcfDZMmTcq6SwAAQC0RAAIUcQAYw79GjRpl3R3q2DLgsWPHhgEDBmTdHQAAoJYIAAGKOAC0/x+z6tatW2jZsmVqWwYMAAClQwAIUGRGjRoVvv/++9QWADKrOBt05513Tu3HH388TJw40QABAEAJEAACFBkFQKjIMuAJEyaEp556ymABAEAJEAACFGkAWFZWFjp37px1d6hjNttss9C6devUtgwYAABKgwAQoEgDwGWXXTY0b9486+5Qx8TK0LvuumtqxxmAlgEDAEDxEwACFBkFQPg7uQAwhn+qAQMAQPETAAIUkXHjxoVPP/00tRUAYU423XTT0KpVq9R+8MEHDRQAABQ5ASBAEXnvvffybQEgc1sGvMMOO6T2E088ESZPnmywAACgiAkAAYqICsBUdhnw2LFjw3PPPWfgAACgiAkAAYowAGzTpk1YZJFFsu4OddiWW26ZLxLz0EMPZd0dAACgBgkAAYqIAiBUVJMmTcL222+f2o899liYOnWqwQMAgCIlAAQoElOmTAnDhw9Pbfv/UZllwKNHjw4vvfSSQQMAgCIlAAQoEjH8y83iEgBSEVtvvXWYb775UtsyYAAAKF4CQIAioQAIldWsWbOwzTbbpPYjjzwSpk+fbhABAKAICQABiiwAbNmyZWjXrl3W3aHAlgGPGjUqvPbaa1l3BwAAqAECQIAiCwBXW221UFZWlnV3KBCxEEijRo1S2zJgAAAoTgJAgCIwY8aM8N5776W2/f+ojBYtWoRu3brlA8D4swQAABQXASBAEfjss8/C+PHjU1sASFWXAX/33XfhzTffNIAAAFBkBIAARUABEObFDjvsEBo0aJDalgEDAEDxEQACFFEA2KRJk7Diiitm3R0KzIILLhg23XTTfAA4c+bMrLsEAABUIwEgQBEFgB07dszP5IKqLAP+8ssv/zSjFAAAKHwCQIACF2dr5QIb+/9RVTvttFOoV+//vS2wDBgAAIqLABCgwH3//ffh559/Tm0BIFW16KKLho022ii1LQMGAIDiIgAEKHAKgFDdy4A/+eST8NFHHxlYAAAoEgJAgCIJAOPyzbgHIFTVzjvvnG9bBgwAAMVDAAhQJAFgrP7btGnTrLtDAVtyySXDOuusk9oCQAAAKB4CQIACpwAINbEM+L333guff/65wQUAgCIgAAQoYL/99lv46quvUlsBEKozAIwefvhhgwoAAEVAAAhQwBQAobots8wyYbXVVktty4ABAKA4CAABCtiQIUPy7TXWWCPTvlA8dtlll3R84403wsiRI7PuDgAAMI8EgABFEAB26NAhtGzZMuvuUCQsAwYAgOIiAAQoYO+88046rrnmmll3hSKy8sorp6rSkX0AAQCg8AkAAQrU77//Hj799NPUFgBSU7MAX3nllTBq1CgDDAAABUwACFAEBUAEgNTUPoAzZswIjz76qAEGAIACJgAEKIICIKuvvnqmfaH4xJ+pdu3apbZqwAAAUNgEgAAFHgC2b98+LLjggll3hyJTVlaWXwb8wgsvhN9++y3rLgEAAFUkAAQo8ADQ8l9qSi4AnDZtWujXr5+BBgCAAiUABChAY8eODSNGjEhtASA1ZZ111glt2rRJbcuAAQCgcAkAAQqQAiDUhnr16oWdd945tQcMGBDGjRtn4AEAoAAJAAEKvADIGmuskWlfKI1lwJMnTw79+/fPujsAAEAVCAABCjgAjFVaW7dunXV3KGIbbbRRWGihhVLbMmAAAChMAkCAAqQACLWlQYMGYaeddkrtJ598Mvzxxx8GHwAACowAEKDAxH3YFAChNu2yyy7pOGHChPDMM88YfAAAKDACQIACLAAyc+bM1FYBmNqw+eabhwUWWCC1H374YYMOAAAFRgAIUMAFQASA1IZGjRqF7t27p/bjjz8epkyZYuABAKCACAABCjQAbNu2rQIg1Ho14DFjxoQXX3zRyAMAQAERAAIUGAVAyEK3bt1C06ZNU1s1YAAAKCwCQIACMn78+PDJJ5+ktuW/1KYY/m277bap/eijj4bp06f7BgAAQIEQAAIUkKFDhyoAQubLgH/++efw6quv+k4AAECBEAACFBAFQMjSdtttlwqCRJYBAwBA4RAAAhRgALj00kuHhRZaKOvuUGKaN2+e9gKMHn744TBjxoysuwQAAFSAABCggCgAQl1ZBvzdd9+Ft956K+vuAAAAFSAABCgQEyZMCB9//HFqKwBCVnbYYYfQoEGD1LYMGAAACoMAEKBAvPvuu/kllwJAsrLggguGTTfdNLUfeOCBfFEaAACg7hIAAhSIWZdbrr322pn2hdLWo0ePdPzqq68sAwYAgAIgAAQoEG+++WY6dujQIbRu3Trr7lDCdtlll/wy4HvvvTfr7gAAAH9DAAhQYAFgly5dsu4KJS4uA85VA77//vtVAwYAgDpOAAhQAH755ZfwxRdfpLYAkLpgjz32yFcDfu2117LuDgAAMBcCQIAC2/9PAEhdsOOOO4bGjRun9n333Zd1dwAAgLkQAAIU0PLf+vXrh9VXXz3r7kBYYIEFwrbbbpuvBjxt2jSjAgAAdZQAEKCAAsBOnTqF+eabL+vuwJ+WAY8aNSq8/PLLRgUAAOooASBAHTdz5kwFQKiTtt9++9C0adPUVg0YAADqLgEgQB331VdfpSIgkf3/qEuaNWsWunfvntoPP/xwmDJlStZdAgAAyiEABCiQ5b+RAJC6pmfPnuk4evTo8Nxzz2XdHQAAoBwCQIACCQDjbKuVVlop6+7An2y99dahRYsWqW0ZMAAA1E0CQIA67o033kjHNddcM1UBhrqkSZMmYaeddkrtRx55JEycODHrLgEAALMRAALUYVOnTg3vvPNOalv+S13Vu3fvdBw/fnx49NFHs+4OAAAwGwEgQB02fPjw8Mcff6S2AJC6arPNNgtt2rRJ7TvvvDPr7gAAALMRAALUYQqAUAji0vS99tortZ955pnw448/Zt0lAABgFgJAgAIIABdZZJGw9NJLZ90dmKO99947HWfMmBHuueceIwUAAHWIABCgAALAuPy3rKws6+7AHHXq1CldIsuAAQCgbhEAAtRRsaBC3AMwsv8fhTQL8N13383/7AIAANkTAALUUUOGDEnLKSMBIIVgzz33zM9UNQsQAADqDgEgQB01aNCgfFsASCFYYoklwuabb57ad911Vz7ABgAAsiUABKjjAeDKK68cWrVqlXV3oFLLgEeOHBleeuklowYAAHWAABCgDpo5c2Z4/fXXU3u99dbLujtQYbvsskto2rRpalsGDAAAdYMAEKAO+vzzz8Mvv/yS2uuvv37W3YEKm3/++VMIGD3wwANh3LhxRg8AADImAASog3Kz/yIzACk0BxxwQDpOmDAh3H///Vl3BwAASp4AEKAO7/8X9/5bYYUVsu4OVErXrl3DMsssk9o333yz0QMAgIw1yLoDFN6+ZLOqX79+qFevXigrK/vLfZSW3Pffz0H1zgBcd911C+73y3mB+DMbZwGeccYZYfDgwWH48OGhU6dOBqbEOTeQ4z0DzguUx7kB54aaJQCkUqZNm/an6y1btpzjfZSm6dOnZ92Fghf3TBs2bFhqd+nSpeB+t5wXiHr37h3OOuusMGPGjHDbbbeFSy65xMCUOOcGZuc9A84LlMe5AeeGmiEApHI/MA3+/CMTixTET2ribI+FFlrIaJaw+HMQ/7OOMzzizwNV984776TQJNpwww3/8ntX1zkvEC299NJh2223DU888US46667wkUXXRSaNGlicEqYcwM53jPgvEB5nBtwbqhZhfVXJZmbPdiJgU8MKnLLgCH+HPhZqJ79/+Lv1TrrrFNw4+m8QM5BBx2UAsAY/PTr1y/06NHD4JQw5wZm5z0DzguUx7kB54aaoQgIQB0NADt27BiaN2+edXegyuIMwEUXXTS1FQMBAIDsCAAB6pA4ozYXAK633npZdwfmScOGDcN+++2X2s8880z47LPPjCgAAGRAAAhQh3zyySdhzJgxqb3++utn3R2YZ4ceemh+Gft1111nRAEAIAMCQIA65JVXXsm3BYAUg3bt2oVtttkmtW+99dYwceLErLsEAAAlRwAIUAcDwMUXXzwss8wyWXcHqsVhhx2Wjr/99lu47777jCoAANQyASBAHQwAN9poo4Kr/gtz0q1bt3yg/d///jfMnDnTYAEAQC0SAALUEd9++234+uuv8wEgFIt69erlZwEOGTIkvPXWW1l3CQAASooAEKAO7v8nAKTY7L///qFx48b5WYAAAEDtEQAC1BEDBw5Mx5YtW4ZVV1016+5AtWrdunXo2bNnat97773hxx9/NMIAAFBLBIAAdWwG4AYbbBDq16+fdXeg2h133HHpOGXKFLMAAQCgFgkAAeqAX3/9NXz44YepbfkvxWq11VYLm222WWpfd911YeLEiVl3CQAASoIAEKAOePXVV/NtASDFrE+fPvnQ+4477si6OwAAUBIEgAB1aPlvkyZNwlprrZV1d6DGbLPNNmHFFVdM7csvvzzMmDHDaAMAQA0TAALUoQBwnXXWCY0aNcq6O1Bj6tWrF44//vjUHjFiRHjyySeNNgAA1DABIEDGxo8fH4YMGZLaG2+8cdbdgRq39957h4UWWii1L730UiMOAAA1TAAIkLFBgwaF6dOnp7b9/ygF8803XzjyyCNTe+DAgX/aAxMAAKh+AkCAjL344ovp2KBBg7D++utn3R2oFUcffXRo1qxZal9wwQVGHQAAapAAECBjL7zwQjquu+66+UAEil3r1q3DEUcckdpPP/10fhk8AABQ/QSAABn6/fffw1tvvZXam222me8FJaVPnz6hcePGqW0WIAAA1BwBIECG4v5nM2bMSO3NN9/c94KSsthii4WDDz44tR955JEwfPjwrLsEAABFSQAIUAeW/8aiCOuss47vBSXnpJNOCg0bNkxtswABAKBmCAAB6kAAuOGGG+aXQkIpWXrppcM+++yT2vfee69ZgAAAUAMEgAAZ+fnnn8P777+f2vb/o5SdccYZaRbgzJkzw5lnnpl1dwAAoOgIAAEy8tJLL+XbAkBKWbt27cIhhxyS3wswVxgHAACoHgJAgIyX/7Zo0SKsscYavg+UtNNPPz3thZmbEQgAAFQfASBAxgFg165dQ4MGDXwfKGmLL754OProo1P7mWeeCS+//HLWXQIAgKIhAATIwHfffRdGjBiR2pb/wv9z8sknpxmx0amnnpr2BAQAAOadABAgA88++2y+LQCE/6d169bhxBNPTO1BgwaFBx980NAAAEA1EAACZODpp5/OL3vs2LGj7wH8nz59+oQlllgitf/xj3+ESZMmGRsAAJhHAkCAWjZ9+vS0x1m09dZbh7KyMt8D+D/NmjULF154YWp/+eWX4eqrrzY2AAAwjwSAALXszTffDL/99ls+AAT+rHfv3vnK2Oeff374+eefDREAAMwDASBARst/69WrF7bYYgvjD7OJvxuXXXZZao8dOzacffbZxggAAOaBABAgowBwnXXWCQsuuKDxh3J07do17Lzzzqn9v//9LwwZMsQ4AQBAFQkAAWrRL7/8Et56663UtvwX5u7SSy8NTZo0CTNmzAiHH3542j8TAACoPAEgQC169tlnw8yZM1NbAAhzt8wyy4TTTz89tWNwftNNNxkyAACoAgEgQAbLf1u3bh3WXHNNYw9/46STTgrLLbdcap966qlh1KhRxgwAACpJAAhQS+IyxgEDBqR2t27dQv369Y09/I3GjRuH//73v6kdq2f/4x//MGYAAFBJAkCAWjJ06NDw008/pbblv1BxW265Zdhjjz1S+7bbbguvvPKK4QMAgEoQAALUksceeywdy8rKwlZbbWXcoRIuu+yy0Lx589Q+7LDDwuTJk40fAABUkAAQoJYDwPXWWy8suuiixh0qoU2bNuGf//xnan/44Yfh/PPPN34AAFBBAkCAWvDll1+G9957L7V32mknYw5VcNRRR6UAPbrooovCu+++axwBAKACBIAAtTj7LxIAQtXEwjm33HJLKgwyffr0cMABB4SpU6caTgAA+BsCQIBaDABXXnnlsNxyyxlzqKIVV1wxnHPOOfnCOv/617+MJQAA/A0BIEAN+/XXX8PAgQNTe8cddzTeMI9OPPHEsOaaa6b2eeedF4YNG2ZMAQBgLgSAADXsiSeeCDNmzEhty39h3jVo0CDceuutoWHDhmkJ8H777WcpMAAAzIUAEKCWlv/GKqZrrbWW8YZq0LFjx3DmmWem9pAhQ/IVggEAgL8SAALUoIkTJ4ann346v/y3Xj2nXagup5xySujSpUtqX3DBBWHQoEEGFwAAyuEvUYAa9Mwzz4Q//vgjte3/B9UrLgHu27dvaNq0aVpm37t37zBu3DjDDAAAsxEAAtSge++9Nx1btWoVNt10U2MN1SxW1b7ssstS+4svvgjHH3+8MQYAgNkIAAFqyIQJE0K/fv1Se9dddw2NGjUy1lADDjnkkLD99tun9s033xweffRR4wwAALMQAALUYPXfuAdgtMceexhnqCFlZWXhpptuCgsvvHC6fvDBB4cff/zReAMAwP8RAALU8PLfRRZZJGyyySbGGWrQoosummb/Rb/88ks44IAD0r6AAACAABCgRvz++++hf//+qb3bbruFBg0aGGmoYd27d0+z/6L4+3fllVcacwAAEAAC1IyHHnooTJ48ObUt/4Xac/nll4cVV1wxtf/xj3+EIUOGGH4AAEqeJcAANeD2229Px7Zt24YNN9zQGEMtadasWbjvvvtC48aNw9SpU1MAP3bsWOMPAEBJEwACVLMvv/wyDBw4MLX32WefUK+eUy3Upk6dOoXLLrsstT///PNwxBFHhJkzZ/omAABQsvxVClDN7rjjjnx73333Nb6QgcMPPzzsvPPOqX3XXXf96fcSAABKjQAQoBrFWUa5oCEu/e3QoYPxhQyUlZWFm266KSy11FLpepwF+Mknn/heAABQkgSAANUoLv394osvUtvsP8jWggsuGO65555Qv379MHHixNCzZ88wadIk3xYAAEqOABCgGv3vf/9Lx6ZNm4YePXoYW8jYBhtsEM4555zUHjp0aDj55JOz7hIAANQ6ASBANRk1alR48MEHU7tXr16hRYsWxhbqgFNPPTVsuummqX311VeHxx9/POsuAQBArRIAAlSTW265JUydOjW1DzvsMOMKdURcAty3b9+w0EILpev7779/GDlyZNbdAgCAWiMABKgGM2bMyC//7dKlS1hjjTWMK9Qhbdq0Cbfffntqjx49Ouy1115h2rRpWXcLAABqhQAQoBr0798/fPXVV6lt9h/UTdtuu23o06dPar/yyivh7LPPzrpLAABQKwSAANXgP//5Tzq2bt067LHHHsYU6qiLLroorL322ql94YUXhgEDBmTdJQAAqHECQIB59M4774QXX3wxtY844ohUARiomxo1ahTuv//+0LJly3S9d+/e4bvvvsu6WwAAUKMEgADVNPuvcePG4cgjjzSeUMe1a9cu3Hbbban9yy+/hD333NN+gAAAFDUBIMA8+Oabb8J9992Xn0m06KKLGk8oADvuuGM4/vjj8/sBnnXWWVl3CQAAaowAEGAeXHzxxWH69OmpnSsuABTO72+s2p3bG/Dpp5/OuksAAFAjBIAA8zD776abbkrt3XbbLay88srGEgpsP8A4g3fW/QBHjhyZdbcAAKDaCQABqihWEJ06dWpqn3322cYRCnw/wF9//TX07NnTfoAAABQdASBAFXz11VfhlltuSe3dd989rLrqqsYRCng/wNwS/tdeey2ceeaZWXcJAACqlQAQoApOOeWUNPuvrKzM7D8oAnEPwHXWWSe/N2D//v2z7hIAAFQbASBAJb3++uv5yr/7779/WGWVVYwhFNl+gHvvvXf49ttvs+4WAABUCwEgQCXMmDEjHH/88andrFmzcP755xs/KBJt27YNt99++5/2A8zt8wkAAIVMAAhQCbFYwJtvvpnap512Wlh88cWNHxSRHXbYIZxwwgn52b72AwQAoBgIAAEq6IcffsgXClhmmWXyMwGB4tsPcN11103tf/3rX+Gpp57KuksAADBPBIAAFXTUUUeF33//PbVvuOGGMN988xk7KEINGzYM9957b2jVqlW6bj9AAAAKnQAQoALuuuuu8PDDD6f2gQceGDbffHPjBiWyH+Do0aPDHnvsEaZMmZJ1twAAoEoEgAB/45NPPgmHHnpoardp0yZccsklxgxKQPfu3fP7AQ4aNCicdNJJWXcJAACqRAAIMBcTJ04MPXr0CBMmTAj16tUL99xzT35ZIFAa+wFuuOGGqX3VVVelcwAAABQaASDAHEyfPj307t07vP/+++n6eeedFzbeeGPjBSW2H+D9998fFltssXT9oIMOCsOHD8+6WwAAUCkCQIA5iEv/HnnkkdTefvvtw6mnnmqsoAQtvvjiKQSsX79+mhW8yy67hLFjx2bdLQAAqDABIMBsZs6cGU477bRw5ZVXputrrbVWqggalwADpWmjjTYK//73v1N7xIgRYf/990/nCgAAKAT+mgWYxYwZM8Lxxx+f9v2KlllmmfDEE0+EZs2aGScocfHcsPvuu6d2rAp+6aWXZt0lAACoEAEgwP8ZM2ZM2GmnnfIz/1ZYYYUwcODAsOiiixojIJSVlYWbb745rLjiimk0TjnllPDiiy8aGQAA6jwBIEAI4dVXXw1rr7126NevXxqPzp07h5dffjksscQSxgfIa968eZr9N//886cZwz179gzfffedEQIAoE4TAAIl7fvvvw+HHHJI2t/rs88+S7fttdde4bXXXjPzDyjXSiutFG655ZbUHjVqVFoWPHnyZKMFAECdJQAEStLQoUPDEUcckfb4u/HGG/Mze6677rrQt29fe/4BcxVDvz59+qT2oEGDwpFHHqkoCAAAdVaDrDsAUBviLJ133nknvPDCC6F///5h2LBhf7p/1113DVdccUVYcsklfUOACrn44ovThwnxvBL3BlxttdXCUUcdZfQAAKhzBIBAQYl7bv3666/hxx9/DL/88kv47bff5noZPXp0/jK7+vXrhx133DGcccYZYfXVV8/k6wEKV8OGDcP999+f9g/98ssvw3HHHRdWWWWVsOmmm2bdNQAA+BMBIFCnZ+3FCptxhk2csTd8+PAwcuTIMHXq1Cq/ZqNGjcIGG2wQunfvnvb6U+EXmBetW7cOjz32WFhvvfXChAkT0tLgt956K7Rv397AAgBQZwgAgTrlgw8+CHfffXd4+umnU/BXGbEqZ6tWrcq9xD/G4/K8ONOvWbNmNdZ/oPR07Ngx3HnnnWGXXXZJM5TjzOLXX389nZMAAKAuEAACmYsz+u677760B9+QIUP+cn+TJk3CyiuvHFZdddXQoUOHsPjii6fLQgst9KeQLy7HA8jCzjvvHM4555x0iR9k7Lfffml5cL166q0BAJA9ASCQmenTp4fbb789/cH87bff5m+PfzBvtNFGYauttgrdunVLM/fifn0AddmZZ54Z3nvvvfDII4+Ehx56KFxwwQXpNgAAyJoAEMjEK6+8Eo444og/VeNdeumlw5FHHhl69+4d2rRp4zsDFJT44cUdd9yR9gOM57azzjordOrUKS0JBgCALFmXAtSqcePGhUMPPTRsvPHG+fAvLuvt27dv+Oyzz8LJJ58s/AMKVtz3LxYFWXDBBdP1+IFGXBIMAABZEgACteb9998Pa621VrjhhhvS9ebNm6d9/z788MPQq1cve/gBRWGZZZYJDzzwQNq6YPz48WkG4C+//JJ1twAAKGECQKDGzZw5M9x0001hnXXWCSNGjEi3bb/99in4O/bYY0OjRo18F4Cistlmm6UPOKIvv/wy7L777qngEQAAZKGk9gD8/fffw4MPPhjefPPN8Ouvv4bGjRunpYfbbrttWHfddav8utOmTQtPPPFEePnll8P333+fbltiiSVC165dw3bbbRcaNJj7MH/xxRdpw/C4RGjs2LFhgQUWSNVOd9lll9C+fftynzNx4sTwxhtvhKFDh6Zlk6NGjQozZsxIlVBXXHHFsM0224RVVlmlyl8TVGehj+OPPz5cffXV6Xqs1HvJJZeEY445JpSVlRlooGjFPU3j/+1x1vNLL72UznvXXXdd1t0CAKAElUwA+M0334TTTz89hYDRfPPNFyZMmJACtHjp3r17OPjggyv9un/88Ueq8Jeb1ZSbyRRDuXh57bXXwnnnnReaNGlS7vNjaHjllVemEDFq1qxZCifj7fG5MTiJ1VBnF2//4Ycf8tfjvxs3H49BYLwMHDgw7LzzzmH//fev9NcE1WXSpElp/6tYDTNq27ZtuP/++0OXLl0MMlD04occ8cOPjz/+OP2/fP3116eiIIcffnjWXQMAoMSURAAYl9ycf/75KfyLAUSfPn3SzLrJkyenjbrvuuuu0K9fv3TbFltsUanXvvbaa1P4F4O7+Ml+bibh4MGDw1VXXZXe9MdP+2NgV14omQv/Ntxww3DQQQelTcNHjx4dbrzxxhQAxuVDsV9LLrnkX2ZVtWvXLnTr1i2sueaaYfHFF0/LLOMMxFiBcNCgQWlW4WKLLZZmA0JtGzNmTNhhhx1Std8o7v335JNPhkUWWcQ3AygZ8QO6uPpg7bXXDl9//XU4+uij00z9TTfdNOuuAQBQQkpiD8ABAwaEH3/8MS35Peuss/LLauP1Hj165AOyWIU0NxOvIuKePvET/Si+oV9vvfXSp/3xEttHHXVUui8u+4lv+mcXg8f478X+nHDCCfmKgfF44oknpttjeBkfN7vjjjsuBYxxH7UY/kXx341Lj//xj3+Ejh07pttiCAi1LYbtMZzOhX/xd+zFF18U/gElaeGFFw6PP/54+rAwfoC32267pe0/AACgtpREABgDuGjjjTdOb8Jnt+uuu6bwLM68i3v1VFRcphtn3cUALgZ+s1t//fXzM/PiY2cVlx+/9dZbqb3TTjulSoGzitfj7VHcszDu+TeruEfgnMSlwHHz8SgGn7ECIdSWcePGpcAv9/O99957p5m2888/v28CULLi0t8777wzteP7jThDOu77CwAAtaHoA8C4R9+nn36a2mussUa5j4mhYG6J7XvvvVfh137//ffTcfXVVy+3mEG8Ld4362NzYvXT3GzDOfUrd3ucBfjRRx+FymjRokW+HWcbQG2IwXaclRqXoEe9evUKt956ayr8AVDq4t68cV/gaPjw4WmP1FjACwAAalrRB4AjR45MM/CiuP/fnOTu+/bbbyv0uvE142v/3esuvfTS5b5u7nrLli1T1d/yxNtz98X9Aitj2LBh+defNQyEmhID7Rj45Zb97rHHHuG22277y+xWgFJ2xhlnhN133z214/7D8ToAANS0oi8CEpfZ5OT22CtP7r7ffvutwjMLY4XTir5ufHy8xOrDs/47c3tu7v64n1pF+xX98ssv4emnn07tzTffvNzZibOL+x/efffd5d632mqrpU3M4yyFuKR4VrmZC+XdR+mIgfipp54annrqqXR9q622Cpdcckn6WaT0OC/A3F188cVpZn/8sO6iiy4KSy21VJodWOycGwDnBcB7hnlX1RUkRR8A5kK6XNGPOcndF0O6ipj1cRV53dxzcgFg7vlze25V+hVnYV166aXp8bHaatxovKJLN0eNGlXufbMuIZ7bD5plTKUrVrq+/fbb80vX//vf/6aZf34m8DMAf9WkSZNwyy23hG233TZ9UNKnT5+0miB+4FYqnBsA5wXAe4baVa0B4F577RUOO+ywVGyDbGZhXXPNNWl/wThjL1YSjhUHKyI+LgaG5Zl1CWcsMDKnN/Cz30dpeOKJJ8L555+f2u3atUtBYEV/7ihOzgvw9+KsvxgCxg/q4oeVBx54YOjfv39YbLHFinb4nBsA5wXAe4YiCQDvvffecN9994Xll18+HHrooWGfffb52yWutfEpe87kyZND06ZNy31cvC/KzdD7O7M+Lvfcub3u7M/Jtef23Mr264YbbggvvPBCCuxOPvnksOKKK4aKihuRx0t5/vOf/6TKrjHgm/0Pk7jsN76hL+8+il8Mm4877rjUjr/rMQxceeWVK7TsnOLlvMDsH07F2ekNGjRwbphN9+7dw/XXXx8OOOCA9HsT3zu9/PLLf3rvUkycG8hxXsB5gfI4N+DcUDFVnXxVryZ+aUeMGBFOOOGEVFk3hoCvvvpqyMqsAeSs+wHOLndfq1atKvS6MZDLhXIVed1ZHz9rv+b23Mr0K84iePLJJ9MPQlxK1KVLlwp9HVBVcW/KnXbaKS0fj6HzAw88kMJ/ACpu//33D8cff3xqv/nmm+GQQw7JFy8DAIDqUq0B4EsvvRR69uyZlp/GN69xSctdd90VunbtGlZZZZVw9dVXhzFjxoTaFEPI3GykuVXSzd0Xl+RURHzN+NpVfd3c9TgeY8eOnWPAEi+zVhMuzx133BEeffTR1Kejjz46bLTRRhX6GqCq4qzPvffeO3z66afp+r///e+w6aabGlCAKojn0Fg8KbrzzjvD//73P+MIAEDdDQDj3n+xkuzIkSNTBdA4GygGgfHy8ccfp6WCSyyxRPq0e9CgQaE2xFl3yy23XGq/88475T4mbsD97bffpnbnzp0r/NqdOnVKx3fffXeOjxk6dOifHpsTl0nG5VBz61fudRs2bBhWWmmlch8Tx/vBBx9M7bj/Yqz6CzXtX//6V+jXr19qx9A/N3sFgMqL7wfiNirLLLNMuh7fL83tvQUAAFRWjVRtaN26dVoCHEO/F198Meyxxx75WYGxOm2csbbhhhumUOzaa6+d4wy46rLJJpuk48CBA8PPP//8l/sffvjh1Le4LLdjx46VCjzjrLvvv/++3EDz9ddfT/fFx+T6kBP3Ilx77bVT+7HHHvtTpd0oXo+3R3E5b3l7F8bgL/7BEMXNw7fZZpsK9x2qKv5cn3nmmakdf19uuukm+3oBzKOWLVuG+++/P71fivv/7r777vlVAAAAMK9qvGxrXP57zz33pFmBcYnLrLMChw8fnpastmnTJhx00EFp75uaEJfVxAIVcUnyP//5z/Dll1+m2+Mb7Biixb3zolgEIzcrLyf2a4cddghXXHHFX163ffv2+YrHcXnz4MGD819bbMeKvFEM/8pbwturV6/0733++efhsssuC7/99lu6PR7j9Xh7nP0XHze7xx9/PAWp0b777ht23HHHahgpmLv4s7nnnnumgDqG0vGPVRV/AarHmmuumf7/j+J7gPgexH6AAABUh7KZGbyzjLMCY8XaRx55JEyZMuX/deT/9umLswKPOOKIFMZVtCJvRcS9+E4//fT8p+kxvIiBYNzLLNp+++3Txtuzi2++R40aFTbbbLN8tdNZxRmNcTZULHwSxU/uo9zXFSvxnnfeeXOs6Ber/V155ZWpQmIcg9ivWFQhiuFg/DdzIeOsYuAXv3XxOQsssMBcv/ZTTz11jkuIKyJXBbh58+ZpZuesVPQrHfHnbbfddkszZqNbb7017Lfffn+6X6VPIucFZj93ODdU7lwbV07Ewkq5DxiPOuqoovihcm4gx3kB5wXK49yAc8O8ZzRz8+fpbrUkFguI+9zE4CoGgbnwL/7Cv//++2kvu9NOOy1djj322CqXOJ5VnIEX30Q/9NBDaaZh3PcvzlyK/dhuu+3CuuuuW6XXjSHlxRdfHJ544okU5sUlv1GHDh3SzL/42rPPKpx9hmQsCBJDlWHDhqXl0LmlyLvsskuaZVieXG4bj39XWCX+4QXz6sYbb8yHf3FWapx5CkD1iu+J4tYKcQ/Azz77LPTp0ycV96rMHsUAAJDpDMA42y4uXY3V7Z599tn8ctkoJpcxhIsh2qyzAuOb3v79+1frbEAqxwxAvvjiizQ7N85OjeF2LFzTokWLPw2MT+zIMcsH54Z5FwPA+L4ovieKHwrGDy/ntJqgUDg3kOM9A84LlMe5AeeGmp0BWON7AEZff/11OOOMM9JMt1133TU888wzKQyMv+DxTW0sBPLdd9+FAQMGpGq8F1xwQVh44YXT/a+88kp+Pxyg9sX9/uJS3xj+xdm4ce/J2cM/AKrX6quvHs4///zU/uCDD/LFlwAAoCrq1WRoEPf423rrrdOMoYsuuij88MMPKdSLhS322muvFO699957acnv/PPPn54Xg7+4Z91HH30UVllllfT4WEQEyEbcozL+rkYnnnhiWH/99X0rAGpBXP6b2wc4ftL70ksvGXcAAOpGAPjVV1+lYhtxz71YMCAu9c3N9mvXrl0KAmNF4L59+4YNNthgjq8T98GL+/9Fuaq9QO2KQXzcizOKgfy5557rWwBQS+rXrx9uv/32tLwjvo+Ke6/G5R4AAJBpALjVVluFZZddNhXFyM32i/v4xUIYTz75ZPj888/DP/7xj7DQQgtV6PWWXHLJdIzVeoHaFYvH7LPPPmHy5MmpkE38I7TQ958CKDTxw9NYxCz65ptv0oesAACQaQA462y/RRZZJC3ljaFfv379wjbbbJOv9ltRTZs2TTMJ27ZtW53dBCrg3//+d3j77bdTO+7hueaaaxo3gAzED2Pi+6jommuuCYMGDfJ9AACgUhqEahar9h5++OGp2Efc629exH1v4pJioHZ9+umn4bzzzstvRJ9bBgxA7YsfoF533XVpK4ZYkOmggw5KVYIbNWrk2wEAQO3PAIxV6l5++eXQs2fPeQ7/gGzEGbyxME9c+hv3n7r55pv9PgNkLK6GuPDCC1P7ww8/TNutAABAJgFg/GQaKGx33HFHeOGFF1L7+OOPTzMAAcjekUceGdZdd93UPv/889NsbQAAqPUAsF69eqlYwOOPP16p5w0YMCDNNIrPBbLz888/hz59+uQ3nj/nnHN8OwDqiPhe6cYbb0zHqVOnpg9pAACg1gPA3PLBqj6vqs8FqscJJ5wQRo8endpxv6lmzZoZWoA6ZNVVVw1HHXVUaj/55JPpAgAAtR4AAoXpueeeC3feeWdq77XXXmHrrbfOuksAlCPOzl5ooYVSO84CjHu2AgBAnQ8AJ06cmI5NmjTJuitQkqZMmZL2lopatWoVLr/88qy7BMActGzZMl8QJO4DeOWVVxorAADqfgA4ePDgdFxkkUWy7gqUpCuuuCKMGDEitS+66CK/iwB13AEHHBDWWGON1P7nP/8Zfvrpp6y7BABAHVblqhvvv/9+GDp0aLn3xQqiY8aMmevz435/EyZMCO+8807o27dvKCsrC2uvvXZVuwNU0XfffZf+eIziH5MHHXSQsQSo42IhkKuuuipsuOGGYfz48eGCCy5I1wEAoFoDwEceeSScd9555QZ7V199daVeKz4nBoCHHXZYVbsDVNHJJ5+c/niMrrnmmvRHJQB13wYbbBB23HHH8Nhjj4Xrr78+HHfccWGZZZbJulsAABTbEuBc5d7ZK/jOfvvfXRZddNFw4403hs0226w6viagggYOHBjuvvvu1N5vv/3CeuutZ+wACkic+VevXr0wderUcPbZZ2fdHQAAim0G4E477RTatWv3p9v233//NJPvqKOOyu9LMyfxzer8888f2rdvHzp27GjWEdSyadOmpd/VqEWLFuHiiy/2PQAoMKusskrYZ599wm233RbuuuuucNJJJ4VOnTpl3S0AAIolAOzcuXO6zB4ARptvvnnYYYcd5r13QI2Jy8U++OCD1D733HPTTFwACk88h8fZ3LGi+6mnnhqefPLJrLsEAEAxVwG+9dZbwy233PK3s/+AbMUiPeecc05qr7zyyuHII4/0LQEoUEsvvXT+PP7UU0+FwYMHZ90lAACKOQDcd99902XJJZeszpcFamDPqF9//TW1L7vsstCwYUNjDFDA4sy/pk2bpvb555+fdXcAACjmABCo+7788stw1VVXpXa3bt3CVlttlXWXAJhHCy+8cDjssMNSOy4Bfvfdd40pAAB5AkAowVkicZ+oWIjn0ksvzbo7AFSTE044ITRu3Dg/0xsAAOapCMgyyyyTjrHi7+eff/6X26tq9tcDqlfcF+q+++5L7QMOOCBV4AagOLRp0yYceOCB4dprrw0PPfRQGD58eKoSDAAAVQoAv/rqq3xgN/vt8baZM2dWaWRnfz2g+sTfyz59+qR2s2bNwj//+U/DC1BkTj755HDDDTeEadOmhYsuuij07ds36y4BAFCoAWCsNldeWDen24HsxdkggwYNSu1//OMfYbHFFsu6SwBUs7Zt24Z99tkn3HLLLeGee+4J55133jyv0AAAoMRnAFb0diBbcSbI6aefnl8ilpsJCEDxOeWUU8Ktt94aZsyYkYo+XXHFFVl3CQCAjCkCAiXg9ttvDyNGjEjtc845Jy0BBqA4LbfccqF79+6pffPNN4fff/896y4BAJAxASAUuUmTJoVzzz03tZdddtmw3377Zd0lAGpYbqb3+PHjw0033WS8AQBKnAAQitz//ve/8O2336Z2LPzRsGHDrLsEQA3beOONwxprrJHaV155ZdoKAgCA0lXrAeAff/wRLr/88rDLLruEHXbYIZx11lnhhx9+qO1uQEmIMz8uuOCC1O7UqVPo0aNH1l0CoBbEomzHH398ascPgWIhKAAASle1BoDvvvtuChk6d+6crzY6q7Fjx4Z11103nHjiieGxxx4LTz75ZAon4nPic4HqFWd9/Pzzz6kdf9fq1TPpF6BUxA99YuGn6LLLLgszZ87MuksAAGSkWtOABx98MAwbNiyMGjUqBX2zi1VIP/jgg/QGdNbLr7/+GnbdddcwefLk6uwOlLTRo0eHSy65JLXXW2+9sN1222XdJQBqUaNGjcLRRx+d2m+++Wa6AABQmqo1AHzjjTfSkpMtt9wyHWc1bty4VIku3r700kuHRx55JAwdOjQccsgh6f6vv/469O3btzq7AyXt0ksvzVd+vOiii/7yOwlA8Tv44IND48aNU/v666/PujsAABRDAPjdd9+l4+qrr/6X+/r375+qkUYxCNxxxx3T0t/4ZjQeo0cffbQ6uwMlPfvv6quvTu0tttgidO3aNesuAZCB1q1b5/d/vffee9P/DwAAlJ5qDQB/+eWXdFx88cX/ct/LL7+cv2/zzTf/03277757Wgr8/vvvV2d3oKT3/osFQKKzzz476+4AkKHDDz88HeMHsbfffrvvBQBACarWADC33LC8QgOxKEhcgjh7+BfFJcFRrlgBMG+/hzEAjOLMvw033NBwApSwuC9zbrVFXHmhGAgAQOmp1gCwadOm5QZ5MZDIze5bf/31//K8Jk2apOP06dOrsztQkq655pp8GH/mmWdm3R0AMhY/gM3NAhwxYkR48cUXs+4SAACFHAC2a9cuHV999dU/3f7EE0+EGTNmpPYGG2zwl+fFKsDRAgssUJ3dgZITl/1efvnl+cq/m222WdZdAqAO6NWrV5h//vlT+7rrrsu6OwAAFHIAuNFGG6VlJY8//nh477330m1jx44N//73v1O7TZs2YdVVV/3L84YNG5aO7du3r87uQMmJf9TlAvU4+0/lXwCi5s2bh969e+eLrv34448GBgCghFRrAHjwwQen/f/iJtNdunRJe8506NAhBXwxiIj3l+eFF15I9+f2pwEqb+LEieHSSy9N7bXWWitsvfXWhhGAvMMOOywdp02bFu68804jAwBQQqo1AIwBXqw4GmcBTp06Nbz11ltpNlK83rFjx3DSSSf95TkffPBB+Pjjj1NbsQKouhtvvDGMGjUqtc844wyz/wD4k86dO4fVV189tW+99VbFQAAASki1BoC5ZYdxacl2220Xll9++bDGGmuEU045JQwcODDMN998f3n81VdfnY4xJNxqq62quztQEmLgftlll+WD+B122CHrLgFQB+2///7p+NFHH4U333wz6+4AAFCoAWAUw4d+/fqlN5dvv/12uPDCC0OLFi3KfewNN9yQCoTEy2KLLVYT3YGi98ADD4RvvvkmtU8++WSz/wAo11577RUaNWqUnwUIAEBpqJEAEKg9cfbsJZdcktpLLbVU6NGjh+EHoFytW7cOO+64Y2rfc889af9YAACKnwAQClwsojN06NDUPu6440LDhg2z7hIABbAMeOzYseGRRx7JujsAANQCASAUuNzsvwUWWGCOlbYBIKdbt26hTZs2qW0ZMABAaWhQUy8cZyT1798/DBs2LPz2229h0qRJf/ucsrKy8Pzzz9dUl6DovP/++2HAgAGpfdhhh4XmzZtn3SUA6rj69euHffbZJ1x88cVpFvnXX38d2rZtm3W3AAAopADwhx9+SEtLnn322UrvYxYDQKDiLr/88nSMy36POeYYQwdAhey3334pAIzvv+JegKeccoqRAwAoYtW6BHj8+PFh0003TeFffENZmQtQOT///HP6oy3ac88988u5AODvrLDCCmGttdZK7bvuusuAAQAUuXrVPRtpxIgRqb3kkkuG6667Lnz22Wdp+e+MGTP+9jJ9+vTq7A4UtRtvvDFMnjw5tc3+A6CyevXqlY5xu5a4pQQAAMWrWgPAXCW5xRZbLLz11lvh0EMPDcsss0xo1KhRdf4zUPKmTp0arr322jQO6623XlhzzTVLfkwAqJyePXuGevX+31vBvn37Gj4AgCJWrQHg559/nvbxO+KII8Kiiy5anS8NzOLRRx8N3333XWofffTRxgaASosf2G6xxRapHbeUiKsxAAAoTtUaAObeOMZ9ZYCac/XVV+f/eNt1110NNQDztAx45MiRYeDAgUYRAKBIVWsA2LZt23QcN25cdb4sMIuhQ4eGV155JbUPO+wwS+wBqLKdd945zDfffKmtGAgAQPGq1gBwhx12SBV9X3vttep8WWAW//3vf9OxYcOGaZ9NAKiq5s2bp/dv0QMPPJAKtwEAUHyqNQCMe5G1atUqfYL88ccfV+dLAyGEsWPHpn2aot122y0tAQaA6lgG/Pvvv4cBAwYYTACAIlStAeDiiy8e7r333tCgQYOw5ZZb2ksGqlkM/yZMmJDahxxyiPEFYJ5ttdVWYYEFFsjPAgQAoPg0qM4XO++889IxVpR77LHHwqabbhpWW221sN5664WFFloo1Kv393njWWedVZ1dgqJyww03pONyyy0XunbtmnV3ACgCjRo1SnsB3nbbben92x9//JHfFxAAgOJQrQHgOeecE8rKylI7HuN+gLFgQbxUlAAQyjdkyJDwzjvv5Gf/5X7XAGBe9ejRIwWA48ePT8uAd9ppJ4MKAFBEqnUJcBRDv9xl9ut/dwHm7MYbb8wX/9h3330NFQDVZvPNN0/7OEf333+/kQUAKDLVOgPwxRdfrM6XA/5PnJERi+tEcZnWwgsvbGwAqPZlwLfcckt4/PHHLQMGACgy1RoA2pMMasZ9992XQsBI8Q8AasLuu++eAsBYbKp///5hl112MdAAAEWi2pcAA9Uv/kEWdejQIRXXAYCaXAasGjAAQHERAEId9+mnn4bXX389tffbb78KVdMGgMqKe8zmZv3169cvTJw40SACABSJGk8SRo4cGZ555plw7733hjvuuKOm/zkoOnfeeWe+3bt370z7AkDxVwOOcsuAAQAoDvVqcsniKqusEtq2bRu22Wab0KtXr7D//vv/5XEXXHBB6NatWzjwwANrqitQsGbMmJEPADfZZJPQrl27rLsEQBGL20y0bt06tVUDBgAoHtUeAP7xxx9hu+22CwcffHD4+OOPw8yZM/OX8qy11lrhueeeC7fddlv46KOPqrs7UNBeeeWV8NVXX6X2Pvvsk3V3ACihZcBPPPFEmgkIAEDhq/YAMIYUcclIDPzi7L9TTz01HHbYYXN8/JZbbhkWXnjh/BtN4P+XWzY/33zzhV133dXQAFAr1YCjuAfggAEDjDgAQBGo1gDw+eefDw899FAoKysLe+65Z/jkk0/SEt+tttpqzh2oVy+FgDEwfPXVV6uzO1DQ4h9euSqMcTZGixYtsu4SACUgbjmRqwb8yCOPZN0dAADqWgAYl/FGyyyzTGrHZSQV0blz53S0BBj+f48++mgYN25calv+C0Btie/funfvnq8GPGXKFIMPAFDgqjUAfO2119LsvxhWVDT8i9q0aZOOP/74Y3V2Bwpa375903HxxRcPm2++edbdAaCE7Lzzzun4+++/h5deeinr7gAAUJcCwJ9++ikdV1hhhUo9r0mTJuk4adKk6uwOFKxff/01PPvss6kdl9PXr18/6y4BUEK6deuW9p+NLAMGACh81RoA5kKKGTNmVOp5o0ePTseWLVtWZ3egYMU/tqZNm5bae+yxR9bdAaDENG3aNGy99db5LSkq+94OAIAiDgAXXXTRdPzss88q9bwhQ4ak41JLLVWd3YGCdd9996Vj+/btw9prr511dwAoQbEAVW6LlsGDB2fdHQAA6koAuP7666dqvvGT4oqaMGFCqnQa9w7ccMMNq7M7UJDiUvoXXnghtXv06JF+NwCgtm233XahQYMGqW0ZMABAYavWAHD33XdPx3fffTfccsstFXrO4YcfHn777bfU7tWrV3V2BwrSQw89lF9qZfkvAFlp1apV2HTTTfMBYPyQFwCAwlStAeD2228f1l133fQG8bDDDgsXXXRRGD9+fLmPjSFh/GT5rrvuSjOcttlmm9ClS5fq7A4U9PLf5ZZbLqy22mpZdweAEparBvz555+HYcOGZd0dAADqQgCYCy8WW2yxVMDgjDPOCIssskg47rjj8vfH/cwWX3zxsNZaa4Wnn346hYVx77/bbrutursCBef7778Pr7zySmr37NnT8l8AMrXTTjvl/y+yDBgAoHBVewAYw7w33ngjPxNw0qRJ4Ztvvsm/eXznnXfSHmfxvnhZZ511wuuvvx4WWmih6u4KFJy4H2ZuiZXlvwBkLX5oG9/TRQ8//HDW3QEAoK4EgLkQMIZ6jz32WKog17p163zgFy/zzz9/Wv57//33h0GDBoU2bdrURDeg4Dz44IPpuMoqq6QLANSVZcDvvfde+PLLL7PuDgAAdSUAzOnevXsKNEaNGpX2Ahw5cmQYM2ZMGDt2bOjXr1/YbbfdavKfh4ISf09ee+211N51112z7g4A/CkAjCwDBgAoTDUaAM6qadOmaaZfixYtauufhILy+OOP55f/xj2XAKAuWHbZZUPHjh1TWwAIAFCYai0ABObu0UcfTce2bduq/gtAnZwFGGeq//jjj1l3BwCASmoQquC8884LNeWss86qsdeGumrcuHHhueee+0vFRQCoKwFgfP8XZ6o/8cQT4aCDDsq6SwAA1HQAeM4559RYQCEApBQ9/fTTYfLkyalt+S8AdU3nzp3TDPWvv/46zVgXAAIAlMgS4Fmr+s7p8nePm/1+KPXlv7Fi9oYbbph1dwDgT+IHv7kPqOKM9ThzHQCAIp8B+OKLL871/quvvjo8/PDDoV69eqFbt25h8803TxtIN2vWLEyYMCF89tln4fnnnw/PPPNMmDFjRthll13CUUcdVdWvAQralClTwpNPPpmvnN2gQZV+LQGgRu24447hyiuvTDPWBwwYEHbbbTcjDgBQIKqUNHTt2nWO9x1//PGpQtxKK60U7r333nzVuNn16dMnDBs2LOyxxx4pLFx66aXDf/7zn6p0BwraSy+9FH7//ffUtvwXgLpqo402Cq1atQq//fZbeOyxxwSAAAClWgX42WefTZ8ML7jgguGFF16YY/iXs+qqq6bHxTeTV1xxRb4IApTi8t+mTZumGbMAUBfFGepxpnoUC4FMnTo16y4BAJBFAHj99denPWIOPPDAsOiii1boOfFx8fFxD8D//e9/1dkdqPPiz31u+e+WW24Z5ptvvqy7BABzXQYcjRkzJgwcONBIAQCUYgD49ttvp+Nqq61Wqeetvvrq6fjmm29WZ3egzvvwww/DN998k9rbbbdd1t0BgLnaaqutQpMmTVI7LgMGAKAEA8BRo0alY9wcujJyj889H0pFbvZftO2222baFwD4O7GgW5yxntvCIs5kBwCgxALAuJdf9PLLL1fqebnHt2zZsjq7A3XeU089lY6dO3cOSyyxRNbdAYAKLwP+9ttvw7vvvmvEAABKLQBcd9110yfBffv2DYMGDarQcwYPHpweH/cOjM+HUhEr/7766qupbfYfAIUiFgKJ79siy4ABAEowADz00EPTcfr06WmPmFgUZE4V4uLtsejH1ltvHaZNm5ZuO/zww6uzO1CnPfPMM+l3JRIAAlAoFllkkbDBBhv8qZI9AAB1W4PqfLEY+sWKvjfffHOYMGFCOPLII8Npp52W3iQuu+yyoWnTpmHixInhs88+C6+99lqaAZXbOyY+r1u3btXZHSiI5b9x6bzZrwAUkp122inNYn///ffDF198EZZZZpmsuwQAQG0FgNENN9yQgr5rrrkmhXtjxozJBx2zygV/cQnJ0UcfHS6//PLq7grUWTNmzAj9+/fPB+cNGlT7ryIA1Og+gCeeeGJ+GfDxxx9vtAEASmUJcC7Qu/LKK8PAgQPTp8ONGjVKYd/sl8aNG4edd945vPLKK+GKK67I7yUDpSBumv7TTz+ltuW/ABSauLJjlVVWSW37AAIA1H01Nu0oLvuNlylTpoT33nsvfP/992H8+PFh/vnnT9VOO3XqlMJBKEVPPvlkOsbgO+6DCQCFJn7QO3z48PRh7i+//BIWWmihrLsEAMAc1Pi6wxjyrb322jX9z1BLcku3c+rXrx/q1auXgqzZ72POnn766XSMvxvxD6ZiGLvc11AMXwvzxnmBWTk3FK8ddtghXHDBBWlbi379+oX99ttvro93biDHeQHnBcrj3IBzQ82y8RiVkqvYnNOyZcs53kf5YvGbN998M7U333zzohu3XGVjSpfzAuVxbig+nTt3Tqs6vvvuu1QNuHfv3nN9vHMDs3NewHmB8jg34NxQMwSAVO4HZrZiFXHJT/ykJs4AtPSnYmLVxNx/asVUACT+HMSvK87wsKdnaXNeYFbODcU/C/C6664Lzz77bNr2JRaCmxPnBnKcF3BeoDzODTg31KziSB6oNbMHOzHwiUt/csuA+XvPPfdcOjZr1iyst956RTdu8esptq+JynFeoDzODcW7D2AMAP/444/0/1usDjwnzg3MznkB5wXK49yAc0OBVAEGKhYAdu3aVSEcAAraJptsElq0aJHaqgEDANRdAkCoRd9++2345JNPUnvLLbc09gAUtFjsbbvttkvtxx9/vOj2tQUAKBYCQKhFcY+kHAEgAMUgt+z3119/Da+//nrW3QEAoBwCQMhg+e/iiy8eVl55ZWMPQMHbZpttQsOGDVM7VgMGAKDuEQBCLYnFUnIB4BZbbKFQBgBFIe4BuPnmm+f3AYxVHAEAqFsEgFBLPvjgg/Dzzz+ntuW/ABRbNeDoiy++CMOGDcu6OwAAzEYACBns/5ebKQEAxaB79+75tmXAAAB1jwAQasnzzz+fjqusskpo06aNcQegaMT/19ZZZ538MmAAAOoWASDUgqlTp4ZXX301tTfbbDNjDkDRLgMeMmRI+Pbbb7PuDgAAsxAAQi145513wvjx41N7k002MeYAFJ0dd9wx3zYLEACgbhEAQi146aWX8u2NN97YmANQdFZcccWw/PLLp7YAEACgbhEAQi0GgKuuumpYaKGFjDkARaesrCy/DDj+v/fbb79l3SUAAP6PABBq2LRp0/L7/1n+C0ApLAOO//c99dRTWXcHAID/IwCEGmb/PwBKRawEvOiii6b2o48+mnV3AAD4PwJAqGH2/wOgVNSvXz/ssMMOqf3000+HSZMmZd0lAAAEgFB7AeAqq6wSFl54YUMOQEksAx4/fnx44YUXsu4OAAACQKhZcQ+kV155JbXt/wdAKdh8881Ds2bNUtsyYACAusESYKhB7777bpoBEQkAASgFTZo0Cdtss01qP/7442HGjBlZdwkAoOQJAKEG2f8PgFK00047peNPP/0U3njjjay7AwBQ8gSAUINefvnldFxppZXCIossYqwBKAnbbrttKggSWQYMAJA9ASDUkLjk6bXXXkvtjTfe2DgDUDJatWqV3/risccey7o7AAAlTwAINeTDDz8MY8aMSe0NN9zQOANQksuAP/nkk/Dxxx9n3R0AgJImAIQakpv9FwkAASg1O+ywQ75tGTAAQLYEgFBDXn311XRs06ZNaNu2rXEGoKQsvfTSYY011khtASAAQLYEgFDDMwDj7L+ysjLjDEDJLgOOlYBjRWAAALIhAIQa8P3334cvv/wytTfYYANjDEBJ2nHHHfPtAQMGZNoXAIBSJgCEGmD/PwAIoWPHjqF9+/ZpKJ5++mlDAgCQEQEg1OD+f82aNQudOnUyxgCUpLgFRm4ZcPxwbNy4cVl3CQCgJAkAoQZnAK633nqhQYMGxhiAUOrLgKdMmRJefPHFrLsDAFCSBIBQzeLshnfffTe17f8HQKmL/xe2bt06te0DCACQDQEgVLNY6XDGjBn5CsAAUMriTPju3bun9vPPP59mAgIAULsEgFBDy3/r168f1llnHeMLQMnL7QMYZ8nPWigLAIDaIQCEapb7w6Zz586hefPmxheAkrfllluGpk2bpnF44oknSn48AABqmwAQqlFc+huXAOcKgAAAIYV/3bp1S0Px1FNPhalTpxoWAIBaJACEavTJJ5+EsWPHprblvwDw/8vtAzhmzJi0FyAAALVHAAjVKDf7L1p33XWNLQD8n0033TQ0a9Yste+//37jAgBQiwSAUI0GDx6cjgsuuGBYdtlljS0A/J/55psvvwz4kUceUQ0YAKAWCQChBmYAxuW/ZWVlxhYA5rAM+NlnnzU2AAC1RAAI1WTChAnhgw8+SG37/wHAX3Xt2jXMP//8qW0ZMABA7REAQjUZMmRImD59emoLAAHgr5o0aRK22mqr1H700UfD5MmTDRMAQC0QAEINFADp0qWLcQWAcuywww7pOHbs2PDMM88YIwCAWiAAhGoOAJdffvlUBAQAKH8ZcIsWLVLbMmAAgNohAIRqrgBs+S8AzFnjxo3DTjvtlNqPPfZYmDRpkuECAKhhAkCoBiNHjgzfffddaq+77rrGFADmokePHuk4bty40L9/f2MFAFDDBIBQzfv/mQEIAHO35ZZb5rfLuOuuuwwXAEANEwBCNQaAsbphp06djCkAzEWjRo3yswCfeOKJ8PvvvxsvAIAaJACEagwA11xzzdCwYUNjCgB/o1evXuk4efLk8NBDDxkvAIAaJACEeTRt2rTw9ttvp7blvwBQMeuvv35o165davft29ewAQDUIAEgzKNhw4aFiRMnprYCIABQwTeh9eqFvfbaK7VfeumlfDEtAACqnwAQ5pECIAAwb8uAZ86cGe655x7DCABQQwSAMI8GDx6cjosttlhYaqmljCcAVNDKK68cVl999dS2DBgAoOYIAGEevfXWW/n9/8rKyownAFRhFuB7770Xhg8fbuwAAGqAABDmwYQJE8JHH32U2muttZaxBIBK6tmzZ/4DtLvuusv4AQDUAAEgzIOhQ4eGGTNmpLYAEAAqb4kllgibbbZZat999935/1cBAKg+AkCYB2+//Xa+veaaaxpLAJiHZcBff/11ePXVV40hAEA1EwBCNQSASy+9dFh44YWNJQBUwa677hrmm2++1L711luNIQBANRMAwjwYMmRIOlr+CwBV16JFi7Dbbrul9v333x/GjRtnOAEAqpEAEKoo/nHy8ccfp7YAEADmzQEHHJCOEydOTCEgAADVRwAIVfTuu++GmTNnprYAEADmzcYbbxyWWWaZ1L7lllsMJwBANRIAwjwu/43WWGMN4wgA86BevXph//33T+3XX389P8seAIB5JwCEeSwA0r59+9C6dWvjCADzaN999w1lZWWpfdtttxlPAIBqIgCEeQwALf8FgOqx1FJLhW7duqX27bffHqZNm2ZoAQCqgQAQqmDs2LFhxIgRqb3mmmsaQwCo5mIgP/74Y3j66aeNKwBANRAAQhW88847+bYZgABQfXbcccew4IILprZiIAAA1UMACPOw/DdSAAQAqk/jxo1Dr169Urtfv37hp59+MrwAAPNIAAjzUAF42WWXDa1atTKGAFADy4DjHoCKgQAAzDsBIMzDDED7/wFA9VtttdXCOuusk9rXX399mD59umEGAJgHAkCopDFjxoTPPvsste3/BwA144gjjkjHr776SjEQAIB5JACESlIABABqXo8ePfLFQK699lpDDgAwDwSAMA8FQFZffXXjBwA1oEmTJuHAAw9M7f79+4cvvvjCOAMAVJEAEKoYAC6//PJhgQUWMH4AUEMOPfTQUFZWFmbOnJn2AgQAoGoEgFBJ7777bjquscYaxg4AalCHDh3C1ltvndo333xz+OOPP4w3AEAVCAChEsaPHx8+//zzfIVCAKB2ioGMHj06PPDAA4YbAKAKBIBQCR988EFahhR17tzZ2AFADdtmm21C27ZtU1sxEACAqhEAQiUMHTo03zYDEABqXv369cNhhx2W2m+88UYYMmSIYQcAqCQBIFTCe++9l46LLLJIWGyxxYwdANSCWA24cePGqX3FFVcYcwCAShIAQhUCQMt/AaD2LLzwwqF3796pfe+994bvvvvO8AMAVIIAECpo+vTpaQ/AyPJfAKhdxx13XDpOmzYtXHPNNYYfAKASBIBQQbH674QJE1LbDEAAqF2rrrpq6NatW2pff/31Yfz48b4FAAAVJACESi7/jQSAAFD7+vTpk45jxowJt99+u28BAEAFCQChkgFgo0aNwgorrGDcAKCWxRmAK6+8cr4YSNyeAwCAvycAhAoaOnRofglSw4YNjRsA1LKysrL8LMDPPvssPPbYY74HAAAVIACEClIBGACy16tXr7Doooum9oUXXhhmzpyZdZcAAOo8ASBUwK+//hpGjhyZ2vb/A4DsNGnSJJxwwgmpPWTIkPDss8/6dgAA/A0BIFSyAMhqq61mzAAgQ4cddlho1apVal9wwQW+FwAAf0MACJUMADt16mTMACBDzZs3D8ccc0xqDxw4MLz66qu+HwAAcyEAhEoEgEsvvXR+xgEAkJ2jjz46NGvWLL8XIAAAcyYAhEpUALb/HwDUDa1btw6HH354avfv3z+8++67WXcJAKDOEgDC35gyZUr48MMPU9v+fwBQd/Tp0yc0btw4tc0CBACYMwEg/I2PP/44TJ06NbXNAASAumPxxRcPBxxwQGo/9NBD4aOPPsq6SwAAdZIAECpRAEQACAB1y8knnxzq168fZs6cGc4999ysuwMAUCcJAKGC+//NP//8YZllljFeAFCHtGvXLj8L8L777vvTB3cAAPw/AkD4G7k/JDp16hTq1fMrAwB1zZlnnhkaNWqUbwMA8GfSDJiLuJwoFwBa/gsAddNSSy2Vrwjcr1+/MHjw4Ky7BABQpwgAYS6+//778Msvv6S2CsAAUHedeuqpoWnTpql9xhlnZN0dAIA6RQAIc6EACAAUhkUXXTQcc8wxqf3888+HF198MesuAQDUGQJAqEAAWFZWFlZddVVjBQB12EknnRRatGiRnwUYt/IAAEAACBWqALzccsuFZs2aGS0AqMMWXHDBcOKJJ6b266+/Hp544omsuwQAUCc0CCXk999/Dw8++GB48803w6+//hoaN24cOnToELbddtuw7rrrVvl1p02blt5gvvzyy2nPuGiJJZYIXbt2Ddttt11o0GDuw/zFF1+ERx55JHzwwQdh7NixYYEFFkizzXbZZZfQvn37cp8zffr0MGzYsPDZZ5+ly+effx5+/PHHdF/Pnj3DXnvtVeWvh7/OALT/HwAUhuOOOy5cffXV4eeffw4nn3xy2HrrrUPDhg2z7hYAQKZKJgD85ptvwumnn55CwGi++eYLEyZMSDO84qV79+7h4IMPrvTr/vHHH+HMM88MI0aMSNcbNWqUjrlg7rXXXgvnnXdeaNKkSbnPj6HhlVdemULEKM4yi+FkvD0+9/jjjw8bbbTRX54XC1PEf5eaM3HixPDpp5+mtgrAAFAYmjdvHs4999xwxBFHhI8//jjceOONqQ0AUMpKYg/AqVOnhvPPPz+Ff23btk2B23333ZcuvXv3Tvu79evXLzz33HOVfu1rr702hX8xuIvV5x544IF0ie14W3zjed11180xlMyFfxtuuGG47bbbwj333JOOG2ywQbr9iiuuCCNHjiz3+THEXGWVVcKOO+4Y+vTpExZffPFK9585izMsZ8yYkdoCQAAoHPFD3ZVWWim1zz777PwHwAAApaokAsABAwak5bFxye9ZZ52VX1Ybr/fo0SNss8026Xrfvn3zM/Eq4ssvvwwDBw5M7aOPPjqst956KUyMl9g+6qij0n0vvfRS+Prrr//y/Lvuuiv9e7E/J5xwQtq3Ztb9a+LtMbyMj5vdwgsvHO69995w0UUXhQMPPDBssskmc5xlyLzt/xdZAgwAhSNuv3LJJZfkV03E90sAAKWsJALAGMBFG2+8cQrOZrfrrrum0G706NFpH76Kist0Y3W5OPMuBn6zW3/99dN98THxsbOKy4/feuut1N5pp51C/fr1/3R/vB5vj+KehXE56qzq1auX+kzN7//XunXr0KZNG0MNAAUk7vG8+eabp3ZcUfHVV19l3SUAgMwUfQAY9+jL7eO2xhprlPuYGAouueSSfwp9KuL9999Px9VXX73cMC7eFu+b9bE5H374YX624Zz6lbs9zgL86KOPKtwvqkfuZyEu/xW2AkBhif93/+c//0nHyZMnh9NOOy3rLgEAZKboA8C4f16cgRfF/f/mJHfft99+W6HXja+Z25tvbq+79NJLl/u6uestW7ZMVX/LE2/P3Rf3C6T2xL3/VAAGgMIWP8Tbb7/9Ujvuszx48OCsuwQAkImiDwDjst6c3B575cnd99tvv1V4ZuGkSZMq/Lrx8fGSk/t35vbcqvSL6hH3dxw/fnxqKwACAIUrFoJr2rRpasf9madPn551lwAAal2DUORyIV2u6Mec5O6bNaSbm1kfV5HXzT0nVu6d9flze25V+lVVsQDK3XffXe59sQBGo0aN0qy4WExlVrkqueXdVwz7RkZLLLFEUX1tUNOK9bwAFOa5Ie6bfOyxx6ZCIEOGDEnLgvfZZ59a+/eBOfOeAXBuqPq5s7KKPgCkYmJRklGjRpV736yflM/tB62qP4R10bBhw9KxYcOGoUOHDkX1tUFt8rsD1IVzw8EHHxzuvffeNMM/BoGxQMjfrcIAapf3DIBzQ80q+gCwSZMm+XbcADq3BGR28b4oN0Pv78z6uNxz5/a6sz8n157bc6vSr6pq1qxZWGSRRcq9b9YKxfFT9Dn9Rz37fYUsV3Rl+eWX/9PPEPD3ivW8ABTuuSG+j7rgggvCXnvtFcaMGRP+/e9/pwuQLe8ZAOeG2lP0AeCsn+7G/QDnFADm9gps1apVhd9IxktcmjvrPoNzet3c42fv19yeW5V+VVXv3r3TpTxxqcy4cePSm/XFFlvsT/fFJTzxP+7y7itkH3/8cTquueaaRfV11aRYGCdWtm7QoIGqySWuWM8LVI1zA3Xl3LDnnnuGBx54IDzyyCNp65NjjjkmrLXWWr5BGXBeoK6cF6hbnBvIcW6Yu6p+kFr0UzOWXHLJfBgxt0q6ufuWWmqpCr1ufM342lV93dz1+Cn02LFjy33u77//ni6zVhOm5sWCK19//XVqKwACAMXj8ssvTzP74x+ZsSCIJYcAQKko+gAwzrpbbrnlUvudd94p9zG//PJL+Pbbbysd+HTq1Ckd33333Tk+ZujQoX96bM7KK6+cZkrNrV+514370K200koV7hfz5v333/9TARQAoDi0bds2nHbaaan9xhtvhJtuuinrLgEA1IqiDwCjTTbZJB0HDhwYfv7557/c//DDD6dPguOy3I4dO1b4dTfeeOM0E/D7778PgwYN+sv9r7/+erovPibXh5y4FHnttddO7ccee+xPhTaieD3eHnXp0mWOS5epfu+9916+bQYgABSXk046KSy77LKpffLJJ4cffvgh6y4BANS4kggAt9pqq7SnxKRJk8I///nPVAEuV2DjwQcfDE8++WS6HvfAy83KyznooIPCDjvsEK644oq/vG779u1TCBhdffXVYfDgwSlIjJfYvuaaa9J9Mfwrbwlvr1690r/3+eefh8suuywtPY3iMV6Pt8fZf/Fxc6rcG5cP5y65ZSzx65r19r8rNEL5AeASSywRWrdubXgAoIjEJcD/+9//UjtutXLsscdm3SUAgBpX9EVAohiinXHGGeH0008PX331VXqjF2fUxUAwF5ptv/32YYsttqj0ax9xxBHpk+MRI0aECy+8MDRq1CjdPmXKlHRcccUVw+GHH17uc2MoGPty5ZVXhldeeSW8+uqrqV8x2ItiOBjvz+01OLtYzW7YsGF/uT1ubh0vOT179kxV76iY3LJts/8AoDhtttlmYb/99gu33XZbKgzSr1+/0L1796y7BQBQY0oiAMyFbXGW3kMPPRTefPPNtO9fs2bNwjLLLBO22267sO6661Z5j8GLL744PPHEE+Hll19OS36jDh06pJl/8bVnn1U4q65du6aCIHEZcgzz4oy93FLkXXbZJc0ypPbEKrbDhw9Pbfv/AUDxuvTSS9MqkLg9zJFHHpnetzVv3jzrbgEA1IiSCQCjli1bhgMPPDBdKqoim0PHgG+nnXZKl6qIIeSJJ55Y6efFGYdUr08++SS/ZNoMQAAoXnGbj7jFS9xqJRaDi6tF4qoMAIBiVBJ7AEJll/9GAkAAKG577rln2HrrrVM7rhSJq0QAAIqRABDKKQAS92LMVQgEAIpTWVlZuPbaa9P/+7GIWyz+NnXq1Ky7BQBQ7QSAUE4AGPdgrF+/vrEBgCIX91s+77zzUvuDDz5IezsDABQbASDMQgVgACg9xx57bFhrrbVS+5///Gd4//33s+4SAEC1EgDC//nxxx/DqFGjUlsFYAAoHbGg26233hoaNWqUlgDvu+++lgIDAEVFAAizLf+NFAABgNKy6qqrhnPPPTe/IuDCCy/MuksAANVGAAjlVACOewACAKXlxBNPDF26dEnt888/P7z77rtZdwkAoFoIAGG2GYAdOnQIzZs3Ny4AUIJLgW+77bbQuHHjMG3atLQUeMqUKVl3CwBgngkAYbYA0P5/AFC6VlpppVQIJFcVONcGAChkAkAIIfzxxx/hk08+SWNh/z8AKG19+vQJ6667bmpfdNFFYciQIVl3CQBgnggAIYQwfPjwMH369DQWAkAAKG3169dPS4GbNGmS3h/EpcCTJ0/OulsAAFUmAITZKgBbAgwArLDCCuGCCy7If1B4xhlnGBQAoGAJAGGWALBly5ZhqaWWMiYAQDj22GPDRhttlEbiP//5T3jppZeMCgBQkASAEEIYOnRofvlvWVmZMQEA0lLgO+64IzRv3jzMnDkz7LPPPmHMmDFGBgAoOAJASl58Q//++++ncbD8FwCYVbt27cI111yT2t9++2048sgjDRAAUHAEgJS8r7/+Ovz+++9pHBQAAQBmt/fee4fdd989te++++5wzz33GCQAoKAIACl5ueW/kQAQAJhd3B7k+uuvD23atEnXDz/88PDNN98YKACgYAgAKXm5AiBxn5+VV1655McDAPirBRdcMNx+++2pHVcO7LvvvmHGjBmGCgAoCAJASl4uAFxppZVCkyZNSn48AIDybbHFFuG4445L7VgR+LLLLjNUAEBBEABS8nIBoOW/AMDfueiii8Iqq6yS2qeffnr+fQQAQF0mAKSkjR07NnzxxRepLQAEAP5OXC1w1113hUaNGoUpU6aEXr16hUmTJhk4AKBOEwBS0t5///18e7XVVsu0LwBAYYgfGl544YWpPXz48HDSSSdl3SUAgLkSAFLSZl22YwYgAFBRxx9/fNhss81S+5prrgmPP/64wQMA6iwBICVt6NCh6bjYYouFRRZZJOvuAAAFol69euHOO+8MCy20ULq+//77h++++y7rbgEAlEsASElTAAQAqKo2bdqE2267LbVHjx6d9gOcPn26AQUA6hwBICVr2rRp4YMPPkht+/8BAFWx3XbbheOOOy61X3755fzegAAAdYkAkJL16aef5qv22f8PAKiqiy++OKy++uqpfc4554TXXnvNYAIAdYoAkJKlAAgAUB0aN24c7r333tCsWbMwY8aMsNdee4XffvvN4AIAdYYAkFDqAWCTJk3C8ssvn3V3AIACFt9LxGrA0TfffBMOPvjgMHPmzKy7BQCQCAAJpV4BeNVVVw0NGjTIujsAQIHbd9990+y/6KGHHgo33HBD1l0CAEgEgJQsFYABgOpUVlYWrrvuurDMMsuk67E4yLBhwwwyAJA5ASAl6eeffw4//PBDaqsADABUlxYtWoR77rknrS6IxcZ69uwZ/vjjDwMMAGRKAEhJUgAEAKgpXbp0CRdeeGFqDx8+PBxzzDEGGwDIlACQkt7/L+rUqVOmfQEAis8JJ5wQttpqq9S+6aabQt++fbPuEgBQwgSAlPQMwHbt2oUFFlgg6+4AAEWmXr164c477wxLLLFEun7ooYeGDz/8MOtuAQAlSgBISQeA9v8DAGrKwgsvHO67775Qv379MHHixLD77ruHCRMmGHAAoNYJACk5kydPDh999FFqd+7cOevuAABFbIMNNggXXXRRascZgEcccUSYOXNm1t0CAEqMAJCSE998T5s2LbUFgABAbewH2L1799S+4447wq233mrQAYBaJQCkpCsAWwIMANTGfoC33XZbaNu2bbp+5JFHhvfff9/AAwC1RgBIyVYAbtGiRSoCAgBQ0xZccMG0H2DDhg3DpEmT0n6A48aNM/AAQK0QAFKyMwA7deoUysrKsu4OAFAi1llnnXDppZem9ogRI8IhhxxiP0AAoFYIACkpcdPtXABo/z8AoLYdffTRYdddd03te++9N1x77bW+CQBAjRMAUlK+/fbb8Ntvv6W2/f8AgNoWVx/cfPPNoUOHDun6cccdF15//XXfCACgRgkAKdkCIGYAAgBZWGCBBcLDDz8c5ptvvjBt2rSw2267hR9++ME3AwCoMQJASjIAjNX4Vl111ay7AwCUqLgX8Y033pjaMfyLRUGmTJmSdbcAgCIlAKQkA8AVVlghfeoOAJCVXr16hWOPPTa1X3vttXDiiSf6ZgAANaJBzbws1E2nn3562GKLLULDhg2z7goAQLjkkkvCO++8E1555ZVw9dVXhy5duoTevXsbGQCgWgkAKSmx8IfiHwBAXRE/lLz//vvDGmuskZYCH3LIIWmbEu9XAIDqZAkwAABkaLHFFgsPPfRQCgP/+OOPsMsuu4TRo0f7ngAA1UYACAAAGVtvvfXCFVdckdpffvll6NGjR5g6dWrW3QIAioQAEAAA6oDDDz887L///qn9/PPPhz59+mTdJQCgSAgAAQCgDigrKwvXXXddWH/99dP1a665Jlx//fVZdwsAKAICQAAAqCMaN24cHn744bD00kun60cffXR48cUXs+4WAFDgBIAAAFCHLLroouHxxx8PTZs2DdOmTQu77bZb+Pzzz7PuFgBQwASAAABQx3Tu3Dn07ds3tWNF4O7du4exY8dm3S0AoEAJAAEAoA7aeeedw/nnn5/aH330Udhzzz3D9OnTs+4WAFCABIAAAFBHnXbaaSn4i5566imVgQGAKhEAAgBAHa4MfPPNN4cuXbqk61dddVW44oorsu4WAFBgBIAAAFCHzTfffKkoSLt27dL1Pn36hIceeijrbgEABUQACAAABVAZuH///qFVq1Zh5syZoXfv3mHQoEFZdwsAKBACQAAAKAArrrhiePTRR0OjRo3CpEmTUmXgTz/9NOtuAQAFQAAIAAAFYuONNw633357av/6669h2223DT///HPW3QIA6jgBIAAAFJCePXuGf/3rX6n92Wefhe222y6MGzcu624BAHWYABAAAArMSSedFI444ojUfuutt8LOO+8cJk+enHW3AIA6SgAIAAAFpqysLFx11VWhR48e6frzzz8fevXqFaZPn5511wCAOkgACAAABah+/frhzjvvDFtuuWW6/tBDD6VZgbFKMADArASAAABQoGJF4Icffjh06dIlXb/hhhvCGWeckXW3AIA6RgAIAAAFbP755w9PPfVUWGmlldL1Cy+8MFx66aVZdwsAqEMEgAAAUOBat24dnnnmmbD00kvni4RcffXVWXcLAKgjBIAAAFAEllxyyfDcc8+FxRdfPF0/5phj0pJgAAABIAAAFInlllsuVQReZJFF0vVDDz003HbbbVl3CwDImAAQAACKSNwLMM4EjMuCowMOOCDcfffdWXcLAMiQABAAAIpMx44dw7PPPhtatmwZZs6cGfbZZ5/w4IMPZt0tACAjAkAAAChCq6++ehgwYEBo3rx5mD59ethzzz3Do48+mnW3AIAMCAABAKBIdenSJTz99NOhWbNmYdq0aWH33XcPDzzwQNbdAgBqmQAQAACK2Prrrx+eeuqpfAjYs2dPewICQIkRAAIAQJHbeOONwzPPPBNatGgRZsyYEXr37h1uv/32rLsFANQSASAAAJTITMBZC4Psv//+4cYbb8y6WwBALRAAAgBACe0J+Pzzz4cFF1wwhYCHHHJIuPbaa7PuFgBQwwSAAABQQtZYY43w4osvhoUWWihdP/LII8MVV1yRdbcAgBokAAQAgBLTqVOn8NJLL4VFF100XT/++OPDRRddlHW3AIAaIgAEAIAStMoqq4SXX345tGnTJl0/7bTTwqmnnpqWBgMAxUUACAAAJWqFFVYIAwcODO3atUvXL7744nDUUUelSsEAQPEQAAIAQAnr0KFDeOWVV8KKK66YrseiIPvtt1+YNm1a1l0DAKqJABAAAErckksumWYCrr766un6nXfeGXr06BEmT56cddcAgGogAAQAAMLCCy8cXnjhhbDBBhuk0XjkkUdC9+7dw4QJE4wOABQ4ASAAAJC0bNkyDBgwIGy55Zbp+rPPPhu6desWxowZY4QAoIAJAAEAgLxmzZqFfv36hZ133jldf/3118Omm24aRo0aZZQAoEAJAAEAgD9p3LhxuP/++8Pee++drg8dOjRsvPHGYeTIkUYKAAqQABAAAPiLBg0ahNtuuy0ceeSR6fonn3wSNtxww/DZZ58ZLQAoMAJAAACg/D8W6tULV199dTj11FPT9a+//jpstNFGYdiwYUYMAAqIABAAAJijsrKycOGFF4aLL744Xf/xxx9D165dw1v/X3v3AR1Vtcd7/B9CRzBIlw4iofciHQSR3vFSBBWwooByRUUQRRG8UuSioKCgFywIKAgICNK70puU0HvvNZm3/vu9M+9kMjNMQsIkJ9/PWmdNO2fm5MzMnsxv/nvv9es5agAAJBEEgAAAAADuql+/fvLFF1+YQPDcuXNSr149Wbp0KUcOAIAkgAAQAAAAQEBeeukl+e677yQ0NFSuXLkiTz75pMydO5ejBwBAIkcACAAAACBgnTt3lmnTpknq1Knlxo0b0rJlS5kxYwZHEACARIwAEAAAAECsaOg3e/ZsSZcundy+fVvat28v33//PUcRAIBEigAQAAAAQKw1aNBA5s+fLxkzZpTIyEhTGThhwgSOJAAAiRABIAAAAIA4qVmzpixcuFDCwsLE5XJJjx49ZPTo0RxNAAASGQJAAAAAAHFWuXJlWbJkiWTLls1c7tWrlwwbNowjCgBAIpIy2DuApEV/2bXTGeBSpEghISEhMW5D8mI9/7wOQLsA2gZ4Q9vgbKVLlzYhYP369eX48ePy1ltvydWrV2XQoEHm/0Q7/meAhXYBtA3whrYhYRAAIlbu3LkT7bJ29/B1G5InHQMIyRvtAryhbQBtg/MVKVJEFi1aJE8++aQcOnRIBg8eLFeuXJGhQ4fGCAEV7QJoF+ANbQNoGxIGASBi94JJGf0lc+bMGfMrrv5TlzVrVo5mMqavA/2w1l9rvP2Tj+SDdgF2tA2gbUhewsPDZdmyZaYScO/evTJy5Ei5fv26jBkzxvQaUbQLsPA/A+xoG0DbkLAIABErnsGOBj5RUVHubsCAvg54LSRvtAvwhrYBtA3JR/78+d0h4I4dO2TcuHFy48YNM0Ow/lBooV0A7QK8oW0AbUPCYBIQAAAAAPEqV65cZkzAsmXLmsuTJk2STp06ye3btznSAAAEAQEgAAAAgHinswL/+eefUqVKFXP5p59+knbt2snNmzc52gAA3GcEgAAAAAASRObMmeWPP/6Q2rVrm8szZ86UVq1amXEBAQDA/UMACAAAACDBZMyYUebOnSsNGjQwl+fNmyctWrQwMwQDAID7gwAQAAAAQIJKnz69zJo1S5o1a2Yu6/iAjRo1kosXL3LkAQC4DwgAAQAAACS4tGnTyrRp06RNmzbm8sqVK81MwefOnePoAwCQwAgAAQAAANwXqVOnlh9++EE6dOhgLv/1119Sr149OX36NM8AAAAJiAAQAAAAwH2TMmVK+eabb6Rbt27m8ubNm80kIcePH+dZAAAggRAAAgAAALivQkND5csvv5SePXuayzt37pRatWrJoUOHeCYAAEgABIAAAAAA7rsUKVLI6NGj5d///re5vHfvXhMCRkRE8GwAABDPCAABAAAABEVISIgMGzZMBg4caC4fPHjQhID//PMPzwgAAPGIABAAAABAUEPA999/X4YMGWIuHz161IwJuG3bNp4VAADiCQEgAAAAgKB7++23ZeTIkeb8yZMnpU6dOrJhw4Zg7xYAAI5AAAgAAAAgUejdu7eMHTvWnD979qzUq1dP1q5dG+zdAgAgySMABAAAAJBovPjiizJp0iQzScjFixelfv36smzZsmDvFgAASRoBIAAAAIBEpWvXrvL9999LaGioXLlyRZ588klZuHBhsHcLAIAkiwAQAAAAQKLz1FNPyc8//yypUqWS69evS9OmTWXOnDnB3i0AAJIkAkAAAAAAiVKrVq1k5syZkjZtWrl586a5/MsvvwR7twAASHIIAAEAAAAkWo0aNTKVf+nTp5fbt29Lu3btZPLkycHeLQAAkhQCQAAAAACJms4GPH/+fMmYMaNERkbK008/LSNGjAj2bgEAkGQQAAIAAABI9GrUqCGLFi2SrFmzmstvvPGG9O3bV6KiooK9awAAJHoEgAAAAACShEqVKsnKlSulQIEC5vLw4cOlS5cucuvWrWDvGgAAiRoBIAAAAIAk49FHH5VVq1ZJmTJlzOUpU6aYGYIvX74c7F0DACDRIgAEAAAAkKTkypVLli5dasYGVH/88YfUqVNHTp48GexdAwAgUSIABAAAAJDkPPjggzJ37lxp3769ubxhwwapUqWKbN26Ndi7BgBAokMACAAAACBJSpMmjfzwww/Sq1cvc/ngwYNSrVo1mT17drB3DQCARIUAEAAAAECSlSJFChk1apSMGTNGQkND5cqVK9K8eXMzQYjL5Qr27gEAkCgQAAIAAABI8l555RXTJVi7Bmvw17dvX+nevTszBAMAQAAIAAAAwCmeeOIJWbNmjRQuXNhc/uabb6Ru3bpy9OjRYO8aAABBRQUgAAAAAMcIDw+XtWvXmlmB1apVq6R8+fKyePHiYO8aAABBQwAIAAAAwFGyZMkiCxYskD59+pjLp06dkvr168snn3zCuIAAgGSJABAAAACA46RKlUpGjBghU6dOlQceeECioqKkX79+ZoIQDQQBAEhOCAABAAAAOFa7du1k3bp1UqxYMXN59uzZUrp0aZk3b16wdw0AgPuGABAAAACAo2n4pyFgt27dzOWTJ09Ko0aNpFevXnLjxo1g7x4AAAmOABAAAACA42k34AkTJsi0adMkc+bM5rrRo0dLuXLlZMWKFcHePQAAEhQBIAAAAIBko02bNrJlyxapW7euubxr1y6pWbOmvPLKK3Lp0qVg7x4AAAmCABAAAABAspInTx5ZuHChjBkzxlQGqi+++EJKlCghM2fOZKZgAIDjEAACAAAASHZSpEhhqv62b98ujRs3NtcdOXJEWrZsKQ0aNJBt27YFexcBAIg3BIAAAAAAkq18+fKZmYGnTJkiOXLkMNctWrRIypQpIy+//LKcPn062LsIAMA9IwAEAAAAkKyFhIRIx44dZffu3fLmm29K6tSpJSoqSsaOHSuFChWS/v37y7lz54K9mwAAxBkBIAAAAACISKZMmWTYsGGyY8cO0xVYXblyRYYMGSIFChSQAQMGEAQCAJIkAkAAAAAAsClcuLD88ssvsnLlSqlfv7657vLly/Lhhx+aCUReeukl2blzJ8cMAJBkEAACAAAAgBfVqlWTP/74Q5YtWyZ169Y1112/fl3GjRsnxYsXl0aNGsmsWbPk9u3bHD8AQKJGAAgAAAAAftSsWVP+/PNPUxHYvn17CQ0NNdfPmzdPWrRoIblz55Y+ffrI5s2bOY4AgESJABAAAAAAAqwI/OmnnyQiIsJMFpI5c2Zzvc4UPGrUKClbtqwUK1ZM3n77bVm7dq2ZSAQAgMSAABAAAAAAYiFfvnxmspDjx4/Lzz//LE2bNnVXBe7atUuGDh0qVatWNeMFPvfcczJ58mQ5evQoxxgAEDQpg/fQAAAAAJB0pUmTRtq2bWuWEydOyNSpU+XXX381YwZGRkaagHDixIlmUUWLFjVVhJUqVZKKFStK6dKlzX0AAJDQCAABAAAA4B7lzJlTXnvtNbOcPXtW5syZI7/99pssXrzYXFb//POPWaxAMFWqVCYELFWqlOk6HB4ebk4LFiwoKVPyVQ0AEH/4VAEAAACAeJQlSxbp0qWLWXQcwK1bt5pJRJYuXSrr1q0zlYFKZw/++++/zWKXOnVqyZ8/v1kKFCjgPm9dfvjhhwkIAQCxQgAIAAAAAAkkRYoUUqZMGbPoTMHq2LFjsn79evnrr79M+Ldjxw45ePCge5tbt27Jnj17zOLrPjUE1LEI8+bNaxbP81mzZpWQkBCeVwCAQQAIAAAAAPeRhnctWrQwi+XatWume7BOIqLLgQMHzKLB4JEjR8yYghatKtTrdPElbdq0ZhISXyGhdjNOnz59gv+tAIDEgQAQAAAAAIJMw7hy5cqZxdOdO3fMLMIaBmooePjwYbMcOnTIff7ixYvRtrlx44bs3bvXLL5ol2KdmETHHrSfakBJ9SAAOAsBIAAAAAAkYjohiDUGYK1atbyuc+nSpRihoP28Ljdv3oy2jQaKuixYsCDa9WFhYWZykrJly7q7L5coUcJUFQIAkiYCQAAAAABI4jJlymRCOl28cblccvr0aRMEauin4wtasxJrl+Nz5865171w4YIsW7bMLJbQ0FBTIVi+fHmpUqWKVK5c2QSDOmEJACDxIwAEAAAAAIfTLr3Zs2c3S4UKFWLcfubMGff4gzpr8aZNm2Tz5s3ursU6BuH27dvN8r///c9clyZNGtNlWcNAKxQsXLgw3YcBIBEiAAQAAACAZE5nDa5Ro4ZZ7FWD2o3YCgP1VGcvtiYf0S7Fa9asMYvloYcekqpVq0rNmjXNfVWsWJGuwwCQCBAAAgAAAAC8Vg1aYw/aZyw+duyYrFu3TtauXWtONRS8fPmyuU27Es+dO9csSrsIa2WgFS5Wq1ZNMmfOzNEGgPuMABAAAAAAEDCdJbhly5ZmsboHa9dhDQO1GnDVqlWybds2c9utW7dkxYoVZrFCxZIlS5owUE81HMyTJw9HHwASGAEgAAAAACDOdIIQawKSZ5991l0JqEGgFf5plaCGgdqtWMcY1MVSqFAhadCggdSrV0/q1KljxikEAMQvAkAAAAAAQLzSsQCbNm1qFnXjxg0TAlqB4MqVK90TjERERMiXX35pFqWVgRoG6lK7dm0JCwvj2QGAe0QACAAAAABIUGnTpjUTg+hidRtesmSJCQK1UlC7DluBoHYf1mX06NGSIkUKM9Nw/fr1pVGjRmYMwVSpUvFsAUAsEQACAAAAAILSbbhYsWLy/PPPS7Zs2WTjxo3y559/mmX58uVy7do1iYqKkr///tssw4YNk0yZMpnuwhoG6qLjEQIA7o4AEAAAAAAQ9ECwYsWKZnnzzTfNeIHaZVjDwEWLFplKwTt37silS5dk+vTpZlFlypSRxo0bS5MmTeSxxx4zFYMAgJhoHQEAAAAAiUrq1KmlevXqMmDAANNV+OzZszJjxgzp0aOH5M6d273e5s2b5eOPPzazCuv1L730kixcuFBu374d1P0HgMSGABAAAAAAkKhp199WrVrJV199JYcPH5YtW7bI0KFDzSQhWj2oTpw4IePGjTNdhHPkyCHPPPOMzJ49mzAQAAgAAQAAAABJSUhIiJQqVUr69etnqgPPnDkjkydPNgFhunTpzDrnz5+Xb7/9Vpo1a2bGCezZs6esXr1aXC5XsHcfAIKCCkAAAAAAQJIVFhYmnTp1Ml2ET58+bcYH7Nixo6kaVBoQfv7552YG4SJFish7770ne/bsCfZuA8B9RQAIAAAAAHCEDBkySOvWrWXKlCly8uRJEwZqZaCOKaj27dsnH3zwgTz66KNSr149+fHHH+XmzZvB3m0ASHAEgAAAAAAAx0mbNq0JA7UyUMcH1PEDa9Wq5b598eLF0qFDBzN5SN++feWff/4J6v4CQEIiAAQAAAAAOFrmzJnNDMJLly6V/fv3m9mFdWxApTMMDx8+XMLDw6Vu3bry66+/SmRkZLB3GQDiFQEgAAAAACDZKFCggOkGfPDgQZk5c6Y0btzYTCyidFIR7TKsXYQ/++wzuXTpUrB3FwDiBQEgAAAAACDZSZkypTRv3lzmzJkjBw4cMFWB2bJlM7dFRERI7969JU+ePNKnTx9zGQCSMgJAAAAAAECyli9fPlMVeOjQIZk4caKULl3aXH/58mUZNWqUmT1YxwvctGlTsHcVAOKEABAAAAAAgP83ccgzzzxjgj6dJEQrBLV7cFRUlJkxuFy5ctKoUSMzlqDL5eKYAUgyCAABAAAAALDR0K9OnTpmjECdHfj555+X1KlTm9vmzZtnbqtevbrMmjXLhIMAkNgRAAIAAAAA4IN2//3yyy/NOIFvvvmmZMyY0Vy/evVqadGihekuPGXKFLlz5w7HEECiRQAIAAAAAMBd5MqVS4YNG2bGCfzoo4/cE4Zs375dOnfuLOHh4TJ+/Hi5efMmxxJAokMACAAAAABAgMLCwuSdd96RgwcPypgxY8wEImrfvn2mq/Ajjzwio0ePlmvXrnFMASQaBIAAAAAAAMRSunTp5JVXXpE9e/bIN998Y7oKqyNHjkivXr2kQIECMnToULl06RLHFkDQEQACAAAAABBHOjnIs88+Kzt37jQzBeuYgOr06dPy9ttvS/78+WXgwIFy9uxZjjGAoCEABAAAAADgHoWGhspTTz0lmzZtMrMDV65c2Vx/4cIFGTx4sAkC//3vf8vx48c51gDuOwJAAAAAAADiSUhIiDRr1kzWrFkjf/zxh9SpU8dcf/XqVfn000+lYMGCpuuwjiEIAPcLASAAAAAAAAkQBNavX18WL14sK1eulMaNG5vrdZbgL774wkwWol2H//nnH449gARHAAgAAAAAQAKqVq2azJkzRzZs2CBt27Y14eCdO3dk0qRJUqxYMdN1ePPmzTwHABIMASAAAAAAAPdBuXLl5Oeff5bt27dLly5dzLiBLpdLpk6dKmXLlnV3HQaA+EYACAAAAADAfaRVf99++63s2bNHXnzxRTOTsJo9e7Y89thjUrVqVZk8ebLpLgwA8YEAEAAAAACAINAJQcaOHSsRERHSp08fSZ8+vbl+7dq18vTTT0u+fPlkwIABcuTIEZ4fAPeEABAAAAAAgCDKnTu3jBgxwswMPHToUBP8qVOnTsmHH34o+fPnlyZNmsi0adOoCgQQJwSAAAAAAAAkAlmzZpV+/frJvn37ZMaMGVKvXj1zfVRUlMydO1fatWsnuXLlkp49e8r69evN+IEAEAgCQAAAAAAAEpGUKVNKq1atZNGiRWbCkDfeeEOyZ89ubjt//rx8/vnnUrlyZSlUqJD07dtXVq9ebUJCAPCFABAAAAAAgESqePHi8umnn5pxAGfNmiWtW7eWVKlSmdsOHDggw4cPl2rVqknevHnlueeek59++knOnj0b7N0GkMgQAAIAAAAAkMhp6NesWTOZPn26HDt2TL766itp2LChqRZUet3EiRPlX//6l2TLls1UCL7++utm3EC9DUDy9n9bCgAAAAAAkGTGCuzRo4dZtEuwVgbOmTNHFi5caC7r2IA6RqAuI0eONNtohWDp0qWlVKlSZilRooTpQpwxY8Zg/zkA7gMCQAAAAAAAkqjMmTNL165dzRIZGWlCv/nz58vSpUtl7dq1cu3aNbPe4cOHzaJBoWeYWLBgQTPTsFYO2peHHnpI0qdPL+nSpTOLnk+TJo2EhIS4t7fOa+h469atgJabN2/K7du35c6dO2afddHzep2OZaiLdb2e1ypHrYDUU/v51KlTS4YMGeSBBx5wn9oXvc6+r0ByRgAIAAAAAIADhIaGStWqVc2iNFTbsmWLrFy5Uv7++2/ZunWrmVREAzjLmTNnzKLBodNoQJglSxYTctpPrfMPP/ywWXLnzm1mV9aQE3AqAkAAAAAAABxIq+TKly9vFouGgnv37pVdu3aZSUT2799vFq0O1CDw9OnT0QLCYAeaKVKkcFcCxpZWGx4/ftwsgVZTahhohYJ6qpWRBQoUMKf58uWTtGnTxuEvAYKPABAAAAAAgGQUCoaHh5vFG+3Ke+XKFRMGnjt3Tq5fv+5etDuxPRzUde20e7BW3QWyWN14NeSzgj69P70PvV4v22kAqOGl1VVYTzXgu3r1qtlf+6LXXbp0ycyGrIv+LfZTXXQdTzp+oi7btm3zefy0UtAKBPXUfl5PqSJEYkUACAAAAAAADB0zTycG0UXHBrxfNPzTUE/DP2/j9mkgaIWH8UHDTK0M1BmSjx49ak49zx85ckRu3LgRbTuronD16tVe7zd79uxeg0HrVMcmBIIhWQWAFy9eNFOgr1u3ziT++stC4cKFpXHjxu4xEuJCG6nZs2ebQVat6dW1XLh27drSpEkT97TsvkRERMgvv/xixmPQXykefPBBKVmypLRu3fquDe69PjYAAAAAAMmNTmiieYAu/kJJ7RKtXaWt5eDBg9EuW5OsWE6dOmUWzR280fEHvYWD1nnNA4CEkGzSoUOHDkn//v1NCKi0LFdLfjdt2mSWZs2amSnUY0vLoAcMGCC7d+82l61fI3RMBV10sNUPPvjA5zgBGtx99tlnJshTOkuRhpN6vW7bp08fqVmzZoI8NgAAAAAA8E4rEbWiT5fKlSt7DQj1+7s9ELSHhHp6+fLlaNtYXZB1UhZvwsLCTBBojUHobdH90W7TQGwkiwBQxwf48MMPTfinb6TXX3/dVNbp2AUzZ86UKVOmyG+//Wauq1+/fqzu+4svvjABnAZ3r732mruScM2aNTJ69GgzsOrYsWNNkOctlLTCvxo1akj37t3NNOs6zsL48eNNgDdq1CizX3ny5InXxwYAAAAAAPcWEOpswrpUrFjRa0CoYwraA0HPU73d7sKFC2bZvHmzz8fV7tA5c+Y04xFagaC1H9aSLVs29/lMmTJ57VaN5CVZBIDz58+XEydOmC6/AwcONG8EpZfbt29vAre5c+fK5MmTpU6dOgF3m9WZkpYtW2bOv/rqq/LYY4+5b9PzOkjpsGHDZMmSJaY7r4aPdho8avinAd8bb7zhTvA1BOzbt6/p0quPoev169cvXh8bAAAAAAAkHA3d9Pu9LuXKlfO6jg4D5i0YtMYh1EUnO7HT7/vWbb4qCe0047DCQK0w1G7GgS46ZqEWHWmPQ0LEpC1ZBIAagqlatWq5wz+7Nm3ayO+//26CQB2Hz9cb05N209VEX1N3ewBnqVatmrlNBwjVdbt06eK+Tbsfr1+/3pxv2bJljPJdvazXjxw50owdoOMK6BgF8fHYAAAAAAAg+LQ6r1SpUmbxRr/3a1ahYZ81aYnnorMb61iFGiZ6o4VHWhSlS1xpRqGZhIaB1uLvsg67psORxWXRXpyes0Dj3jk+ANRx8vbs2WPOly9f3us6GgpqF9vDhw+bMttAA8AtW7aYU13fWxKu1+lt+ia11rXs2LHDPe6fr/2yrtcX/86dO6VChQrx8tgAAAAAACDx0+/2OnGILr5CQotWCur4ghoI2hcNB63z2r1Yh0ezL57jFHoTGRlp1gtk3figAaD22gw0SLTW01NvS1hYmDRv3lySM8cHgDpttybmyl83WL1NA0BdAqH3qfd9t/vNly+fOfW8X+uyVX7rjVVyq29IHS/QCgDv9bEBAAAAAICzaDdd7QmoS2xY4Z5nMKiL9l60Fu2Z6O28t8s3btwwxUxxpd2ctaBLl/jw8MMPEwCKw2mprEX73fti3eY5AKcv+iLUF3Sg92u9cDV5tj+Ov22t2/VNZ9+ve31sAAAAAAAAq3uvFifpEp80WNTJVzW/iM1y6tQpc6oVjTp+4d3WtzISK/vwFhymIw9xfgWgFZQpLR/1xbot0HTZvl4g92ttY73orO39betrv+71sb3RCVC+//57r7eVLVvW/JKgCbznmAF6nXV6L+MJAHAO2gUAtA0A+J8BgGeXXh0j0D63wd2+T1jbxYX2nLSHj5GRkY7JLOzHJzYcHwAiMFqiqym7N/pGCeSFFtcXIQDnol0AQNsAgP8ZAATj+4QWMumiE62o5P7dxPEBoA4CadH011farLfFpizUvp61rb/79dzGOu9vW1/7da+P7Y3O0pM9e3avt9lnKPZM3+MjmQfgLLQLAGgbAPA/AwC+TyQujg8A7WPk6XiAvgJAa6zAzJkzB3S/1kwy2rXWPs6gr/u11vfcL3/b+tqve31sbzp37mwWb4YPH24GBNWAL2fOnNFu0xJa/bLv7TYkL1pirTNb6xgN3mamRvJBuwA72gbQNsAT7QJoF+ANbQNoGwIT1+Irx5ds5cmTxx1G6Ey6vli35c2bN6D71fvU+47r/VqXdQruS5cued3WmnXHPqNvfDw2AAAAAAAAkg/HB4Ba+VakSBFzfsOGDV7XOXPmjBw+fNicL1OmTMD3Xbp0aXO6ceNGn+ts2rQp2rqW4sWLm0opf/tl3W+qVKmkWLFi8fbYAAAAAAAASD4cHwCqOnXqmNNly5bJ6dOnY9w+Y8YMU26s3XJLlSoV8P3WqlXLVOMdO3ZMVq9eHeP2VatWmdt0HWsfLNoVuVKlSub8zJkzo020ofSyXq8qV64co+vyvTw2AAAAAAAAko9kEQA2bNjQjE+nUz8PHjxY9u/f754kY9q0aTJnzhxzWcfAs6ryLN27d5fmzZvLqFGjYtxvwYIFTRCn/vvf/8qaNWtMkKiLnh8zZoy5TQM4exdeS6dOnczj7du3T0aMGCHnz5831+upXtbrtfpP14vvxwYAAAAAAEDy4PhJQJSGaO+++670799fDhw4IL169TIVdRoIWrNVNm3aVOrXrx/r+3755Zfl+PHjsnv3bhkyZIiZYlrdunXLnIaHh8tLL73kdVsN5nRfPvvsM1m+fLmsWLHC7NfVq1fN7RoO6u3WeH/x+dgAAAAAAABIHpJFAGiFbVopN336dFm3bp0Z9y9DhgxSqFAhadKkiVStWjXOYwwOHTpUZs+eLUuXLjXdblXhwoVN9Z3et2dVoV3t2rXNJB3aDXnbtm1mQhCrK3Lr1q1NpV9CPTYAAAAAAACcL1mlQ2FhYdKtWzezBGrChAl3XUdDtpYtW5olLjSE7Nu3b5y2vdfHBgAAAAAAgLMlizEAAQAAAAAAgOSKABAAAAAAAABwMAJAAAAAAAAAwMEIAAEAAAAAAAAHIwAEAAAAAAAAHIwAEAAAAAAAAHAwAkAAAAAAAADAwQgAAQAAAAAAAAcjAAQAAAAAAAAcjAAQAAAAAAAAcDACQAAAAAAAAMDBCAABAAAAAAAAByMABAAAAAAAAByMABAAAAAAAABwMAJAAAAAAAAAwMEIAAEAAAAAAAAHIwAEAAAAAAAAHIwAEAAAAAAAAHAwAkAAAAAAAADAwQgAAQAAAAAAAAcjAAQAAAAAAAAcjAAQAAAAAAAAcDACQAAAAAAAAMDBCAABAAAAAAAAByMABAAAAAAAAByMABAAAAAAAABwMAJAAAAAAAAAwMEIAAEAAAAAAAAHSxnsHUDSceXKFRk+fHi066KiotznU6QgTwZAuwDAO/5nAEC7ACAQ/M9w92wmLggAETCXyyWXL1/miAEAAAAAACQhBIC4qwceeMDnbWfPnpXIyEgJDQ2VLFmycDQB0C4A4H8GAAHhuwQA2oaEyWq8CXFpWRcQR40bN5ZTp05J9uzZZe7cuRxHALQLAPifAQDfJQDEGTlDwmDQNgAAAAAAAMDBCAABAAAAAAAAByMABAAAAAAAAByMABAAAAAAAABwMAJAAAAAAAAAwMFSBnsHkLR17NhRrl69KhkyZAj2rgBIJGgXANA2AOB/BgB8n0hcQlwulyvYOwEAAAAAAAAgYdAFGAAAAAAAAHAwAkAAAAAAAADAwQgAAQAAAAAAAAcjAAQAAAAAAAAcjFmAEScXL16UadOmybp16+Ts2bOSJk0aKVy4sDRu3FiqVq3KUQWSmNOnT8vq1atly5YtcuDAATl37pykTJlSsmXLJmXLlpVmzZpJzpw5/d6Hbv/777/Lvn375ObNm5I1a1apVKmStGvXTjJlyuR3W9oUIOn48MMPzee/qlevnvTu3dvnurQLgLNduHBBZs+eLevXr5dTp07J7du3JXPmzFKwYEGpUqWKPP744163o20AnEfnl126dKksXrxYIiIi5MqVK5I6dWrJkSOHlCtXTpo3by5ZsmTxue3ChQvNcujQIblz547Zrlq1atK6dWtJmzat38c+ceKETJ8+XTZu3Cjnz5+XDBkySHh4uHnMkiVLJtBfnPQwCzBiTd+Q/fv3N1/YVbp06cyX/aioKHNZg4IePXpwZIEkFP51797dfPBa0qdPL7du3TIfvko/vPVLfo0aNbzex7hx42Tu3LnmfIoUKcyPAtevXzeXw8LC5KOPPpK8efN63ZY2BUg6Vq5cKcOGDXNf9hcA0i4AzrZ27VoZNWqUXL161f2/QmhoqPvzX384/Oqrr2JsR9sAOI9+bxgyZIhs2LAh2veJGzduuHMCzQ00RyhdunS0bSMjI+Xjjz92/7ioRQi66LYqd+7c5r71xwVvtIBBv2tYbY8+rp7X7zYhISHyzDPPSKtWrRLsb09KqABErOivevrLv4Z/+fPnl9dff938wqcB4MyZM2XKlCny22+/mevq16/P0QWSAOtDuXz58ubLvFb8acWefhjv3LnT/POuVYEjRoyQPHnySIECBaJtP3/+fBP+6Qdsp06dpEWLFiYA3L9/v9nm4MGDpt0YM2aMpEqVKtq2tClA0qFf8sePH29+Vdd/wo8cOeJzXdoFwNk2bdpkfgzQHwrr1q0rbdq0kXz58pnbtOrnn3/+kV27dsXYjrYBcKapU6e6w78OHTpI06ZNJWPGjOb7hAZ0GvwfP35c/vOf/8iECRPMdwXL999/b8I//Z7w/PPPm8phDQC3bdtmvkscPXpUPvnkExMSeqtC1us18CtVqpT07NlTcuXKZdohvV+tUJ40aZIUKlRIypQpI8kdYwAiVvRDW8tr9Q07cOBAE/Qpvdy+fXtp1KiRuTx58mR35RCAxO2BBx6QkSNHyqBBg6RWrVru7rr6K76WzL///vvy4IMPmve0Bv2eAZ5+uCodAkDbAesDXduHAQMGmMv6gf/HH3/EeGzaFCDp0H+gdXiAzp07m8peX2gXAGfTL9qjR482/xdo17w+ffq4wz/r/4oKFSqYHwXtaBsA51qyZIk51WICDQA1/LO+T2j33zfffNNc1kKi7du3RwvwrO8X+v9Fw4YNTfin9HvI22+/bYoMdJu//vorxuNqt1/9gfKhhx4y1YUa/lntkIaJFStWNJWA33333X04CokfASDi9MbWkEDHBvOkv/7pG1S/IGzdupWjCyQBWs2jv4r5opU++o+80vH97PQXPR1nQ9/3+iXAU/bs2U17YW8/7GhTgKRhx44dsmDBAilSpIj7xz5faBcAZ1u0aJGcOXPGjOXlGfL5Q9sAOJd+H1CPPPKI19u1MEDDQGV17VWrVq0y3Ye1264WE3jS/zusLsOe3yU02Fu2bJk5r/+b6H14atu2rTnds2ePqSRM7ggAEatf+/SNY3UV9EZDQe0iqDZv3szRBRzCqgrUMn7Pf+aVju/n7UcBpb/6Ke0OZP/Ap00Bkgat2tEu/Br0v/zyy2acT39oFwBns76E6+D8nkN7+EPbADiXTtih9u7d6/V2HRpIv0fo/xBWL0J7u1C8ePFo3YK9fZfwzBcOHz7sDh595RNFixZ1B4ObyScIABE4HevHmiRAx//zxbpN35AAnEHH4PD23rfe54G0Cdp+2McMo00Bkoaff/7ZvF+bNGkihQsXvuv6tAuAc2mljs7uqbQ90LZh+PDh0qVLF9MToFu3bmZiEJ3gyxNtA+Bc2nVX/fnnn/Ljjz/K5cuXzWUN/XTMUB3DT2mVn9VNN7btgnYfvnTpkvt6eztjH4bATqsOrQKlw+QTTAKCwGm3Xov2sffFus1K4wEkbWvWrHH/mqeD8nprFwJpEzzbBdoUIPHTf5anTZtm3seBdvWjXQCc69SpU+5xvo8dOyZjx441kwHqDMC6nD592gQAy5cvN2MD1qhRw70tbQPgXDrph77/dUJQHR9cF/sswDqT7wsvvGB+TLSzvhvE5ruE1TPJ2lbH+/NVPWjf/jz5BAEgAmfvuufvDWbdZk3DDSDp0g/yzz//3JyvUqWKeyxAz3YhkDZBXbt2Lca2gW5PmwLcX1q1q+9//bLfvXt3r2PreEO7ADiXzqxp0R8HdJKwfv36me532rVPqwN1yAD94VArAXWM4YcfftisT9sAOJdW2j377LPm/f7111+b4UPs//frDwVWGGgfSiS27YL9+4B13t+29tuvk0/QBRgA4Puf/MGDB5ty+5w5c8prr73GoQKSEZ2lWyf/0ODfXsUDIPmyhgNS+kW+d+/eZpZN6wu9Bn7vvvuupE2b1nQXnjVrVhD3FsD9orP56oy948aNk+rVq5sfAKZOnSpfffWVqfzT8O3bb781QwYgeJgEBAHTD3J7gu+LdVu6dOk4ukASpR/S77//vhw4cMCUzX/wwQeSMWNGn+1CIG2CslcQ0aYAiZd21dN/1LVLn/7jHhu0C4Bz2f+/1wnArMH57fT/hlq1asUYdJ+2AXCukSNHyq5du8xwQa+//rr5MUDf81pEoN1+NRzUycR0eIC///47zu2CvQ2yzvvb1n57OvIJAkAEzt733j52lyfrtsyZM3N4gSRIPyQ18NNZe7Vrj1YB6oe3v3YhkDbBs12gTQESr++++06uXr0qLVq0MO2A/ihgX7Tyxxrc2/M62gXAueyf3dbA+t5Yt+lQIp7b8j8D4Lzxgjdu3GjOt2zZ0us6pUuXNqGgWrt2bby2C9pryV8ISD7x/1EBiIDpB7mm9srbzF4W6zb9VRBA0qIfnhr4bd++3Qyoq0Ggv/eydVsgbYK2H/YvC7QpQOIe6N+aAfipp56KsWjXYLV06VL3dVoxrGgXAOfSwfdj8yO/9d1B0TYAzmSfXddX0YDKkSOHOT158mSc2gX9QdKaAMS+rec+2OmPkzpbuef6yRUBIAKmJbNFihQx5zds2OB1nTNnzrjffGXKlOHoAkmIDtY7ZMgQ2bJli+mqO2jQIClYsKDfbfTXPOuDWd//3li/CBYtWjRat1/aFMCZaBcAZytbtqw5tb5Ue2Pdlj17dvd1tA2AM9mDfnvVryfru4J9SCCrXdDiA19VfFb24JkvaKBnVQH6yie0W7I1GUkZ8gkCQMROnTp1zOmyZcu8vrlnzJhhBgfWN2KpUqU4vEASobN8Dh061IR1GtINHDhQHn300btupx/aWgmg7/tffvklxu3aTmh7YW8/7GhTgMRJfwzQwft9LSVLljTr1atXz32d1bWHdgFwNn3fK/3R39uXbu1uZ3326wQhFtoGwJnsBQO///6713X27NljZgdX9u8Yjz32mBlvWEO6efPmxdhOt9HiBG/fJTR4rFmzpjmv29pnHbbnE0oLmXLnzi3JHRWAiJWGDRuasl6drlu7Ce7fv99cr2n9tGnTZM6cOeZy586dJWXKlBxdIAnQMbw+/fRTWb9+vfkA1tn7ihcvHtC2qVKlko4dO5rzs2fPNu2A9eudtg/aTmh7kStXLmnQoEGM7WlTAOehXQCcTatodHZw9dlnn5kB/a0xQPWz/6OPPjKf/Tp5mI4jaqFtAJxJ84Hy5cub85oHTJw4Uc6fP28u6/eCVatWmR8WtZ3IkCGDmSjEEhYW5m4ndPzhBQsWmO8matu2bWY7LTQoUaJEtB8ULG3atDH3qdWF2vacOHHCXK/jGI8fP17WrVtngsIuXbrcl2OR2IW47HO5AwHQrn79+/eXixcvukt49UPe+uBv2rSpPP/88xxLIInQD9d33nnH/c+5foj6ox/OnsaNGydz584150NDQyVNmjTuX+H0g10/kH2Nu0GbAiQ92mZo26GVQL179/a6Du0C4Fw66L7+YBgREWEu6w+I+uO/9dmv4whrO2FVC9vRNgDOo4HfgAEDoo3lp8P9aE5gRU6aG7z11lvuYQQsGvh9/PHHJqxT2pbootsqrdzTINDX+KNaIajfNXRCMqXfZazJyTT8e+aZZ6RVq1YJ9rcnJQSAiJMLFy7I9OnTzZtU03btMqhdf3SK76pVq3JUgSRk69atJtQPlHb182b16tUmBNQvA/qBnTVrVqlcubK0bdvWDNrrD20K4LwAUNEuAM4eO1irfbS779GjR82X+GzZspnqQP2ynSVLFp/b0jYAznPr1i1Twafvb50YTH8Q0B8HdPKPcuXKmUIhbSO80ZBw4cKFZtEQUYcn0u2qVasmrVu3jjaOuDda+ac9kXQ4Iw0jNQQMDw831YXefohIrggAAQAAAAAAAAdjDEAAAAAAAADAwQgAAQAAAAAAAAcjAAQAAAAAAAAcjAAQAAAAAAAAcDACQAAAAAAAAMDBCAABAAAAAAAAByMABAAAAAAAAByMABAAAAAAAABwMAJAAAAAAAAAwMEIAAEAAAAAAAAHIwAEAAAAAAAAHIwAEAAAAAAAAHAwAkAAAAAAAADAwQgAAQAAAAAAAAcjAAQAAAAAAAAcjAAQAAAAAAAAcDACQAAAAAAAAMDBCAABAAAABNWSJUskJCTELIMGDeLZAAAgnqWM7zsEAABIai5cuCCjRo0y58uWLSstW7aUpET3Xf+GsLAw6d27d7B3BwAAAIkMASAAAEj2NDx7//33zXHo2rVrkgwADx48KPnz5ycABAAAQAx0AQYAAAAAAAAcjAAQAAAAAAAAcDACQAAAAAAAAMDBCAABAECydeDAATPraMGCBd3Xffvtt+7ZSO2LzlLq6caNG/Lll19K06ZNJW/evJI2bVp58MEHpWTJkvLaa6/J7t27vT7u+fPnzXh9er8pUqSQBQsW+N3P559/3r0fzz33nPv6AgUKmOt0/D+lp972PT5nVX3mmWfc96vHTy1evFjat28v+fLlkzRp0kj27NmlcePGMnPmTL/3NWnSJPd96flAnitddB+8sY6Hnqpbt27JmDFjpFq1apItWzZ54IEHpEyZMvLJJ5/I1atXo2178uRJc5z0dn0OM2bMKFWrVpUJEyaIy+WS+LZ27Vr339O/f3+f6+XJk8e93gsvvOBzvRIlSph1cuTI4XN/r1+/bo5HgwYNJFeuXJI6dWrJkiWLVKpUSd599105duxYrJ+vDRs2yIsvviiPPvqoOWa+nsv58+dLq1atzOPq+0RfK61bt77ra9/T8uXLzXugWLFi5vFSpUplXm/FixeXJ598UgYPHuzzfQcAQLLmAgAASKb279+vSUlAy+LFi6Ntu2TJElfu3Ln9bhMaGuoaMmSI18devny5uV3Xy5Ejh+vEiRNe15s6dar7/ooWLeq6cuWK+7b8+fMHtO/vvfdevB2zrl27uu83IiLC9eqrr/p97FdeecXnfU2cONG9np4P9LnSffDGOh56evz4cVeFChV87lelSpVc58+fN9utXr3aPAe+1u3QoYMrKirKFZ9u377typgxo7n/qlWrel1n165d0fbjkUce8bqevnasddq3b+91nXXr1rny5s3r97lKnz696+uvvw74+Ro2bJj7NWxf7M9lZGSkq3v37n4ft1evXub95e/1qvfzwgsvBPR6b9KkSQDPAAAAyQuzAAMAgGRLK4d++eUXOXXqlLu6qm7duqZ6z5NW9Vl+//13adGihdy+fdtU8GnlUf369SV37tymKvCvv/6S7777Ti5evCjvvPOO2ebtt9+Odn81atSQ9957TwYOHGiqz3T2Yb1fraCyV7316NHDnNfKuh9//FEyZMjgvv2rr76Sa9eumQrB06dPmyo3vc5TeHi4JAStGvv+++9Nxd3TTz9tqrL0mCxatEgmT54sUVFR8vnnn5sKvI4dO8r9ovvQpk0b+fvvv021m87qnDVrVomIiDD7c+TIEVm/fr2ZMVmr/ho2bGiq47SysFatWpIuXTpz+9ixY831P/zwg3l+7dWX9yplypTmsebMmWNeL5cvXzYVbXZ//vlntMt79+6Vw4cPm2pTX+vVq1cvxmNt2bLFvK6tqketltPnSytfz507J7/++qupxNPXUrdu3UwFoZ76M3XqVPN61arKLl26SOXKlU013o4dOyRnzpzu9fr06WOqKFVoaKh06tRJ6tSpY17PmzZtkq+//lo+++wz83f5o5WLWm2r9Di1bdtWKlSoYF7zWumpz6kex4ULF/q9HwAAkq1gJ5AAAADBFkh1meXYsWOuhx56yKybPXt2Uz3mzZEjR1wlS5Z0VwLu3LnTa1VTnTp13I/9ySefRKsQ08ow67bRo0f73Cd75VtCs1cA6vLUU0+5bty4EWO9//3vf+51SpUqdV8rAHUJCQnxWs2m1XI5c+Z0Py9ly5Z1ZcmSxbVhw4YY6y5atMh9fyVKlHDFt08//dR9/7/99luM29u1a+euVkyZMqU5P2nSpBjr9ejRw30/u3fvjvEas16Humg1nr62PE2YMMEcM6sSUI+3v+dLl0cffdR18OBBn3/fihUr3PeZIUMGU/Xq7f0UHh5+14pVPf56W+bMmV0HDhzw+ZjXr193rVmzxuftAAAkV4wBCAAAEAv/+c9/TNWUmjZtmhknzhutBvz5559N1VNkZKSpcvKk1YNaKafjsCkdC04rz9SAAQNkzZo15nyzZs3k1VdfTXTPk477pmMmajWXp86dO0uVKlXM+a1bt8rRo0fv6751797da8WejpHXs2dPc16fF61C06rAcuXKxVhXq+kef/xxc3779u13rVKLLXu1nme1n1bhWeNONm/e3IzT5209+3VaGVikSJFot2mF4bZt28z50qVLy7hx40z1oSet+LOqYLUS0Nvr1U4rVbUiVcfy82X48OHu8QiHDRtmql496ZiAP/30k3mf+KPVj0orMXX8TF90fEHrdQcAAP4/AkAAAIAAaZihXXvVY489JjVr1vS7vna91a6R1iQIvoLCiRMnuruudujQQWbMmGECE8/bE5uXX37Za/hn0e63FiuEul/8Bab2IEoDwXbt2vlc1/4ca/fW+KQTjjz00ENegz0NTbVbtxUUWmGhTrhid+jQIdm3b585r918PelryfLGG2/4Ddreeustdxd0+3a+jqG30NRy8+ZNEz4qnVRFA1lfNJh84okn/D6e1fVdj4t2+QUAALFDAAgAABAgDYDOnj1rzmfOnNmMnXa3xQpc9u/fb8YH9EYr/KxxBzXM0fHrNGz0rBBMbDQE9UdnsLXPfHy/aFhkH7PRk32MOh1HTo9zIOvG99+gj1u7dm33OH1nzpxx32YFgjrenYbIVgCoVYh79uyJsZ6v8f90tmHL3UI2rayzxovUYPH48eM+171b+L1582Z3UFe9enW/QbGyKi19sfZ9165dZl0du1MrFQEAQGCYBAQAACBAOimHZe7cuWaJDe06/PDDD3u97ZNPPpFly5aZLqkW7RKsEyYkVjqxhj/20MdX+JkQtKrOPpmKv/26W7ia0H+DhnYaZmngq9V9VjWiVemnQZt22dWJVHRftLJOQz+rq6+9ItBbAGiFeBok2sNMf926d+7c6d5Wu+jeLdz15tixY+7zjzzyyF0f927raEXsihUrzGQfeqqLTjpSvnx5c2z0faIhoXYBBgAAMVEBCAAAEKALFy7c07Hy13VRwx2dTdfOX9fUxMBf5VxS2a9g/w3exgHUsQk1DLbfrsGWVXFpr/qzAkAN0DxnB1Y6u7Cyzx7tj87q67mtNzpTsj9Xrlxxn0+fPv1dH/du+6djDW7cuNHM3Gx1m9Yu81rhOHLkSDMrt3bn1lm1NSQFAADRJc7/2gAAABIhezjy+uuvm6qt2CyeAZ+dTs6gXYY9J9IgzBB3KOZExYsXN8GVWrRokTndsGGDO2y2B4TWeZ0cRF9P2hXYmpjE2/h/VuWfunr1akD7Yw/urG3v9b0SSFfdQPZPK0417Dt58qQ7+NOQ3AoEL126JIMHD5bGjRtLVFRUnPcdAAAnIgAEAAAIkL3bY3zOCKsTZGigaAUnDRs2dI8L17dvX8c+P/butXeb2ME+Pp7TWOGdBnraxdWq8NPuyWXLlo2x3qlTp8xr5m7j/ymrC69W82lwdje7d+92n/fVXT0QOnmN5wy+/gSyjkW7ROu4iFoNOHXqVHM8dMZtnWxE6XHRbtUAAOD/IwAEAADJnr0bqFZW+aJhjBUyaNfL+KjOu379uvzrX/8yp+qLL76Qn376yV0tOGbMGPntt98C2n9/+54Y6UQqlqNHj/pdd9WqVeJUnt2ArW69Oq6dfSzDKlWquLvK2tfzvA873cayYMECv/uhE3/oJBtWl9tAxgz0N7OvFfCuXLnyru8Vq/oxLnSinbZt28qgQYPc1y1fvjzO9wcAgBMRAAIAgGTP3l3RX1dEDRo6derkrkgbMWLEPR+7Pn36yPbt2835p59+2iwaMv7www+m0kk9++yz0SZV8LX/gXbzTCxKlCjhPr9w4UKf6+nkG2PHjhWnsnffnTdvnpngwluop5Ne1KhRI0YAqMcxe/bsXu9bZ5S2DB8+3G9Xap1owwqR7dvFhYZ/2hVXXbx4Ub755huf62o1493CyUAULFjQff7OnTv3fH8AADgJASAAAEj2dAwxq7JPZ+H1V0n3zjvvSFhYmDn/7rvvyqhRo/yON6ah3IQJE0yg52n69Ony5Zdfuidx0Oo/S9WqVeWDDz4w58+ePWvGA/T1OFbwoetpFVdSoZNWWCGgVvhpN05PWjnWtWtX0z3WqfS514o7pcfACnIff/zxGOtaoaDOQK1dX+3XeaMhXKlSpcz5zZs3y0svveQ1HJs0aZIZh9KatKNXr173/He98cYb7grGfv36yerVq2Oso92Sn3rqKb/BpM5GrPe1b98+n+vo3zR+/Hj3ZXvXaQAAIPJ/f1YGAABI5jRsmTFjhgkZ2rdvL61btzZBnxVg6JhjGhTq2GY67lizZs1MOKUVfBrctWrVykzooNV4Ot7a/v375a+//jKVWlrBppMT2GlQ16NHD3M+derU8uOPP0arRLRCE+0aqYtWe3388cfSv3//GPtev359mTVrljmv+/Hiiy+a/bS6BmvApEtipH9jly5dzPmOHTvK77//bgItrX7cuXOnfPfdd3LgwAFTeTllyhRxchXgt99+6w7n9PkrWrSo1/WUPcTzFwDqa2Dy5MlSrVo1EyxqSKZBnFaaajfzc+fOycyZM03loWX06NGSP3/+e/6bqlevLq+++qq5P31P1KpVywTZtWvXNhWCGrZrOK77oO83ff95o+8zrbbVpUKFClKzZk0pVqyY6UKuk5ZERESYgN0KCAsVKmS61QMAABsXAAAAXJs3b3alT59eS/+8LosXL452lNavX+8qWrSoz/XtS2hoqGv8+PHube/cueOqXr26+/ZPP/3U5zNw7NgxV7Zs2cx6KVOmdK1atSrGOleuXHGFh4f7fPz33nsv3p7hrl27uu93//79ftedOHGie10978uLL77o9/j17NnTFRER4b6s++BN/vz5ze166o/u993uK7Z/w72aNGlStL+5c+fOXtfT186DDz7oXi9FihSu8+fP3/X+161b58qTJ4/f46yv/wkTJsTrsYiMjHR169bN7+P26tXLvL98vV4PHDgQ0PtMl5IlS7r27t0b0L4BAJCc0AUYAADg/01asHHjRnnhhRdMdZFOtmCfgMFTxYoVZceOHabLplY1FSlSRDJlymTGCdTuxCVLlpQOHTqYLr46s2v37t3d2+pkBToxgnryySfdMwD7msVVu2fqvmjVl1bJ6Zhqdrqva9askYEDB5r90se3T2yS2On4fr/++qs5FlmzZjUVkVoBp1VhOjbgf//7X7/PhRN4VvH5qurT15dW0FnKlSvn7pLuT6VKlcwMv1qNp9WuOXLkMGMKahWdVtVp13btZt2tWzeJT/o61Co/rexs3ry5GatQn1+dUVurVbXyULvR+6PViFrdp5W2+l7T96r+zXos0qVLZ7rA62tFK0T1PVy4cOF4/RsAAHCCEE0Bg70TAAAAAAAAABJG0vlpGAAAAAAAAECsEQACAAAAAAAADkYACAAAAAAAADhYymDvAAAAABKeTrIRV+nTp5cnnngiXvcnKTtz5oysWLEiztvny5dPypcvH6/7BAAA4A+TgAAAACQD9zKLrs7CeuDAgXjdn6RsyZIlUrdu3Thv37VrVzOzMwAAwP1CF2AAAAAAAADAwagABAAAAAAAAByMCkAAAAAAAADAwQgAAQAAAAAAAAcjAAQAAAAAAAAcjAAQAAAAAAAAcDACQAAAAAAAAMDBCAABAAAAAAAAByMABAAAAAAAAByMABAAAAAAAABwMAJAAAAAAAAAwMEIAAEAAAAAAAAHIwAEAAAAAAAAHIwAEAAAAAAAABDn+j9bTgCwsaZumQAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<plotnine.ggplot.ggplot object at 0x0000025ED26CA960>"
+            ]
+          },
+          "execution_count": 13,
+          "metadata": {
+            "image/png": {
+              "height": 480,
+              "width": 640
+            }
+          },
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Text lengths\n",
+        "train_full['text_num_words'] = train_full['text'].str.split().apply(len)\n",
+        "print(np.nanquantile(train_full['text_num_words'], 0.99))\n",
+        "(p9.ggplot(train_full, p9.aes('text_num_words')) + p9.geom_density())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CDlHPQZfcv7I"
+      },
+      "source": [
+        "Let's make a two-way scatter plot of prices and (proxied) market shares."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 497
+        },
+        "id": "dNujhir1q_0N",
+        "outputId": "0fb9ceff-b680-4ea7-b42f-1385e33744d6"
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAABQAAAAPACAYAAABq3NR5AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAewgAAHsIBbtB1PgABAABJREFUeJzs3Qm4jPX///FPkWQNKRJZU6FCZU+pUCSFRJbKVoRKGyUqQqmUJUtF1myRpV0RkqUie1qsSShCCXX+1+vz/47fnGOW+55zz5yZOc/HdZ2rOu4zc5/ZNK95L6elpKSkGAAAAAAAAABJ6fSMPgEAAAAAAAAA0UMACAAAAAAAACQxAkAAAAAAAAAgiREAAgAAAAAAAEmMABAAAAAAAABIYgSAAAAAAAAAQBIjAAQAAAAAAACSGAEgAAAAAAAAkMQIAAEAAAAAAIAkRgAIAAAAAAAAJDECQAAAAAAAACCJZc3oE0D8GDVqlDl8+HBGnwYAAAAAAABCyJUrl+nUqZNxigAQJyn8O3ToELcIAAAAAABAEiEAxClOO+00myQDgfz3338n//3005kiAABe43UWAKKH11gAyVC8lZKS4vrnCABxCoV/PXr04JZBQL/++qv9HyeFf4UKFeJWQtzTX44nTpwwWbNmtR9wAPGO11kkGl5nkUh4jUWi4TUWab300ksRdW9SvgMAAAAAAAAkMQJAAAAAAAAAIIkRAAIAAAAAAABJjAAQAAAAAAAASGIEgAAAAAAAAEASIwAEAAAAAAAAkhgBIAAAAAAAAJDECAABAAAAAACAJEYACAAAAAAAACQxAkAAAAAAAAAgiREAAgAAAAAAAEmMABAAAAAAAABIYgSAAAAAAAAAQBIjAAQAAAAAAACSGAEgAAAAAAAAkMQIAAEAAAAAAIAkRgAIAAAAAAAAJDECQAAAAAAAACCJEQACAAAAAAAASYwAEAAAAAAAAEhiBIAAAAAAAABAEiMABAAAAAAAAJIYASAAAAAAAACQxAgAAQAAAAAAgCRGAAgAAAAAAAAkMQJAAAAAAAAAIIkRAAIAAAAAAABJjAAQAAAAAAAASGIEgAAAAAAAAEASy5rRJwAAgNdSUlLMsmXLzIIFC8yRI0fMueeea5o3b26KFCnCjQ0AAAAg0yEABACc4rfffjMHDhww+fPnN+ecc05C3UJLly41Xbp0MWvWrEn1/ccee8yGgMOGDTP58uXLsPMDAAAAgFijBRgAYP37779mwoQJpkqVKua8884zZcuWNQULFjS1atUyU6dOtVV18e7TTz81derUOSX88/1+kydPNrVr17bhJgAAAABkFgSAAABz7Ngx07RpU9OmTRuzYsWKVLfIkiVLzJ133mnatm1rQ7R4dfjwYVvhp98llLVr15oePXrE7LwAAAAAIKMRAAIATPfu3c3s2bND3hKqDnzyySfj9tZSdd/vv//u6NhJkyaZffv2Rf2cAAAAACAeEAACQCa3c+dOM2bMGEfHvvrqq45DtlibPn2642P/+ecfM3fu3KieDwAAAADECwJAAMjkxo0b57i19+jRo2bixIkmXheXRPN4AAAAAEhUbAEGgExu3bp1ro5fv369iUe5c+eO6vFI7b///jO//vqrOXHihF0ac+aZZ3ITAQAAAHGKCkAAQFKoW7duVI/H/6cW8H79+pkLL7zQFClSxP4zf/78pmPHjmbDhg3cTAAAAEAcIgAEgEyufPnyUT0+Vjp06GDOOOMMR8fWq1fPlC5dOurnlGx++OEHU7lyZdO7d287O9Lnr7/+snMkK1asaGbOnJmh5wgAAADgVASAAJDJ3XPPPSZLliyOjj3rrLNMq1atTDwqXLiwefHFF8Mely9fPrvMBO4cPnzY1K9f32zdujXoMceOHTMtWrQwK1as4OYFAAAA4ggBIABkcmrjVPumEw8++KAN0OJV9+7dzdChQ0327NkD/rmq/hYuXGjKli0b83NLdBMmTDA//vhj2OOOHz9u+vfvH5NzAgAAAOAMS0AAAGbIkCFmz5495t133w16a7Rp08Y899xzcX9rPfDAA7YKTduNFyxYYNtTtaTirrvuMg0aNHBc7YjURo8e7fgmmTdvntm1a5cNlwEAAABkPAJAAIDJli2bmT59upkyZYoZPny4WbZs2clbpXbt2jZUa9KkiTnttNMS4tYqUKCA6dGjh/1KSUmxm2qzZs2aMOcfb3QbutkWrQ3BGzduJAAEAAAA4gQBIADAOv30022VnL72799vDhw4YNt9teEVUAgYzeMBAAAARA8zAAEAASvoSpUqRfgHS5WTl156qavjL774Ym49AAAAIE4QAAIAgLA6dOjg+Fa66aabTNGiRblVAQAAgDhBAAgAAMJq27atKVasWNjjtGSlV69e3KIAAABAHCEABAAAYeXJk8d8+OGHIRd7aNHK+PHjTY0aNbhFAQAAgDhCAAgAABy55JJLzDfffGOefPJJc+6556baIt26dWuzcuVK07JlS25NAAAAIM6wBRgAADim4K9fv36mb9++Zvv27eb48eO2KjBXrlzcigAAAECcIgAEAADu/wcia1ZTsmRJbjkAAAAgAdACDAAAAAAAACQxAkAAAAAAAAAgiREAAgAAAAAAAEmMABAAAAAAAABIYiwBAYAYSklJMRs2bDC///67Ofvss82ll15qsmTJwn0AAAAAAIgaKgABIAaOHz9uhg4dai655BJTvnx5c80115jLLrvMlClTxrz44ovm6NGjMbsf/vnnH7Nnzx5z5MgRk8hB6t9//23+/fffjD4VAAAAAIh7BIAAMjUFb6rGO3HiRFQDt1tvvdV069bNbN68OdWf/fzzz+axxx4zdevWNYcPHzbRtHTpUtO8eXOTO3duU6hQIZMrVy5Ts2ZNM3ny5IQJ0n744Qfz0EMPmXPPPdfkyJHDnHHGGfZ3mDRpkg1ZAQAAAACnIgAEkHQUpP3444/ml19+sZViaSnsmjp1qq3CO+uss0yBAgVMzpw5TcuWLc3y5ctPOX7//v1m8ODBpmLFiua8884zJUqUMPfcc49ZuXKlo/N58MEHzQcffBDymMWLF5sOHTqYaHn22WdtUDZt2rRUQZlCwbvuuss0atTIVtTFM517uXLlzJAhQ8y+ffvs93T/6ndo1aqVuf76682BAwcy+jQBAAAAIO4QAAJIGgqCmjVrZmfrlS5d2hQpUsRWianldvTo0Tbg0lfjxo3NnXfeaUM3n2PHjpkpU6aYqlWrmgEDBpz8/scff2xKlixpHn30UbN69Wrz22+/ma1bt5px48aZq6++2oZ2oaoHf/31V/Pmm286Ov933nnHBpdeGzNmjOnTp0/IY95//33Tvn17E68WLlxoA1rdT8Ho/mzatKn577//YnpuAAAAABDvCAABJCxV8n355Zdm1qxZ5r777rMVbjNmzEjVzqoW3/Xr15tOnTqZCy64wDRo0MDMmzcv5OX26tXLjB071nz11Ve2Mu7PP/8Meuwbb7xhunbtGvTPJ06c6Ko19a233jJe0nX37dvX0bFqBdZtFY+eeuopR23KCxYssF8AAAAAgP9DAAgg4ajiTi25pUqVMjVq1DC33367GTVqVNif06y/zz//3NF1PP300+aRRx6x8/vCGTlypFm3bl3AP9uyZYuj64v0+HBU2adWaKdUKRlvdNuqutMp3R8AAAAAgP9DAAggoaiirUmTJrYld9u2bVG7np07d3oSOmXJksXV9bo9Ppw1a9ZE9fhY+Oabb6J6PAAAAAAkOwJAAAlFlXlz5swx8SZYWFipUiVXl+P2+HDczsOLx/l5bjcUJ8pGYwAAAACIFQJAAAm13Xf48OEmHmnWYCBaNpI7d25Hl5EtWzZz9913e3peF198cVSPj4UyZcq4Ol4LYAAAAAAA/4cAEEDC0LKPQ4cOmXhUrFixgN/PlSuX6d27t6PL6NGjhylYsKCn56WNx/nz53d8vLYax5vq1aubiy66yPHx7dq1i+r5AAAAAECiIQAEkDB+/vnnmF2XQrN8+fI5Pr5NmzZB/0zLRB577LGQP68txf369TNey549u52X6ETdunXNVVddZeLN6aefbnr27Om4+q9p06ZRPycAAAAASCQEgAAShlpkY0WhWdeuXR0dW7Ro0ZCh02mnnWYGDRpklixZYluCzzzzTPv9M844w9x2223m008/Na+//roNuqJB4aMCxlAU/L3zzjsmXrVt29Y88cQTIY+54IILzPz580/evgAAAACA/y/r//4JAHGvSpUqnlxOzpw5zZEjR4L+efv27W1opoUY2or73nvvhawU1FISJ6FTjRo17Jcu9++//zZnnXVW1EI/f7oOBYzXX3+9efXVV1MtLClRooS5//77TZcuXUyOHDlMvFKIOmDAABtUvvzyy6l+h7x589rZiQoICxUqlKHnCQAAAADxiAAQQMK49tprTdmyZc3mzZsjvgwFRKq4U2g3cuRIs3379pN/VrVqVdOtWzdbpafAScHZjBkzzIsvvmiGDRtmfvnll5PHZs2a1c7XUyjldumELlchZCzp92nWrJn92rlzp9m7d6+dT1iqVKmYhJBeuf322+3XTz/9ZH8PtTiXL18+rsNLAAAAAMhoBIAAEoZCrMGDB5tGjRqZlJQU1z9fv359WwlXvHhxU65cOVvl9/3339vtwueee6658MILT/kZBX2aP6c5fosWLTK7du2yYZMq+c4//3yTiNQqq69EVrJkSfsFAAAAAAiPABBAQmnYsKF5++237abX48ePBzymdevW5o477jBffvmlDQrVpqtqvTJlyqQ6LkuWLOaSSy5xdL2a13fDDTd48jsAAAAAABBLBIAAEo4Cvlq1aplRo0aZKVOmmD179th21htvvNF07tzZ1KxZ82RYCAAAAABAZkcACCAhqY1X8/f0heShqs5t27aZY8eO2TblPHnyZPQpAQAAAEDCS5zJ7wCApKWlJE8++aQN/dSqrRmNBQoUMM2bNzcrVqzI6NMDAAAAgIRGBSAAxDktKlm7dq2dZ6gtyBUqVDDJRFud1b69Y8eOVN8/ceKEmTZtmt3EPHr0aDv3EQAAAADgHgEgAMQpbR3u27evWbhwYarvV6lSxTz11FMJNePwjz/+MOPHjzdLliwxR48eNUWLFrWzHBVm3nTTTaeEf/7+++8/07FjR1OiRAlTp06dmJ43AAAAACQDAkAAyECq6lu1apX59ttvzb///msuuugic91115mpU6fagEzfS2v58uXmlltuMa+++qrp1q2bifffb8iQIba99++//071Z6+//ropWbKk+fnnn8NejkLA/v37EwB65MCBA+bw4cN2Q3aOHDm8ulgAAAAAcYoAEAAyyAcffGCDMYV//jQH75dffrGhVyjdu3c3V1xxhbnmmmtMvBo4cKDp1atX0D//6aefHF/WZ599Zn788UdTqlQpj84uc1FL9aRJk8zw4cPNypUr7feyZMliw2QFyQqeAQAAACQnloAAQAYYO3asadCgwSnhn+zcuTNs+Ofz8ssvm3i1ZcsWG3B6aePGjZ5eXmZx5MgRc/PNN5u77777ZPgnqjCdPXu2razs3bu3rdgEAAAAkHwIAAEgxjZs2GA6dOjgSdgyd+5cs3//fhOPRo4c6XmgdNppp3l6eZnFPffcYz755JOQx/Tr18/eZwAAAACSDwEgAMTY0KFDA872i4QqBVUxGI/mz5/v+WWWL1/e88tMdtogPX36dEfHPvfcc+b48eNRPycAAAAAsUUACAAxpMBOc9i8dOaZZ5p4dPDgQU8vr379+ubCCy/09DIzgzFjxjg+dvfu3baqFAAAAEByIQAEgBjS5tVDhw55dnkFCxaM26UY55xzjmeXlTVrVvPUU095dnmZyXfffee6YhAAAABAciEABIAYyp49u6eXp1mCZ5xxholHTZo0cXzs6acH/+soW7ZstmqyRo0aHp1Z5uJ2DiOLQAAAAIDkQwAIADGkMKtatWqeXJbaYR988EETrxRO6vd14r777jMvvPCCKVGixMnv5ciRw3Ts2NFuSr7jjjuieKbJ7ZJLLonq8QAAAADiHwEgAMRY586d030ZpUuXNp9++qltAY5XRYoUMaNHjw57XKVKlczAgQPNo48+an788UezZ88eu9jkjz/+MKNGjTKXXnppTM43WSmIddO2feutt0b1fAAAAADEHgEgAMRY8+bNTe3atcMep9l+b7zxhqlTp44pUKCAyZ8/v6levboZO3asneumEDDetW3b1syYMcNccMEFAdt+W7RoYT777DOTO3du+73TTjvNnHvuuTY8dFo9iNAqV65sbr75Zkc30+OPP+55mzoAAACAjJc1o08AADIbzeybM2eODQI//PDDgMdUqFDBbmNVm2+7du1MItMsQFWVzZ8/3yxevNj8888/NhBs2bKlKVq0aEafXqYwefJkc9NNN5lly5YFPeaBBx4wPXr0iOl5AQAAAIgNAkAAyAB58uQx77//vg3ERo4caefc/fvvv+aiiy4y7du3Nw0bNrSbb5OFfheFgLSXZoy8efPaSku1VI8YMcJ8//33J//suuuuM127djWNGze2FZgAAAAAkk/yvLuEp9gCiWCyZMliWzcVFPA4Sb9atWrZL56H0eN7nGb2x+uZZ55punXrZsO+7du3m0OHDtl2a335ZPbbKF7wOotEw+ssEgmvsUg0vMbCKwSACOjEiRPcMgjo7LPP5nGChKQKS/x/mrHow+t9/OF1FomK11kkAl5jkah4jUV6EQAi8AMjiVoP4a19+/bZT6FUAaiNoUC80+NV/8OkT/xpcUUi4HUWiYbXWSQSXmORaHiNhVdIeRAQb5IRjIKU//7772QbMJAo9HjNbI/ZVatWmXfeecfs2bPH5MyZ01x//fV21p8W0SB+8TqLRJUZX2eReHiNRaLiNRbpRQAIAECS2bp1q2nVqpVZunRpqu9rCUjhwoXt4plGjRpl2PkBAAAAiK3TY3x9AAAginbs2GFq1qx5Svjns3v3blsFOGPGDO4HAAAAIJMgAAQAIIloy++uXbvCzpK59957zcGDB2N2XgAAAAAyDgEgAABJYtu2bWbOnDmOjj106JCZMGFC1M8JAAAAQMYjAAQAIEnMmzfPVvc5NXv27KieDwAAAID4QAAIAECS+OOPP6J6PAAAAIDERAAIAECSyJcvX1SPBwAAAJCYCAABAEgSDRs2NKeddprj47UNGAAAAEDyIwAEACBJXHjhhaZRo0aOjs2dO7dp3bp11M8JAAAAQMYjAAQAIIkMHTrUFClSJOQxqhJ88803Td68eWN2XgAAAAAyDgEgAAAe2LNnj/n666/N+vXrzbFjxzLsNi1atKhZsmSJqVGjRsA/L1y4sJk1a5Zp1qxZzM8NAAAAQMbImkHXCwCIge+//96MGjXKLFu2zBw/ftwUL17c3H333aZ+/fomS5Ys3Ace+OSTT8xLL71kPvroo5PfK1iwoGnfvr15+OGHzTnnnBO12/no0aPm3XffNWvWrDEpKSmmbNmy5o477rD3s0LAVatWmXfeecf8+uuvJmfOnOaGG26wc//OOOOMqJ0TAAAAgPhDAAgASejEiROmW7du5vXXX0/1fQVCM2bMMOXLlzfvvfeeKVmyZIadYzIYMGCA6dWr1ynf37t3r/2zKVOmmAULFnh+OyvsU6vvs88+a/bv35/qzx566CHTvXt307dvX3PllVfaLwAAAACZGy3AAJBkFA517NjxlPDP37p168y1115rK8MQmWnTpgUM//xt3brVNGjQwPzzzz+e3sxPPvmkDfnShn9y6NAh069fP3PPPffYxwIAAAAAEAACQJJR6+fYsWPDHrdjxw5bJQb3FKwpZHNi06ZNtk3XK4sWLbLVheFMmDDBTJo0ybPrBQAAAJC4CAABIMmMGDHC8bETJ040Bw8ejOr5JKOVK1eatWvXOj5+zJgxnl23Wn+jcSwAAACA5EUACABJ5tNPP3V87JEjR8zy5ctP/ve///5r5syZY1q3bm3q1atnmjZtakaPHm2Pw//ZvHlzVI8PRtuFNbvRqRUrVpjt27d7ct0AAAAAEhdLQAAgybgN63zHf/PNN3aD7I8//pjqz2fOnGkee+wxM3LkSHPnnXd6eq6J6vTTT4/q8cEcOHDALnhxQwtJihUr5sn1AwAAAEhMVAACQJI577zzXB//3Xffmeuuu+6U8M9HbcItWrQwkydP9ugsE9vll1/u6vgrrrjCk+vNnTu365/JkyePJ9cNAAAAIHERAAJAklFQ51Tx4sVNlSpVzP3332/+/PPPsMffd999dstsZle+fHlTvXp1x8d36tTJk+s966yz7PZmp0qXLm1KlSrlyXUDAAAASFwEgACQZBQ2ZcuWzdGx3bp1s8ssvvzyS0fHK/zTdlkY88wzzzhq7a1WrZq56aabPLvJunTp4vjYzp07e9Z+DAAAACBx8a4AAJLMhRdeaMaNGxc2+LnttttsAPj++++7uvwPPvggnWeYHG644QZ7O2fNGnyc7pVXXmmXqmTJksWz67399tvtVzg1atSwlZ0AAAAAQAAIAEnaBjx//nzbqppW3rx5zZNPPmmmTZtmgyknrb/+3B6fzLQtefXq1bbqMmfOnKlmBGppyuLFi80555zj6XUq2J0yZYpp3769Oe200wIe07hxYxvsZs+e3dPrBgAAAJCY2AIMAEmqfv36pl69embp0qXmq6++MseOHTMlSpQwt956q8mRI8fJ4woWLOjqcr0OtBJduXLlbNg3bNgwu6VXoVuuXLmiep1q8R4zZozp2bOn/eeaNWtMSkqKKVu2rA0GAwW/AAAAADIvAkAASGKqEKtZs6b9CtUK/Oijj9oAyYlmzZp5eIbJQ63AsQ5HS5YsaQYMGBDT6wQAAACQeGgBBoBMTiFSw4YNHR17/vnnO5o/BwAAAACIHwSAAADbwqrlIaGotfWdd95xvGEYAAAAABAfCAABALay78svvzQ333xzwFvjsssuM59//rmpVasWtxYAAAAAJBhmAAIAToaA2hy8ZcsWM2PGDPPbb7+Z3Llz20Ui1atXD7pxFgAAAAAQ3wgAAQCplClTxm6XBQAAAAAkB1qAAQAAAAAAgCRGAAgAAAAAAAAkMQJAAAAAAAAAIIkRAAIAAAAAAABJjAAQAAAAAAAASGIEgAAAAAAAAEASIwAEAAAAAAAAkhgBIAAAAAAAAJDECAABAAAAAACAJJY1o08AAAAEt3HjRjN+/Hizbds2c+aZZ5pq1aqZli1bmly5cnGzAQAAAHCEABAAgDi0f/9+07ZtWzN//vxU3x83bpx55JFHzPPPP28eeOCBDDs/AAAAAImDABAAgDhz8OBBc91115m1a9cG/PNDhw6Zrl27msOHD5snnngi5ucHAAAAILEwAxAAktCePXvM0qVLzZdffml+//33jD4duPTMM88EDf/89erVy2zevJnbFwAAAEBIBIAAkES++uorc9ttt5nzzz/f1KxZ09SoUcMULlzYtGrVyqxfv94kgiNHjpjVq1ebVatWmX379pnMRr//W2+95ejYlJQUM2LEiKifEwAAAIDERgAIAEli8uTJNvSbPXu2+e+//05+/9ixY2bSpEnm6quvNp988omJV1u3bjVdunQxhQoVMhUrVjRXXXWV/ffbb7/dLFu2zGQWX3zxhW0BdmrOnDlRPR8AAAAAiY8AEACSwNdff20XRvz7779Bj/nrr79smKagLd6sXLnSVK5c2Vazaa6dj36fWbNm2WBz7NixJjM4cOBAVI8HAAAAkPkQAAJAEnjxxRfNiRMnwh6ncG348OEm3rbdNmjQIOSsQlU0tm/f3ixevNgku/z587s6Pl++fBFflx4z3333nVmyZImdJaiWYgAAAADJhwAQABLcH3/8YWbOnOn4eM2XC1UpGGujR482e/fuDXucQsBBgwaZZFerVi1XoV7jxo0jmjPYv39/U6JECXP55Zfb67z44ovNFVdcYd54441ULeQAAAAAEh8BIAAkuO3btzuq/vNRpZ1Cw3ihwMmp999/3+zatcsksxw5cph27do5Ovb000839913n6vL1/1fu3Zt89RTT5mdO3em+jNVA3bo0MG0bNnS1WMKAAAAQHwjAASABJclS5aY/Ew0KGT66aefHB+vFtUtW7aYZPf000/bRShOWr8vuugiV5etcE8zI0OZOnWq6dOnj6vLzUz0ONRWbS1sWbNmTVxV1AIAAACBEAACQIIrVaqUyZMnj+Pj1fZ59tlnm3hw2mmn2a9EDC+jKXfu3Oazzz6zS1sCUYvwqFGjzMMPP+zqchX8ffTRR46Ofe2118yhQ4dcXX6yU2CtRTWXXnqpKV++vK2kVNt0yZIlzYABA+yiHQAAACAeEQACQII766yz7AZgp9Qy6jZ0ixaFeRUqVHB8/BlnnGHDl8xAIa1mO6riURWBuo87duxoxo0bZ9ug9e9uaf6jU1oYM23aNNfXkayOHTtmmjRpYrp06WI2bdp0Sht+r169TJ06dczBgwcz7BwBAACAYLIG/RMAQMJ45JFHzOTJk+1G3VCKFy8eUXAUTZ06dbKhihPNmjUzBQoUMJlJ6dKlzTPPPOPJZX3//feujs8M7dZOPfbYY2bOnDkhj1m+fLkNamfPnh2z8wIAAACcoAIQAJJAsWLFzIcffmgKFiwY9Bi1KX788cdx0/7ro8DEyRw7Lcfo2bOniTc//PCDefPNN83QoUNtxV68tIGqfXfVqlU2lPJtWXbbPp0Z2q2dULA+cuRIR8e+9957ZsOGDVE/JwAAAMANAkAASBJXXnmlDR769+9vK/18LrnkEjNkyBCzevVqU6ZMGRNvcubMaefShTq3XLly2WBFc9fSUril+WsKEdUirKBQs9mmTJlijh8/HrXzXrt2ralXr5497/bt25tu3bqZpk2bmiJFipgnnnjC/PPPPyYjqGpP53PeeeeZq666ylStWtUULlzYzhPU99xwsogkM1B1rZv7002rNQAAABALtAADQBI555xz7CwyfSmwOP30020oFu8UWKpaTcGJKq02b9588ve59957bYuwqhzTWrJkiWnUqJH5448/Ui1q0HZWfb366qtm7ty5nlc9qqruxhtvDLgk48CBA2bQoEFm5cqV5v333zdnnnmmiRXdHg0aNDB//vlnqu9rS+2sWbPs40HzH7XFNpxChQrZ2xbuW6FpnQYAAEC8oQIQAJKUgqdECP98tMn4wQcftAsWFKwp1NuzZ48N0wKFfxs3bjQ333xzqvAvUFCnEMvLSkC1+DZu3Djshlxt8e3du7eJld27d9vfNW345++///5zfHmaO5gtWzaPzi6x0ToNAACAREcACACIO2r5VdWeKtaCefbZZ8OGcPLVV1+Zd99917Nzmzp1qvn1118dHTt69Ghz5MgREwuvv/56yDDUR9V/F1xwQchj+vXrF3fLYjJS5cqVXR1fqVKlqJ0LAAAAEAkCQABAwtHcPy3ccGrMmDGeXfekSZMcH3vw4EEzf/78sIHczp07bduojo+ELkOLSJz65ZdfzMSJE039+vVPVrdlz57dtG7d2qxYscI8+eSTEZ1HsmrSpInJnz+/o2OzZs1q29YBAACAeMIMQABAwlmzZo2rtl7N4/PKrl27XB2vsC1tWKeQTQtb1Ca8ePFis23bNvtnqnhs2LCheeihh8y1117r+DpUZZj2ekJRK3Dp0qXNBx98YOcD/v3333Z5SqiKy8zsrLPOMn379rWLXsLRMeeff35MzgsAAABwigAQAJBw3M7083IGoNu5eAqPfFR1p43FCv+CBXNz5syxX9rmrGUu0ZhRJ76wTz+rlmuE9sADD5h9+/bZ1vNg7rnnHvPCCy9wUwIAACDu8FE/ACDhlChRIqrHh1q04avWc6p27dr2n2qrVYttsPAvLR2vwNBpyFi2bFnH5+T2eBi7PVmLUTRT8q677rIt076W31tuucV89NFHtg07kjAWAAAAiDYCQABAwrn44otN1apVHR/ftm1bT65XwY+bOX3XXXedPVctIXn++eddX5+qzZxu7u3UqZPjy23ZsqXdugz3qlSpYoNZbYM+fPiw+eeff2zFZt26dW1ICAAAAMQjAkAAQEJ6/PHHHR2n5Q1qzUyvb7/91nz++eeuquxeeukl++8vvvhiRNepxSCLFi1ydGy7du1MyZIlwx6n4M/pbYfgFPblzJmTuYkAAABICASAABCh/fv3m1GjRtlWzeeee86GQ1rwgNho3Lix6devX8hjcufObWbPnm0KFiyY7uubMGGCq+PvvPNOU7FiRRviqW00UuvXr3d0nII9taGGCgHPPvtsM2/ePFOmTJmIzwcAAABA4mEJCAC4pNa/Hj16mLFjx9r2P39q9xwyZIipV68et2sMKHwtV66cXbywbNmyk98/44wzTNOmTU3v3r3tfXLixIl0X9eOHTtcHe+bBbd9+3YTK9rsq0pFzaJTOL1582b7/cKFC9sKwfvvv58NtQAAAEAmRAAIAC78/fffpn79+mbx4sUB/3zTpk2mQYMG5p133rEBFGJTCagv3fY///yzDf8uv/zyk1V/XlVl+pY+OHXmmWem+mekypcv7+p4VQI+9NBD9kuP13///de2qjKfDgAAAMi8aAEGAJdLGYKFfz4KXNq0aWP27NnDbRtDqvS76aabzA033OBJy29atWrViuj4yy67zAZwkbjooovMNddcYyKlOYS5cuUi/AMAAAAyOQJAAHBI1VSjR492fKzaMJE83GzOPe+888xtt91m/10/06pVq4ius0+fPiyZAAAAAJBuBIAA4NBnn31mfv/9d8e319SpU7ltk4gq6QYNGuTo2FdeecVky5Yt1axChYJuDBw40IaOAAAAAJBeBIAA4NBvv/0W1eMR/+677z7z8ssvn1zwkZbmD6pKtEWLFqm+X7RoUfPpp5+aYsWKhbz8008/3TRp0sR88cUX5vHHH/f03AEAAABkXiwBAQCHcufOHdXjkRi0XENLR7Rld86cOebgwYMmf/78tuW3Q4cONuwLtsxj48aNZsqUKbY9/McffzRZs2Y1lStXNs2bNzdVqlQxhQoVspWGAAAAAOAlAkAAcEjLGFThdfz4cUfH161bl9s2SZUoUcK26OrLjRw5cph27drZLwAAAACIFVqAAcChc88919xxxx2Ob6/777+f2xYAAAAAkOEIAAHAhQEDBpjzzz8/7HGa31auXDluWwAAAABAhiMABAAXNN9t0aJFdp5bIFoO8fTTT9ugEAAAAACAeMAMQABwqXTp0mbNmjXmk08+MePHjzc7duww2bNnNzVr1jTt27d3VCEIILzvvvvOzJs3zxw4cODkopWyZcty0wEAAAAuEQACQAROP/10U69ePfsFwFvaltypUyezePHiVN/v2bOnufHGG83o0aNN8eLFudkBAAAAhwgAAWRa2ua7fPlys3//fnP22WebKlWq2Eo+ABln3bp1duP2H3/8EfDPVXlbrVo1s3TpUlOyZMmYnx8AAACQiJgBCCDT+fvvv80zzzxjihUrZmrVqmUaN25srr32WjvfTxVGhw4dyuhTBDKllJQU06JFi6Dhn8+vv/5q7r777pidFwAAAJDoCAABZCqHDx+2LYR9+/a1IYK/ffv2mYEDB4asPgIQPZ9//rmtAHRC7cHffvstdwcAAADgAAEggEylc+fOtnUwlNWrV5u2bdvG7JwA/H/Tp0+P6vEAAABAZkUACCDT2Llzp5k0aZKjY+fOnWs2bNgQ9XMC8H9+++03VzfH3r17ufkAAAAABwgAAWQaEydONP/995/j48eNGxfV8wGQWu7cuaN6PAAAAJBZEQACyDR++uknV8f//PPPUTsXAKeqX79+VI8HAAAAMisCQACZRrZs2Vwdf8YZZ0TtXACc6vbbbzfnnXeeo5umTJky5oYbbuBmBAAAABwgAASQaVSpUiWqxwNIf0j/xhtvmNNPD/2/J1myZDFDhw4NexwAAACA/4//cwaQaTRt2tTkz5/f0bFnnXWWadOmTdTPCUBqDRs2NO+++67JkSNH0Jvm33//NT179mQJCAAAAOAQASCATEOhXv/+/R0d27t3b5MvXz4Tj7TI5MCBA+bQoUMmJSUlo08H8Nzx48fNX3/9FfKYb7/91jRu3NjVYh8AAAAgsyIABJCp3HfffWbgwIHmtNNOC3rME088Yb/izbZt28xjjz1mZ6QpnMyTJ4+5+OKLzSuvvGLDQCAZKNTu27evo2O//PJL88knn0T9nAAAAIBERwAIINN5/PHHzdq1a839999vwzQt+yhYsKC59957zapVq8yAAQNCBoQZQSFH+fLlzYsvvmj27dt38vvff/+9efjhh02lSpXYWoyksGzZMrN+/XrHx48aNSqq5wMAAAAkg6wZfQIAkBHKlStnRowYYb/i3bp162yrY6iWyB9++MHUr1/ffP311yZXrlwxPT/Eri32559/tv8sUqSIOfvss5PyptfjPZrHAwAAAJkRFYAAEOc0tzDcPDRfNeD48eM9b8f8+++/7dIFZIy9e/eaXr162dCvbNmythL0nHPOMc2aNTPLly9PuruFuZYAAACA9wgAASCOqd135syZMW+HVEXhQw89ZFujtY1VbdK1atUykyZNMidOnPDkOhDe5s2bbXu32tIVBPookJ0xY4apXr26eeONN5KuOteNSy+9NGrnAgAAACQLAkAAiGMbN260LZ9Offfdd+mu1ps2bZoNYYYMGWL2799/sipryZIlplWrVub66683Bw8eTNd1ILwjR46Ym266yezcuTPoMdqA27FjR/Ppp58mzU1ao0YNu9zGKf3+wW4/BeJXXnmlyZ49u/3Sv48ePdr+GQAAAJCZEAACQByLJMxLTwvlwoULTcuWLc2xY8eCHvPFF1+Ypk2b0qoZZRMnTnS02EX39/PPP+/4crds2WJnX77wwgvm7bffNr///ruJJ1rA06dPH0fHXn311aZevXoBf8fLLrvMbv3WXMx//vnHfunfO3XqZK644gpb5QoAAABkFiwBAYA4VqZMGRuIOA31SpUqZbJmjfylvXfv3o5CR1WcffbZZ7YaENExZswYx8d+/vnnNtAqXbp00GM2bdpkunfvbj7++ONU31dlXOvWre2G6bx58xqv6DGrsFgbffXvml14zTXXONqwfeedd5rt27fbjd3BVKhQwbz33nsmS5Ysqb6vqtUbb7zRbNu2LejP6rbSMQoE8+fP7/I3AwAAABIPFYAAEMe0+EFtoE61b98+4utSUKM2X6dGjhwZ8XXBWfu3Gwr4glm9erWpVq3aKeGfHD161IaN1157rWet3e+884655JJL7GV26dLFPPDAA/bf9b0pU6Y4uozHHnvMVqRqA/bpp//f/66UKFHCDBo0yHz55ZemUKFCp/zcsGHDQoZ/Plu3bjXDhw93+ZsBAAAAiYkKQACIcz179jQffvihnfcWyrnnnpuuAFDVUG6sWrXKJDPN3ps8ebL56aefzFlnnWVn09166612IUosuG3lDlZZp6UtTZo0MQcOHAj58woJVSE4btw4kx5qLQ5WuaelJmoxD1fd51O7dm37pWByz5499n5QKO4fCPpT9apm/DmlGYFPPvlk0MsDAAAAkgUBIADEuZo1a5o333zThnvB2nMLFChg5s+fb84555yYzRtM77KRSP3yyy9m7Nix5ttvv7XnULZsWXPvvfeaiy66KNVxf/3118lKMIVGuXPndnT5hw4dMm3btjWzZ89OFcJpKcrZZ59tXnvtNdsyG21uW7nVLh7I3LlzbYjphAJPVdedd955JhKLFy92FOw98cQTtiJRLcFOqDXZSXvyrl277OPDKd/xF1xwgeOfAQAAABIRH3kDQAK4++67bXuuKrn8Z54p1FJ7par3tOE0PULNj3MTOEWLKtl69OhhLrzwQvPUU0+ZmTNn2pBOgZVCwDvuuMMcPnzYfP/993bRQ8GCBc2ll15qvxQAdu7c2fz4448hr0PbYbU8YtasWQEr8FRF16ZNG/Pyyy9H8Tf9v3NxY+XKlUFDPae0cXrGjBkmUgpJo3GsU6GW1wTjZss2AAAAkKioAASABFG1alUbzuzbt89WtqlCTCFcjhw5PLl8tbiqik4BmhPt2rUzsaIwThWQ2lobzPTp0+3cPIV8f//9d6o/UzComYWTJk2yFXFqKw1Ec+o0Gy4cBZGNGjVyHZq6Ea7lO60NGzYE/P7u3btdXc6vv/5qIqHKSS3lcErH/vnnnyZPnjzGK+eff74588wz7cZfJ7QAJdAcQQAAACDZUAEIAAlGbb6VK1c2l19+uWfhn2gOmuYNOqHgUdWIsfLBBx+EDP981q1bd0r4lzakUnAXKOTTPDg3cw3VxhpNTrbl+suVK1fA77t9jET6mPrtt99ctYUr4NRcPy/p3Js3b+74eG0b1lxBAAAAINkRAAIATtLsu3DBlualzZs3z1ZaxYqX21pVdaY5fv5UMaats25o5mI0aamLG8EC2Tp16ri6HLfHpyc49DLA9nnooYcczU/UMQ8++KDn1w8AAADEI1qA00nVCx06dHB8/PPPP2/Kly/v+Pi1a9faDYXhvPTSSzGfxwUgfmlrqjatal5giRIlHFc5qepswIAB5qqrrrJz7pYuXXryz7SEQbMIFRBGo21SFWGffPKJbdXVTEPN/FOLrWbuaQuyl7RERLMDfRt9NfNPwaAbR48eTdesOs0TVNVesBCsS5cu5umnn3Z0eaVKlTplCYqPFqT06dPH0Xw8VZZeffXVJhJ6TLhpIdd9q5Zdr11xxRV2k7HC7GAViXpejB8/3lbRAgAAAJkBFYDpvQFPP91uhQz1lS1btpPVBhpeH6lQ1+F2WySA5LR69WrTqlUrWz2mZRblypWzwUy3bt1sIOjU7bffbpeOaJ7eokWLzPLly+22VC1uiEb4p8Cybt26pn79+naxx44dO+zsOm2V1YcsbufhhaPwzb/99KuvvjKx8MUXX5imTZuanDlz2k27+qfmEU6dOvWU31EViU6rALXgJBhdhkLdcFTROXToUNetxz76ufvvv9/x8TrnSK8rnLvuusssXLjQ1KtX75Q/02NMj+kWLVpE5boBAACAeERqlE7aMqkqglD0hmjXrl22qkIbOyMV7noAxC+9BowZM8Z8/vnndkZd4cKFTcuWLc1tt9128kOC9NISDAUfabeaqrJNwY4WYKiSTtV9TpUsWdJ+RZMq/TSXT+FYLPmHT5FsgnUTXmmJSe/evU3//v1P+TP93vrStl4FgVpM4QvkVAmpqjzN1wu3lOTFF180/fr1s4+rtBWfaotVwKgZj7q90ypQoICZNm2aqVatmkmPjh07mgkTJphvvvkm5HGVKlWym5qjqWbNmvbxrnmPmzZtst+75JJL0vVBHAAAAJCoqACMMm2k1Bt/uf7666N9dQDijIIfhT7Fixc3zzzzjA16Vq5caebMmWMXEKhlMlxY4oSWVwQK//z9/vvv5uabbw4bJnlF16cqLLX1qpIwGG02jnX4p0UqqsDz0f3jllqinRoxYkTA8M+fHhNpK+g0b/Gnn34yjRs3drS9V5uSFXKtX7/+lLDykUcesWGY2oEV9FWoUMH+vTR69Gi7VTrS2X/+1M6s0E3hW6ht0zomGvP/AtF9q6o/fRH+AQAAILMiAIyyBQsW2H/mz5/fVjwAyFxUkfXUU08FrLoSX/CyYcOGdF2P5tk5qWLbt2+f3XYbTZoBp7l9mu923XXX2dZezXtTq+v7778fMByLNQVl/qMTFJ5qpIMb+hkntGBE4a8Tml23ZcuWU+bVqRXaKT2mFOypjTqtIkWKmL59+5ovv/zSfPfdd+bTTz+1LdZqRfayMl4tth9//LFp1qyZDST1pdZnfU9hr44BAAAAEDsEgFGkN32+Afp646s3cQAyD1VbKWxxMv/u4Ycfjvh6FOppbp5TakVWZWI0KFhSi7HaQPUa6E/BT4MGDcwLL7xw8ntqS9XPeMW31CNc9V/Xrl1TfU9hpUJLpxQWaq6iE++9957Zu3ev48vWUid/7777rtm/f79xQ/MNFT5nFN0+N954o20rVritL7Wo63tug1YAAAAA6cf/hUeRhsofOXLE/vsNN9yQ7st79NFHTfPmzW0VhapX9CYxvVVDAKJHlXZOl1d89NFH5ocffojoetReG6zCMBBVhmkOYTAKBxVYKcA8dOiQqyBSs/zCbdN9/PHHzfz58+2/a0trsE2twQSqVtO8vAcffNBWtOXLly9k+PfBBx8E3D47bNgwU7VqVUfnoKUawbbuprVmzRrjhs4vbXt3JDTz0e1mYwAAAADJiQAwBu2/epNYtGjRdF/e5s2bbeWE3pxrhpdarJ544omoVvMAiJzCKDc+++yziK4nkk2qgX7m2LFjdh5cxYoV7ebYEiVK2C3jt956q6Nz02uR00o1tSz7Kvb8Z/E5oYrBt956y1bxdenSxbz66qt21uorr7xirrnmGrN27VobMirs89Hv06tXL9v2euWVVwYNFvV7avuuAsVA8uTJY1uWdYxTbsJZ0bZl/+pJtz/vow+gvv3224h+FgAAAEByYQtwlKh6Rm8007v8Q29ItSVUA9WLFStm35SqokiVQlOmTLEbIufOnWuH0d9xxx1hL2/ixIl202QgV1xxhd1GqsvXMHkgEF9FG48T46i1123wE8lzT89/vTakbbkNRsGezs3//FTppxZYVS770/2s5RT60ibZUMHXG2+84ficNdNOQZ42DDdp0sTxHEC1FyvMu+mmm+yXj+Yf+m47jVtQNaACQl8gqS23vjEM4W5j/Z4PPPCAbavWsgpV0RUqVMhWB+r1WMsr3NxPbpddKPBTcOdbTJKeeXm7d+/m9TwB8ToLALzGAkAwTrvM0iIAjJLPP//c3ikK1GrVqhXx5ejNsb78qQpQVYVPP/20raLRm2ht0dR2z1y5coWtCAm2AdS/DS/SBxQyFx4noakCLe1Ch1AU9ERym+bOndvccsst9nXAiVatWp1yPZ07dz4l/EtLFXaFCxcOuPxCVchqGXZDxyvkUvCoir6jR4+G/RktrHB6G6nK0b8K0M1tq7BQwaS+0nJ7H2kRipNZkGlfj33Xow3AmuenCk23dH/xPE1s3H8AwGssAHiBADCM559/3mzatOmU7yvU0xvRYHztclWqVAkbykVKb27btm1rA0C9cVbFYfXq1cNWFKp6JhD/JSUMaYeTN6M8TkJTcLNs2TLHVWLpWZCgajdt2P3rr79CHqctsGk33q5evdpxu/KQIUNMixYtUm3Q9QWA+p6bkErtvzqPCy+80AwfPtzcd999ITcZqypPQWeiUcWlmwpNvU5rRqHvPlIwrPts7Nixrq738ssvN2XLlo3onJGxeJ0FAF5jAcBrBIBhHD582Bw4cOCU7/uWewSixRxq5Utv+6/T6g7NpFKLmpOWNFX+6CsQLRVRG6DedKrdDQhEjzO9OeVxEp6q6rTx1slcvHvvvdfxUolA9JzVtlm1qOp1KxDNIv34449PCYW0ZdYpvbapPTVQEKf2XN/mcyfh37XXXnuyvdX3+6uyWRXU/i6++GI771QfeERC4aTaahVQRjIv0QsKNzWr0AlVRCo09Pf666/b517aBSGhaA4ir+WJiddZJJp4eJ0FnOI1FomG11ikFWnRCAGggwpAt3zVf2o901w9AJmTqn+nT59u2/NDtbeqUnjgwIHpvj5tG9cCDG2zVbXY77//br+v+aGdOnWyIVT+/PlP+bl169a5uh4dHygA1OU7DQC1zTztbDvNOtXrpxYeab6p3kyWLl3aVKtWLeHfUGomodqcw21VVvWfZhCmpQpCBbyqlFSorNl+oTz88MPmzjvvTPd5AwAAAEgObAH2mFq8lixZYv9d1S3RbpHUJ1iq/hO3mzQBRJ/mvy1cuNCGfGllz57dBnNqv1Xw4wXN1Bs8eLCd9blnzx6zb98+O2tPG3ADhX/idot4sOO1iCjYht20Mwt79+4d9M9VodiyZUtbCaexBoke/vnuFy1S0e8ejB4DWjxSpkyZoFWTChJ37txpxo0bF/ADJv2slrHoMZAMtxsQLRpXMG3aNBu4q1pbM5V37NjBDQ4AAJIWFYAe0zw+3wwuL9p/9UY71Ju4t99++2R1iOY9AYg/Cv+0YOObb76x7a16jdCMN7XrBgvl0kszPYPN+0yrXLlyYReApD0+EC09mj9/vmnQoIFZtWpVwGPy5ctnQ65LLrnEZDb6UEjt0xq3MGHChJOt2pr/qNEMPXr0cNQGrg+W1A6tL1VL6rZWtaQWRtWoUYPZnEAYEydONI888oj9kMSfPijRjFO13IcK6wEAABIRAaDHfO2/mlmlYftONGrUyP5T7Vqqekk79L5u3bqmcuXKJ4fCKxT84YcfzNSpU82KFSvscc2aNYvashEA3qhUqZL9ijdaaPTmm286OlavQ2ppDkaho9qA9fqkN9ErV660G21VAac5fx07dnQcTCajUqVKmREjRtgKve3bt9vXc7VoR1oBqmpJFn0Azul1SRV/gWi+7aRJk+z/Yy1YsMCzymwAAIB4QADoob1799r5W75ZXF5QO4remOtLg5VVKaJZYr5Nm6oOvPXWW23rHQBE4uqrrzb16tUzH330UdhjVSGjVtRQVAnYunVr+6WAS19sjE5Nr+X6oAhA7Pz00092Y3o4y5cvN/369TMDBgyIyXkBAADEAjMAPa7+06fHasfVMHsvdOnSxdSpU8dceOGF9pNotQ6qtU/bPPWGXa1kqqoBgEjpg4R33nnHVK1aNexW2WCVM6Eum/APQDwYOXKkrUh2YsyYMSGXNwEAACQaKgA91Lx5c/vllgbDB6OQT18AEE1nn322nU+oN71qUd20adPJP1OlmmbT6Y3zrFmz7AbgcFWAyHj6wEjLYLRsRkuiWAqCzO7dd991fOz+/fvNF198YcewAAAAJAMqAAEAloIitcdt2LDBfP/996Zp06Y26FMYqA8qNLeuSZMmdp7flClTuNXilJaCaKmIFq6UKFHCFC5c2G4HVsW4b/EIkBlpK7obCgEBAACSBQEgACCVf/75x7Rr187MmDHDHD9+/JRb55dffrELizRMH/Fl9OjRduu0Fhn4ZsXKjz/+aLeeqs1b9x+QWSud3cibN2/UzgUAACDWCAABAKkMHDjQLF68OOytompBBUuIDx988IG577777CzaYNavX29buE+cOBHTcwPiQYMGDRwfmzt3blOrVq2ong8AAEAsEQACAE5S1ZgG5TuhmYBOj0X09e3b125cDuebb74JOXsWSFZulhi1bdvWhoAAAADJggAQAHDS0qVLzZ49exzfImoTRsZbs2aNWbFihePjR40aFdXzAeJRuXLlTJ8+fcIeV7ZsWfPMM8/E5JwAAABihQAQAHDS3r17ozpUP9mo4k4zE51U3kWTWnvdWLduXdTOBYhnCgBfeOEFc9ZZZwX88+uuu84sWrTI5M+fP+bnBgAAEE1Zo3rpAICo0zy3999/36xdu9YGUZdeeqlp2LChyZYtm+vLcjv0PrMOyVdAMHz4cDNv3jzz999/2w3KNWrUMI8++qipV69ezM/HbQCZ0YElkFFOO+00+zxt3769GT9+vPnyyy9tiH/hhReaNm3amMqVK3PnAACApEQACAAJbMyYMbZVbdeuXam+f95555mePXuabt262Te8TinE0tyrQ4cOOTr+pptuMpmJFmw8+OCDZujQoam+f/ToUbNgwQL7VaFCBTNr1ixTqlSpmJ2XQl+3rZBAZpYvXz7TvXt3+wUAAJAZEAACQAJR0DdhwgTzww8/mNWrV5uvv/464HGa46egatu2bebll192fPm5cuUyd9999ykBVzBdunQxmYnC1nC3jSoxFQIuWbLEVKpUKSbndcUVV9jKpWCPh7Q6duwY9XNC9Bf2zJ0717Zzq6JToW6jRo3MmWeeyU0PAACAUxAAAkACUJvpAw88YMaNG2er0Jx65ZVX7EyrW265xdU22Y8//ths3rw55HGPPfaYDZ4yi/3795tBgwY5vr9uvvlms2XLlphsElWVp2abKQAK56KLLjK//fabGTx4sDn33HPtY0PVUEgMCvvUft6vX79TFvYULFjQVv4q/HdT+QsAAIDkxxIQAEiASp86deqYt956y1X45/Pqq6+6Ol7D7xcuXGiuueaagH+u2YLPPvusGThwoMlM3n77bTsrzCmFMxMnTjSxoiBP1Ymhgp8cOXKY77//3obJmoPWtm1bU6RIEdOpUyfz559/xuxcEblevXqZrl27BtzWrSU+Dz/8sP1iziMAAAD8EQACQJzTm/2vvvoq4p/XXLpAYUEohQoVsosuVqxYYTp37myr2W677Ta7PXPnzp2md+/ema7CaNWqVa5/ZuzYsSaWFOyp9bhp06YmS5YsqWZCauvpX3/9FbBacfTo0ebaa681Bw8ejOn5wp1PPvnEUfA+ZMgQuxgIAAAA8KEFGEBcUvXK8ePHzRlnnJHpgiZ/aiHVoo/0GjlypG0Rdeuqq66yXzDm33//dX0z/PTTTzG/6apXr26/VNH366+/2iCwbt26YUPgb7/91raOxjq0hHOvvfaaq8rfBg0acPMCAADAogIQQNRDE7WTqhVyxowZ5pdffgl5vKrOmjRpYquVNMxeSylat25tK9EyI4V2XrTyvfPOO7QEplMkW30VYGeUPHny2Hl/3333neMgctKkSa6rRdNDLas6t4xqP9Zz67PPPjPNmjUz559/vilQoICpWLGiXZzzxx9/mHiizdzz5893VS2ouZUAAACAEAACiArNqtMCipIlS9olFArx9Ca7WLFitj0x7YIJHa85ZGpDfPfdd0/OWlPLosLDKlWqmCeffNLTEEsVhqp6Wrx4sZ2LFm8zs3R+7733nieXtWnTJvs7InL33HOP65+5+uqrM/wmnzx5sqvH3MyZM6N6ProOzbPU1mItIVGwevbZZ9s28w8//NDEilqf9WHD9ddfbz+c2L17t/n999/tdu0ePXqY0qVLmy+++MLEC4V5bl+jFLACAAAAQgAIICpVf3fddZcdRL99+/ZT/kwBQ9WqVVPNVNNGWc0hC+X555+3lTnppWqjp59+2hQtWtRUqlTJLrsoW7as/Xdt2Y2XIFDtm4FmtkVKlVZqIVRLr2b8lShRwrRp08YsW7Ysbn7neFamTBkbYrtx//33B/0zhd5ff/21+eCDD8zSpUvN0aNHjVdOnDhhq20VaoWruk0rmmH4kSNHbNDXrl07880335z8vq5Pt8NNN90U9QUWP//8s5k+fbqpXbu2mTVrVtDjFAbqXFVBGQ9UDe1WLDZQAwAAIDGclsK7PvzPSy+9ZFuM9IZB1Q9AsFBKwcXpp59uQ6RAtCji8ccfD3sDFi5c2M64U8ily3Ky4VYbaNWap22mkVB74w033GDWrVsX9BhtRlWFkn7HjLRr1y5zwQUXeHZ5efPmDbrkoVWrVubNN9+0t69T+utj+fLltr1Yj4ucOXPa21ZVVW4uJ9p0ngrEsmbNmu55knqNrFmzpqNQSLfFRx99dMrjSOeibb3Dhg1L1Zqr9tP27dubnj172vsqEjt27LAhrx6/CrB8bciqunPj0ksvNV26dLFBnVrxvdK8eXMzbdo0R38fKQj00sqVK23w77bKUNuV58yZY+LhdVYfUqhq2el9qNe5zDxDFYn5OgvEw//LAvGE11h4ld1QAQjAUwoa1PrrhKqTFB4NGjTIUfgnx44dC1spGOovT7Ufhwr/5O2337bVhhlN/1OqFkkv6A1ZqA2varNW+OSUgqtq1arZLy0bmDp1qg2dWrZsadu81cadjPSXrDYy33333SHf5NapU8dWuqYN//T4bdy4sQ230s7lU4unngs1atQwv/32m+tz0/bfChUqmMGDB58M/8Rt+CcbNmywAaDaY72az7d+/XpH4Z/o+edlRaSqC2vVqhVRi/G8efPMtm3bTDzQRm43xxLEAAAAwIcAEICnFixYYD9ZdUphnt5gu6H2vUgoINGXEwoxNSMsI2l7q5tQLhQnxd4TJkxwtGxFYYiq4FT9F6zKUkGrQsFkpAU12pSr20FzK1XJqqBP37/xxhtt+Pnxxx/bJRxpPfHEE2EXOSgoU6WcmwJ9tbU2bNgwZMgbCbUmK9T1whtvvOH4WIWhodpz3di5c6dt3fbNFXXLV+kaD1SdrJmq4ej56dVrBwAAAJIDASAAT7mt/FI13r59+1z9jJuA0Z9aXJ1SBdXs2bNNRuvatatnVYBOvP76647OSdWb4UITBRBeB1LxRDMkR44caWfsabalWtkV/N122202vE1Lres63gltzlbLqlOajRmt21qBpf+8zkiFq7xN7/HB6DbX7MH0iDQ8DHV5Ws7ywAMPmI4dO5r+/fs7qjJUO7fakW+//fagxygI1n3mZes2AAAAEl/WjD4BAMkV/o0ZM8bVz6jKTm9q3VAbZSQ0bzCax6eHlkGoslGtn2ozrVevnv1SG7DaFrUcQZV1bqkqzU0lY7gKya1btzqu2Dx8+LAZP368DQxhbEWkm/tCLdVOtgirVVZt69Gk5/WVV16ZrsvIqJHDegym14UXXmi8oupRLT1K+8GH5hPecccdZtSoUWGXgai9fM2aNfZ+Wbt27cmZfx06dLBzAgEAAIC0CAABeEJzwu65556IQgFVuLmpXtKMuUg4nTPoE6iKy2uaA9e6dWvz5Zdfpvq+FjloS6/e4GsOm5ZOqJJJLdNaDiJnn322vd2D/V7ly5e3Sxweeughx+cTbu6awj83Qc57771HAPg/aWf+eXW8Nm1rCLAb559/vqvtwGpLTq9y5crZEQFOKdBKL1VmajFKeuh5qJZaL+h53b1794B/puexZqL++OOP9p/Zs2cPeVmXX365XSQDAAAAOEELMABPaH5cpMsCKlas6Or4q666KqLrcRvo5cuXz0ST5rZp4UPa8M//z+vXr283ySokVYWQwgy1J2tGmr50jObK+bbYaRadFnPo/lBVodsQRW2toRw4cMDV5bk9PplpO2Y0jo+ksu6uu+4yseZmJl3+/PlDtrk6peeD2wrjtLSwxYuN4D/88IOjMF6t304XKQEAAABOEQACcUybONUGqLls77//fkTbPGMl0nl5CjluvfVWVz/ToEGDiKuB3FALazTdd999YecZnjhxwlYI+lpHtdVTwaQCEoUSqoYcMGCAncmnuWJ6jChQbNWqlcmWLZtdGKBqLzdLBkLR9cZTiJpInLTzRnK8QtscOXI4vlzdh1WqVHF1LqomTS9tKG7SpImjYxVqq309vfR8qV69esQ/rwpabUP2wogRIxxXIU+aNMnTLcgAAAAAASAQh7Rx8tprr7Utc3oD2rlzZxt6aQ7VoEGDXLeyxoKq0iKhyjW1uLqp4vOqHS8cLXWIls2bN9uFEU7s3bvX0eZjBX5pK5VU/fTggw86uh5VGYarDNOCATfVUFqIgf+77ZyGsW42QCv8U+Dr1L333msaNWp0smrUCS2q8MK4cePsa1soWozxyCOPGK/cf//9rn+mVKlSZvjw4bYFXyGiF9xsNdbCGCcbuQEAAACnCACBOKOFD7Vr1zaLFi065c9U5aXKmDZt2sRdCKh5dJFo3ry5mTZtmqsqvkirDd1u043m9l3NxotWeBCohfHOO+8MeUyePHnsOWnBQCiqOHRasanLdBNMJTtVuw4cONDRsZoTd8EFFzi+7B49epicOXOGPS5v3rx2JqOC4d69ezu6bIWF/oslFE7NnTvXTJkyxXz22WeuKpP1+FJLu+ZZqiLQ34033mg33GpOnlehm6jqsFatWo4er6+++qpdhPP999/bD168PA+17Luh2xkAAADwCgEgEEe0AVZbINXKGa49LN6Gv7tt4/Vvgw02Ay+YZcuWRXRd4UIwfwpIvJhB5lXFZKQVlr5qsokTJ5rBgwefEiqpmk8Bj27TqlWrOrq8oUOHhp0VqMvVtlOFKvg/auceMmRIyGBJm1xfeOEFVzfbRRddZLdwh2oFVvin4M63REeVcfpAIZRrrrnGPnZ8H0CoIllVjHrMtGzZ0lbvqjK5X79+jrdzq1K1U6dOdoutFpGoGlbhmCpib7nlFk9DN1/wqmAxVOVhkSJFzBdffGG6detm53J6MfMvvR+S8NwBAACAlwgAgTjy5ptvOt7mqRAhnqoAVZUYrnosrWeffdaULl06bOCZltOgIS0Fek5bMBXEummRdMvtbLxIKyz9Q0BViWlpyKeffmpbMbVpdOvWrbbyz82yEIUlqpJSOBSIQkZdZjQD1GhQ1dfkyZPN22+/bX+/aD2/VN23du1aW2F2zjnn2O/lzp3bNGvWzCxcuNBueo5kA3XdunXNN998Y9t1/asBddlqq/32229TVcIpaNP8SAVvak/2D94uu+wyW6X3ySef2J/XRmLNJNRM0rSz6RQMqppQ4Z2b57Kur3Dhwja8dDtb0i09f/S41xZr/a7nnXeeKVCggP2d9Htu2rTJbtWNJt0+bsI/t3MaAQAAgFBOS4lkfSCS0ksvvWTDJ73ZU1CA2NPMPy3+cGrx4sUxm4fno6UVCkZUIZM2IFOgpKqgcC8rqq5TxdCjjz5qQwC1qLrZetm/f3/Tq1eviM5f1YYKSo4cORL0GIVhum2jGUqsX7/e1WKFN954w1ZfxZvVq1fb+12PCwXAqghT0OF242006fGoZSo6J1/Ipcfw9u3b7XIV/VMVd2pn9VemTBk7L08hneZBqiX85ptvTlWZtW/fPhugaduxQl09thQsueF7PnlJ56uN0fp9VfGXPXv2sD+jLd76fXQ/FixYMNVtdcUVV9jQMhzNm2SDbfqf86oC7du3b8DXWSAeBXqdBeJVqP+XBeIRr7HwKrshAES6H0Twtkrl4MGDjo9X8KIZevH0P01qQ1RrodqZA/1+qk7SgH8FDP4hUsWKFR1dv65XVWy+NsZIqEpKmz2/+uqrVN/XGxdV/qnFNdoVSaINvar4CkfBksIcJzPeEPp/mhSMaRurNmvrceSWwjGFgg899JB55pln7Bw8/6o3BW0KwbWsx1fdlwxzSW+66SZHx6oFWW29ajfGqZ577jnz9NNPh/0gaObMmfbvYt6cIlHw5hSJhAAQiYbXWHiV3cRPiQYAc9ZZZ7kKAHV8vFHbpzYWKwhcsGCBOXz4sA0KW7RoYdvtAlUGqLpICwDUbuhkjl96wj/RQgPNvFNLpK5T56iWQJ27WhJjZdSoUaZ69eohlwP4ZukR/qWftinXq1fPBs6R0mNFSyp03wVqd1V7rNpkVUGqLz2uEt348eMdH6uAVeGVQlKc6qmnnrLPZYWAgaqQ9fjUzEUF1vE04gEAAACJjwAQiCPa/jt16lRHx6qN1unShlg788wzbeCnL6f0pldD+jdu3Bj0GN+8Lq+o6tBp5WE0aPaZQiLdTlqIkJaC0zFjxtiZZUgfhSkKeNMT/vkLN+tuy5Ytdi6mNt66pU3X+kRPQZGe5xlt27ZtUT0+M/GNPFA7v17zNJJAM021SKVt27YnNyOrOgUAAADwEktAgDii1lmnmjZtameSJQv9LkuXLrULEtJuv9RMtZ49e9oZbSpzTiaXXHKJrURctGiRbUvWIghVTykI1mw6wj9vfP755/bxFUuaDai5b07p/FThqjZatX2rnVitt1pckZHjehXoR/P4zEgt0nq+a6P79OnT7YZuX/gHAAAARAMVgEAc0VZVBQCa7ReKAjEt0Ug2Cj203VhLPlQZp3ZozeLT5lInSwwSuSpI932wrbrwZsN2RlBru9q4Ferp/tXmX7Wg+1O4py26etynrVrU/D19tWrVyraCZ8RylWrVqtkA1Sm1tQMAAACIL1QAAnEWBI0bN86+2Q+maNGidrZeyZIlTbJS62P9+vXtghMFKMkc/iE2QrWWR9Pu3bvNrl27bEuwQsjKlSubTp062RlvPpopmDb8S0vtohm1nEmLe5xu9bz44ovtKAMAAAAA8YUAEIgzap+bMGGCWblypW0FVYuowj5tjH377bfN5s2bzeWXX57RpwkkFKcBViyMHj3adO3a1f7733//bZ599llHPzd8+HCzc+dOE2uaT+ckfFSl48svvxxXtzUAAACA/48WYCBOXXnllRnWtggkm/Lly5t169aZeKFlNpr5+d1335nff//d8XIQvSb06dPHxNrAgQPt4pOhQ4cG/eBC1cuaWQgAAAAg/lABCABIeu3btzfx5vXXX7cLYNxwe7xXsmTJYluVV61aZSuTL7jgAnP22WebsmXL2kDyxx9/tPNLAQAAAMQnKgABAElPi2Tq1KljN0nHCy26ueGGG1z9jKoAM5JmGFKZDAAAACQeKgABAElPc+mmT59uqlSpEvI4VbUVLlzYFCtWLOgsOx3TvXt3c8YZZ6TrnI4ePWouuugiVz/j9ngAAAAAEAJAAECmkC9fPrNo0SIzYsQIOxPQJ2vWrOaOO+4wS5cuNX/88Yf55ZdfzLZt22xb6+OPP24qVqxoypQpY2rWrGmGDRtm/2zIkCFm69atpm/fvvbPS5Qo4Xozt9poW7RoYc466yzHP9OuXTtX1wEAAAAAQgswACDT0LIKLd+47777zP79+81ff/1lzjnnHJMjR45TjlWop+UX+grk/PPPt/PvfEs5tCRDod6+ffscnUubNm1sKNmlSxczePDgsMffdttt5tJLL3V02QAAAADgjwpAAECmo/ZeBX9q9Q0U/kUaLj7wwAOOjvWFjnPnzjWdO3c2TZo0CXl8tWrV7JZdAAAAAIgEASAAAB558sknTaNGjcJu1FWVoNp/dWzp0qXNsWPHzFNPPWUqVKhwShXioEGDzIIFC0yePHm4n5Auv/32m3n++eftLMls2bKZnDlz2kU0M2fONCdOnODWBQAASGK0AAMAYu6///6zodbEiRPNrl27bDXcNddcY+655x5ToECBhL1HNE9QYYpCu6FDh5o9e/akqjpMSUk5ZZOvbgtVAn766adm1qxZdpagAsK8efOasmXL2sAQSK+FCxfaNvIDBw6c/N7x48ft81Bfev699957dskNAAAAkg8VgACAmNqyZYu54oorTN26dc348eNt+KAA7NFHHzVFihQxL7/8sg3KEjkEVCXg9u3bzfvvv2/GjBljHn744bC/099//22aNm1qw1C1/GreH+EfvLB27VrTsGHDVOFfWl988YVp3LjxKQE1AAAAkgMVgACAmNEG3Vq1aqWqjPOnRRo9evSwrYpa1qFAUIFaIlKL5U033WT/Xb+zE4cPHzajRo0yzz77bJTPDqEorFUg9u6779pqTFXFNWjQwNSrVy8hQ1ktqjly5EjY47Qle968eebWW2+NyXkBAAAgdhLzXRUAZKBDhw6ZyZMn2zfLqtrS5tdWrVqZq6++2rZ5ZhYK6xSQqIpP1W7Zs2c3NWvWtBt2L7nkkoA/88gjjwQN//yphVZfagdu166d6d69u926m4h+/PFHs2TJEsfHv/rqq+bXX3+1t6eCQ4UxChMRu2q5u+66y/7T34gRI2x7tpaxOA1048Evv/xiW3udev311wkAAQAAkhABIAC4MHr0aBtiKQT0N2zYMNu2OXXqVFO0aNGkv03XrFljQwJV9Pn75ptvzGuvvWa6dOlihgwZkqp6T0GEZty5sX//fvPCCy+YsWPHmg8++MBUrlzZJJq0t1E4f/75p20bFs0RLFSokHnllVfMnXfeGfLn/vrrLztPURVqegyeccYZ6TrvzGjdunU23Dt48GDAP//pp5/MjTfeaD766CNTu3Ztkwj0nNScSadWrFgR1fMBAABAxmAGIAA4pGCrU6dOp4R/PsuWLbPhwe7du5P6Nv3hhx/M9ddfHzLYGj58uOnatWuq72nJRaTzxfbu3WvbaZ1UD8ab9AZxqgbUxmCFgnpsqdry6NGjJ/98w4YNpn379uacc86x211LlSplChcubB577DEbusJ526+W0AQL//wrX1u3bp0wW3O1YdoNLQYBAABA8iEABAAHduzYYWfThaNQTMFLMuvZs6etzAtn5MiR5uuvv05V2ZYeCgHVnphoLrvsMnPWWWel+3I6duxo26AvvPBCky9fPnPvvffaULpSpUrmzTfftO3oPrp/XnzxRVOxYkWzevXqdF93ZqDKt1WrVjl+PZgzZ45JBGpbdqNEiRJROxcAAABkHAJAAHDY+uu04mfatGl2iUUyctvG6wvsVF31+++/e3I/uGlnjAd58+Y1LVu29PQyVQGotmjNRlRFWjB6HNavX98uskBobubkRXJ8Rrn88svtl1OqggQAAEDyIQAEAAfmzp3rquVO7a7JSMss3LTxfv7552bBggU2gNAm0vRSC+yBAwdMonnqqafsQpOMoLZpBacI7Y8//ojq8RlFi4kef/xxR8cWLFjQ3H333VE/JwAAAMQeASAAOBBuLlh6j08UWjThhlpR69Wrd8pG1cymePHi5uOPP7YLPTKCAkBVYSI4tVVH8/iMpBmSTz75ZNhKVX3QkUi/FwAAAJwjAAQS0M6dO83TTz9typcvb4f9X3LJJebRRx81P/74Y0afWtJyW72VP39+k4w0g84NLUyJdPFHIHq8n3322SYRaVbfpk2b7Ny+K664IqZbejWb0n9GIE6lrdbRPD6j9evXz24pv/LKK1N9P1u2bKZVq1Z2BmKVKlUy7PwAAAAQXVmjfPkAPPbGG2+Yzp07p9rUqC2hChZefvllM3DgQBsGwlu33357qoUWoWjhg6rektG1115rq9j0mHPC63l9HTp0MKefnrifXanKStuRixQpYpo0aZLRpwM/V199tQ3HnCwCKVq0qGnUqFHC3X533HGH/Vq/fr3ZunWrDf+0KEYbpAEAAJDcEvddFJAJvfPOOzYA8Q//0oYt2kA7fPjwmJ9bsmvXrp3Jnj27o2PbtGmTsFVq4Sgw6NKli6NjoxHUVa9e3SQDVQHGkja75siRI6bXmWg0K0+LVRTShnLmmWeaCRMmmKxZE/cz1HLlypkGDRqYG2+8kfAPAAAgkyAABBKEFks89NBDjo594oknbOslvHPeeeeZMWPG2JAg3BvrAQMGJPVNr4UCDRs2DBuSRCME1X2Q6LSZd9GiRTG9zk6dOsX0+hKVxiosXrzYXHbZZQH/vGTJkuaTTz4xtWvXjvm5AQAAAOlBAAgkiPfee89x2+Xhw4fNxIkTo35OmY3mZM2YMcO2b6alYFAzwRTsJPsQfc2ue/fdd+1m20C/a40aNez232hsvZ09e7bdapvI9u7dG/O5jaochjMVKlQwq1evts/lbt26mbvuusuOXXj//ffNli1bTK1atbgpAQAAkHASt38FyGRUleLGkiVLzP333x+188nMswA1+0vbMr/44gu7WEGBYMuWLU2pUqVMZqEQ8LnnnjO9evUy8+fPNzt27LBVfzVr1jxZPaX2QgUmXtJCkc2bN9uKzESVO3fumF2XlqZ8+OGHSbuUJloU6F9zzTX2CwAAAEgGBIBAgjh69GhUj4dzmv1122232a/MTgtPmjZtGvDPFECPGDHC8+tMSUkJe8wvv/xi24U/++wz89dff5lzzz3XhrQ6VwWVGUkLJLS5e+PGjem+rCxZstjtrgpgx48fb6t/RQGpqv4eeOCBhA5LAQAAAHiDABBIEMWKFXMdMiBx7d+/37Zxq9pNAdaff/5p8uTJYxc5aFNp8+bNTc6cOTP6NMPOU3vkkUfM4MGDw4ZYquxzulikbNmyIcPBF154wbYnnzhxItWfqYVT8zHVvnzVVVeZjKwu0yIVhXNu6P7X48BXgdmsWTM7F1SPB3nllVfsmADdntrUrH8mgp9//tm8/vrrZtasWWbfvn12dqQWVKjt9tJLL83o0wMAAACSAgEgkCBUvfT00087qn7ybaJF4tGGZ4VU2uT8zz//BD3u4YcfNn379jXdu3cPu5gkIw0aNMhuDh44cKDdUp2WwrzGjRvb45zQnEWFW8HoetSWHMzOnTvN9ddfb5YuXWpnvWUUVedNmzbNtpGHo9vv1VdfNe3bt7eVfloIpLl+aVuJdZzbDwoymoI/zdnzD2sPHDhgH/+qHtVjvHfv3nH9GAcAAAASAUtAgASh7ZOaP+eENlRWqlQp6ucEbykgU9D78ssvhwz/5ODBg7b6q0+fPnF9N6hir3///mbr1q22Ku/aa681VatWtdVrmqO4fv16G3hecMEFYS9LVW89e/YMGe7pOsLRhuyMDsgV1s2bNy9kG3nBggVtAKbQ77777rOt5yVKlLChaSznCEaLKlxV5Ze2UtNHH3bo8a3nQyC6XVTVqcfR999/H+WzBQAAABIbFYBAAtFMsx9++MGsWbMm6DGlS5c2U6ZMiel5wRua4aYtw25oEcctt9ziaUur5sh9/PHHdlut2k7r1KmT7jlyaknXuQailk8tqqhbt66d3RcsMJs0aVLI31NVcoGqDAPRlldVlgU7p1hQiKd25LVr15o33njDzgRUpZtap1UhePHFF5tkpSpGtYc7oYrOe++99+TG6ZUrV5rHH3/cbpr2V7FiRfP888+b+vXrR+WcAQAAgERGBSCQQPQGWC2DaplLWwGkZQwKDb788ku7+ROJRdVOQ4cOjehn1S7pVfCnqkK1lzZp0sRWnakiUeGd/qkKu2gpV66c+eabb8yTTz5pF3b4ZM+e3YY/X3/9ddBlIz7Tp093dZ1anvHRRx+ZjKZWZIWXCl11Pi+99FJSh38ye/Zss2fPHsdhoaqf9RyZOXOmqVKlyinhn3z77bfmpptuMi+++KKJhSNHjtjt7Aqv9aGM0/EMAAAAQEY4LYX/Y8X/6E2nWuMULPXo0YPbJc4prFmwYIH5/fffTd68eW2Vliqpok1LBlRlpdbOULPY4M727dvNhRdeGNHNpuesbzlEpPTc12w8VVcFo2BQgYfa0aNJLaEKG/VPXacWnzihENzt9mu1yy9cuDDCM0WkHnzwQRt6uqGAXB9+OPnfFoWpN954Y1TuIAWXamt/++23Uz3vtLBEv5dmNaZ3ZiGvs0g0el7qNVujCpjZiXjHaywSDa+x8Cq7oQUYSFC5cuWyCxGQPFt/I6UXf98br0hpI22o8E/UnqtKLFVaRfMNnn6P4sWLu/45p+2//hYtWmS2bNliypQp4/pnEblwMy4D0XxHp59ZKoTbtm2bicbG4uuuuy7gZW/YsMF07NjRLFmyxIwdO9Z+SAIAAADEC/7vFEBCUSto27ZtbWWYWqLVKqnNr5pXl8jSU72ZM2fOdIV/u3fvNpMnT3Z0rFodA7VfxgNVwkZCASBiK5JtxVp846aiVo9rL/3777+mUaNGYYNFzfJ84YUXwrYPv/XWW+b++++3oxv0GrZr1y5PzxcAAADwRwAIICHozbdmwV155ZX2Dbbe3B84cMBs3rzZboZVoKCtqonk+PHjtg1F1X9q/1ULYSS0BCQ9pk6dGnQTayATJkww8ejmm2+O6OeyZMni+bkgtLvuuivqFXLz58/3/PLWrVvn6NhXXnklYJWjKhjV+lykSBHTrl07M3LkSLsARq9heg3Qa9xff/3l6XkDAAAAQgAIICGopU9tdcFo9ptaorUkJd4ptOzcubMpUKCAXdhyzjnn2O3NF110UUSX16VLl3Sdj9vlHtFcBpIemg/nlkIoLeGIB6os08bbsmXLmvz585sSJUrY+9Zp6JRIFNiHW+qSXsE2Skcq1OtPWr/99pt5//33T/n+M888Y+cEBqpm1Iccuo6GDRtG1CINAAAAhEIACGRy2rA5bdo006BBAxuEqMJOQcrGjRtNvNBsrXHjxjmaAdeqVSsTz2bNmmUuv/xy8/rrr9vZff6zxbQZVYss3OjevbupWbNmus7J7XW6PT5WKlWqZDp16uTqZxS2qCpLLeQZuRNLVWCaQzhgwADz/fffmz/++MNs3brVjBgxwj4vn3766aTbMjtmzBjbvh4tl112maeX99NPP6Xr+FWrVtkAMBy12Ou2AQAAALxEAAhkYuvXrzeXXHKJad68ua1WUaWRZuxp26baUVWl5qY1NFqefPJJx8fu2LHDLF++3MSjFStW2Ns6VHXP33//bfLkyRP2ss4880zTp08f22qYXtdcc42r4/U4eeedd2wLczAKsGbMmGGDrXfffTfdW4qdGjZsmLnvvvsct/5qW+wFF1xgzj33XFOqVCk7u83NrDkvKIDXHLhQt+dzzz1nBg0aZJKJHudDhgyJSqu2ltTUr1/feMntnM0zzjjjlMemU/rAQxWBAAAAgFcIAIFMyrfNMlRVi6rUNKQ+o2lTqxsKneKRQpxQIY+PwjJVgmnrqdokFWQopNOsvxYtWti171oY0LdvX0+28V5//fW2BdnNY0fnce2115rff/891Z+pkk7t2lrS0qxZMxtsNWnSxM4806Zhp+Gaqt10rOYjuglCFNLocasqKrVYh6LLVeu4/+/1+OOPm6uuuspW38WCAvaHH37Y0bGqHkvPtuh4dPfdd5s6deqEPU4fVGhmnlN6bGbPnt14SY+L9ByvCl+n9PxOxtZvAAAAZBwCQCCTUrjkZHOuwrRIK+q06XL06NHm6quvttU+2tKqIGvixIlBq+C03ENBWZUqVewstOrVq6dqlXXC6+2fXtDcPDdLCbRoQ7fD9OnTzQcffGBD0Dlz5thtvQqMwoVbbufgvfbaa66XMnz55Zd2K6qvSlQz16pVq2befPPNVMGaHD582AwfPtzUqlXrlNDQn+5rVTVqu7M2I2s+or40N+3HH390FQBpE6yvhdZHlxkuNNVW4JtuuslWY6aXbhs9D4K172pxjdPtr7pNnbTCJxIFtgrGQi2yUZC2YMECWy2ox4KT6thJkyZ5fKbGcWWpr/24atWqqcJmt5WlWnIEAAAAeIUAEMiENKBewZJTqqiKZNGFghfNZFu5cqUNdlTZtnjxYtO6dWv7pj7tMolRo0aZ4sWL23lnapfVLLRly5a5bkOO9nbRSNut3cxw27Rpk4klBV7aBpwjRw5XP7d06VIbTErLli3DhnRr1661FYLBlmBoBqUCTt33/kGINqfq8eRm07N+F1Wwrlmzxj72FMAolHFyP+j2V5tzMAoHFdI+8sgjpkePHnZmm6/NWY9XBbUKO7Nly2Zy5cpll3qoAjLt/arbz23oGg2rV6+2gbN+l/79+9vHa6zkzp3bvPfee+arr76yFYFXXHGFDdBUQfrRRx/Z72tZjmZPfvfdd7ZlOxh90KBZezreazovbS928vozcODAVEGz2pf1OHDDySgAAAAAwCl3A20AJAWFCE5aUX0+++wz1wHjDTfcEHJbrIKgunXr2qBPb4y1/dJNhU24DaPxxm2IqYUmCqxUNRkrajeuXbu2rbR6/vnnXQXEus2dtmqr4ktBoWbu+fz111+21dk/+AsUuukc9fjVwg831A6qSjsFSk4pkL7nnntSfU/hoSoU+/XrZ+cc+nvooYds4KjAO+1toRBTFZC6zLfeesuG4L4lPG54vR1Wy37Upp02iFSFsEYEKNj0v5+iRWGZqn71FYqCPY0t0AcYeozqcaTnilrOFRzfe++9UV0soopoPQ411zLY3D/dvwrU01KV45QpUxxdT6FChUz58uXTfb4AAACAT/yVyQCIOrUkRut4BTl33nlnyPDPP3zQG2pdvsITr8RjAKg39G6pIi7WChYsaCud3FDgpbZupxSipW3RVMWck6pHBWCqUItFFaZC6rQ0I1BVcmnDP9HjePDgwSGDUAXBqnLT8pFIHqtePrY1Y65GjRpBqxA1R1Et3WqJjicK2VRtqvNXGKfHhOY3du3aNarhny9I1nIbLU3SBmlfxaye33pc6DUt2CbyLl26OL4eBcRpl4gAAAAA6UEACGRCbtvjVF3jhGa7qe1RwYFTI0eOtOGPl5tXQ7UIZpQSJUq4/hk3W0/TQ7PldPvv2bPHtqm2bdvW1c+rmlTbl90I1P7tlNpFI5nz6Cb8C3S8HtcvvviiSS9VrKnCTrRMxc12Wbf3TajfTSFaoCDTn+aEtmnTxpPrTBaqVlSF39y5c23oq/l+ejwq/A1VLamw1ckHHaqC9KoaGgAAAPAhAAQyIS3icBrqiYKCQJV+anW744477JthhQRqGfzmm29czwr0VUN5NU8s1EKBjJIvXz5z7rnnOj5ebdElS5aM2vmoakr3n2YxaraalmPoMaE2VbfLL3Sebjeu+h+vMEpz+pxS4BLJjDptkk3P8VqU4hVVTeq5otvcyVw5qVmzpl2o44WFCxcGrHAMRDP4dL5I/8xRbfDWNudgzxdtzNbrodtZnAAAAEA4BIBAJqSKI7XLOaGWunbt2qX6nipfKleubL+vWVwffvihXYigAf2xaEkORQsmFALGY9VQt27dHB+vNlEFc9Gwf/9+GwLr/tPCBP/KtEho7pouzw1Vivpze92RnKuCyjp16jg+XrPx/Ksk9bj3ki8sHzZsWKqNsYGoskxLWsJtMHZKbaxuuFkaFAtLliyx1ZPaCqytv0WLFrUtuD/88IOJZ7r/tORI8yg1S1IfruhDlJ49e9oPQ3S/sPwDAAAA0UAACGRS2l566623hjxGM6i0CdW/ck0bX7XoQEsNvKBKN23+9cK1117ranlFrKmtz0l7sqoFFWZEg6rnGjdubJeveDUzUGGlggynwavmpekc/EORsmXLurreiy66yNFm26FDh9q2XYVnCpqffPJJRxVbekz6z3LT4123nZd8l6fnwIIFC8wTTzxhChQocEoAr03a2obtpmo3HLX2urFv3z4TD3Sb6fZQgKzXJoXZWqSilvKXX37ZVm2++eabJt5pK/SDDz5oZ2HqsanXLSePaWQMLZ559NFHzYUXXmirM8877zxb9e7V6ygAAEAsEAACmbgKUFU9vXv3toFToDlUCiU06N7n8OHD9k2Q21lq4Ybd+zaiOpW2Ckrtq4899pj54IMPXLeixpLCHW2hVbVSqGO0YMCrUDQt3UaqnvKCbvd58+bZx4/Cv0GDBjn6OVU+pV1woMpNp2688caQt4+2BGt5RcWKFW3VpRZ36DGm8FXtldpaHCoE1P2jqlYFcz7RqCotU6bMyX9XqDBgwAAbZOm6tVRFFYeqFNOcTAWtbij81FZcbU1WkKnLOHTo0Mk/d1tlFi9VtfrgYvTo0SGXrOixFGxLL+CWFlXpAwrNeNy+fbsdkaBN96p619+Teo2JtHoaAAAglk5L8fKdPBKaZhPpDaLe6EWr+gjxSW9oFOTozY3a6apXr24qVap0ynF6463qG69ky5bNzn7TmysFNsuXLw/7MwokX331VbtpVRVdWmiiGYSJNDNLy1LGjBljF19oe6no91Bw0blz54g2Bjul+Yi6r9NDy0k0t06LLPxDLFEVlsLYQNVyur9HjBhxSku5r8KuXLly5pdffgl53QruPv30UztvMhAFfPodVRUWTP369W0bph5HM2fOtKGRqNJVbb96Qx9oXqMqTENt+HW7FEbtqm7mxznx66+/2i3cgc5TzxGFtFr0olbTZs2auQqOdbtlpK1bt9o2bif/26KW6e+//97z2zdWdD8qVNL5R/P1AKE5fZ7oQ4aBAwcm3M2pTfOqbtRrevny5W1laqT0vNRrqT5c9GpUARAtvMYi0fAaC6+yG+erBwEkLc2ac/ImRyGAV/SGQ1VOF198sf1vtfNpyYEqnoJRi5za+xTORHNBRrTpTZbeMCooU1Wl/lLXi7dXb5p0mdqsrPZCBWoKfhReqXX722+/9aQKK9ibXVWd3XbbbTbcVAWbtgurQvD22283HTt2NEWKFAlaTajKx7p169rqmkAUhiiEDhb+KVjV4zhU+CeqsFPljh5zOj895lSRqKrCtJWJ/hSceRUAqt3X63BK7bD6vRTkB6LFPZr9+eeff9pKXt0XoZ5vPqqEjIcQSqG5088sf/zxRxsU6/EEREIfYui1zglVB+q5Fez1Ld588skn9sMAVfn76MM/zaPUmAS3IxkAAEBiSMyPxgFkCAUHXlCb7meffZYqdFT4om2jegOiCgJ/emOiOXNLly51tUk33inwU/Cndkyvwj+19yocVaXmF198YavMtJxFG2w1H82L2Y3BAjj/6jYFhNrUq5ZWbZvV5tNwb44vv/xyuxjjoYcesoGgf1isAHHx4sUBqwd9xo0b5/gxqjZgbULOmzevufTSS20lY6jwT3QO2tIajh6voXTv3t2Gav369bNtvwqqvGgh7NKlS9Dwz58qN1VNp9ZG3bZOAmVV6CqgzUh6fXDDSUUxEIzGNahCzmlYqOdTItBcVAXj/uGf6PVQbc3aDO/VmAgAABBfqAAE4Jg2bnpB4UugrbGa0aaB+Kpa05svVWepWu7mm2/27LqTmar76tWrZyu9orVxWeGiZvBFi0JCtRFrKYLCy+PHj5tixYqdshwjEFU9OqUqQ70B1mPLKVXs6TpU6ROsGk0z91544QUzfPhwM3bsWFuV6KMQTY/x8ePH2/Zjf6VLl7ZhoH4+EnquON3sq/Pu06eP/V201Eft3OGCYW1B1rmpZT9t23es6LHgRrhKUMDLwFmLehKh8i/cNnq1EzVq1Mhs3LjRLjsBAADJgwpAAI45qX4Kp3///raaLxRtO73nnnvslkxtWiT8c0btaqHCPy9oo24s5qqpSlQzqbTIw0n4J7t373Z1HW6P980xVHuz5mapVU4zKRUiqvV5w4YNdrGOKiDVEqj22lWrVtnKRYWZ+r7+/I8//jjlcvXnqojVso5IKPxzs6XYNwdS5+6/6CfcrFBVkmYU3X7RPB5IT4CcCIGz00VNeo0KtWwHAAAkJgJAAI41btzYLqtwwn/LqFp6FW4oCOnVqxe3eBRs2rTJtlVHi+7Dt956y7bBxqtwrbdp5cyZM+LrUsu6Wng153D+/Pl2EK9arNOGmJUrV7azLXXfOKlQVBuvgsS0Q5/DUeu0G75KULX3KpR06u2333ZdieeVcB8cpL1vI62mBMTtJvZ4D5zVzpy27TcUvd4DAIDkQgAIwFX1k9p3FWyEWyqiNs59+/bZGXBqKZo2bZoNQmJJ8+CGDRtmrrjiCntOmrumc9CcI807Siaa9+dGuHl3Whyi+1ntt1oYsXnzZluVGY7CKrWVas6dthpr3ty6detMLBQsWDCqb/AjpRBvyJAhjo7VLEC1D6sFXm14uh90X6kV/r777gt6W+q56YZv5qSen26eC3ouB1vSEm1aZKP5ZE5o4Y3/hxCAW5pHG+7vukgD6oygqmU3NCfUyYcPAAAgcRAAAnBFW0ZVMaTFCaFaBRX+VK1a1bYSuXkT5RUtntA5al6b5pZphpmqnrRIRG3FV199taMNqInCbevvhRdeaFuGFSz5u/LKK02dOnXsfaZKL9/tpvs0HC2JKFWqlLn11lttq6g2Nqvlu0KFCnZuYLRvb7dvVlevXm1iQaGdf1VfOFomUL9+fVtdqNtf9DxS6/Fll10WsA33hhtucHVOvrZ6J0tA0orkZ7yg0PLdd9+1j7FQ1NKsGZKR2LFjh52l+fPPPzveOIzEoHBdr2VO71e9Nnbo0MHx34ux/oDLrbTLtcLRqIdYjHsAAACxw9/sAFyrVKmS3VyqkC8UzTVT1c6WLVtieisraAoXOGkzrkKWaM/Mi5VwG3bTUmWf5vnpNlLg8eWXX9r7UzPr1K6q5RWaKadqrxEjRtgQT22uwcyePdvccsstQbfQ6vFSo0aNiObuOeW2NVWLM2LBbcVcqFliCi9UXZm2nVjLX1Th6pS2RPuC4LQhcLj5nBm5iVtLVLScQcF+2go//S56TM+aNStshWvaYEiLWVRdqOeFXt+07EYzKPXYz6iWZ6Sfni9afKHxFfpQQ88RVdVq8Y2TpR16PIVbeqRAeubMmZ5tco8WPZ7djEnQ84AAEACA5EIACCDiShknM4L2799vK81iSW/a9uzZ46gya9y4cSYZaJlD3rx5HR/funVr+0+9KVaL9Icffmgrz0K9kdb9GOg+V5DWtm1bG6SEm0GlxS7R4nZZjNPlIumVnlmDwWiWpv/SD1X39OzZ09HPKgB56KGHTrYO33vvva6Cw4wOBXQ/qwpS4bVmmil8VoD9448/2seom0onVY22bNnSPn4VfvtT1aZmMuq5lSwfFGQmen507NjR1K1b17z33nsng1xV1SpAr169uh1REKoiUIGZFuaoolThs7/cuXObBx54wAbSbj+AyQj58uUzzZs3d3y82ugBAEByIQAEEBHN0QsX+PjoDZTCn1hQq6qbUE8zDZOBQiZfVVc4hQoVSvVGUBVqAwcOdPSzCpnSVqjpsaB5i06oUuaXX34x0eBmQYkqxFSxGC2qqlTYqXboF154wYZuXtLzSaGtvyeeeCLsbaDAT63aZ5999snvKQx0UtWnAKRz584mXqiaS+3quo2rVasWUWuygtSpU6eGPEbVqwqSkFj0WhXqQw3RiIJXX3017HNGl6W2cM1a1WvYxx9/bF/Hhg4dmlBb6vV4dzIbU6MGFIwDAIDkQgAIICILFy50fKyCwmhuqPWnZRVuWjtVBei2ukcVH6qgUwWZqo20GVmVIG7mvEXDs88+G3YWnKpWVDGlpSg+CkxDtZ36U1ioFkt/af87XFWOZttFg96wOq1OK1eunDnvvPM8P4e9e/falkG1zylY0EIU3T7RqCBLW7Gm313LdhQ4Bgr0dF7Lly83tWvXPqWtV0tHFAwHU7RoUXtMIoUd4WiuogIcJyZNmmQrDJEYfv31V/PKK684ft108vzUa32tWrVsyK7nkpuW+3hRtmxZu7Vc1YChwr8PPvggQ2b3AgCA6CIABBARt4GGtofGgtMgy5/TGV8KMlXVpWqjiRMnnpyTpzeb2tyqGUtO33Smh85DIWfa+8DXrqZKMP8KLx+1wmkJigbW+1uxYoWr61eI5E+3gxtuj3cTzDqtSnW7/daJAwcOmOuuu85WjMVCoKUnqoLT1mb9fqoQHDNmjJ1vp3mcqlpSu3cg+r7C8AEDBpgSJUqc/H6ZMmXM4MGD7czMUIt/EpFCPd+SFSecjDxAfBg7dqzjpUAKgrXYKrPQspJNmzaZ55577uQmdH14oBmYWtyk13d9KAAAAJKPu5VgAPA/qn776aefHN8e0ai2CkSLADSM3c2mR1XFOdGnT5+Q7WK6zocffthWV9x9993Ga1qmMmzYMBvoKGySyy+/3M5q0gwzVWwoBFSI07t3b1vFoTY1tZ+q6qt06dKehKZpA9NAYWMobmYVuuEmoNm3b5+thHHTNhxOv379zPr16yP+eYVtbhbmBLs/fS3OWgzi9jmt8FhfCsb0PHKzNCDRKARxY+PGjVE7F3jr66+/dnX8N998Y19DMwtVCGv+ob70IZae6xk92xMAAEQfASCAiGju1sqVKx0dq1apm266KSa3tIJGDe1XuOOEgjonb3y0VGTQoEGOLlPzotSOqtlRXnn33XftZaatWluzZo257777zKhRo2zg5wtaFfo1adLE0WVr46kb/hVi0rBhQ8ct4Xqj2aBBAxMNbrdNe9nSqWpMNwGkNocWLFjQthVeeeWVdn6jQkm1GDqh0Nrp/RuJYO1/WuqjlmYt4PAFy6ocivcNqIG4PWcCksThvyAnGscnk0hmZwIAgMTEx30AItKsWTPHlV/33HOPo8HjXlELpJM395qDpy2fTijccdoqrJZgbZ30ijacamlHqJZVLZ3QUgun5+jPTbWi3izeddddp9y/Tpdc6BxVpRkNbtvMnbYIOm0/ViuhU4cPHzbLli0zixcvtm3jF198salRo4Ztz3Oia9euMZ1BduTIERs0axFIhw4dTN++fc1jjz1m28kVAKq1PNGoetYNzUZDYlA1bTSPBwAASEQEgAAiokDvnXfeCVvldvXVV5vnn38+preyqpJee+21kMeotVFzojQnTaGLKrL0Br979+4BWwPdzslze3woCluchFWqyAwUPGpjrBZDaNvrk08+aT755BMbPinAuffee83bb7/tOMBTsJq2Okxt1KpADEdLJsLdL+nhtopHG6O94mvJdirQohrdtjNmzAg7a0/h+zPPPGNiGf5puYzu40Az89RuqW28elwlkjvvvNNx+7+Cbz1XkBjc3Ff6uyDthxoAAADJiBZgIE5pnpzaKlX9pcovDetWy1+05qdFQjPGtPCgW7duZvXq1ae8qdKmXFU3ZcS2RG3l1Yw0hY+qsvIPWdSyqpbkzp07n7KQYu3atTakeuSRR2zLr6/tL71z8iKlNlU3wYpCmqZNm55s11TVltqH/ZdjpCeQVRCpGYSqQPPXqlUrO3dOFZW63rRUJabAOFrVf6Lrd0OtrFpuoeq7du3apasKyO12XM3bC0Qt3Kqm02PvjTfesG3BPjpPPdc6duwY07Y9zQlThWMoen7ccccdNmyOZbVveuh1SfMOFYqH46t+RGLQc+W2225ztKFcFa3JtN0aAAAgGAJAIA69//77dpnE5s2bU31foYve/A8cODBuhvNrZpkGqCsgUGCpWWhFihSxIVRGv6mqX7++/fr+++/tl8I8VfmpRfeaa64JWQGmzac63jf3L71z8iKlgMoNtQKL2lH1O27YsMF47aOPPjolABS1KWs25LRp08xnn31mK8dU9deiRQu7OTlac+J0f6qac/fu3a5+Tltv9aWqSd3PqghT6JYzZ07X51C1alX7u+pcnAg1v0+PO4USWu6iJS5qF9bQ/goVKsR81p7aqrUZ1GkVpLZjK1hPFJrXqfts6NChQY/R4zoW273hrXHjxtn7VtXOwejDoJdeeombHgAAZAq0AANxZvLkyfZNSdrwTxSuDRkyxDRq1Mh1RVo0KZRQwKM3088995ytlsno8M/fRRddZG9TLQdRFY9aYZ20f7744osnF0Vozp1TaotW6JWRw+x79OgRlfAv3Kw9tQe3adPGvvmePn26DVaqV68eleBK1Yj6PYsWLWp69eplnx/poQpFLSgJNWsx1H2ux70TCvgU7qWlalrNSNRsTbWkq1pSQaCWm5QtWzZDFm1osYyb2YpTpkwxiUS3qTZ7K9TWbe+/6ENtzTNnzrSvyW6rS5HxVIm6YMECuxW9WLFiqf5MzydtVFeFoJfLmgAAAOIZASAQR3bu3GlnF6n9N5SPP/7YhlNwTy2+S5YscXSs7gffbLtKlSrZOWhOKCxUxZYX3L451RtbtY0qtIgWr3639NB9o+fKyy+/7Okyj0WLFpmRI0dG9LOPP/64oy2+qjhSi6L/76I22xtvvNHMmzcv1fNfFYqqqNNj788//zSxpu3X0Tw+XkLAunXrmjlz5tiqVVWS6p8Kj26//Xa2/yYwLXpSm/dPP/1kx1To+a3n1MaNG+24Am3hBgAAyCwIAIE4orDJafXR8OHDPZszl2g0Y04hnmb7uW37/OKLL1wdr7ZmH4Vq5cuXD3n89ddfb6s000vVYAod1VLrRvv27c38+fMjqmJzSrPeMtrcuXPNhAkTonLZI0aMCBvCB6t+1FIZBZOBggXN91Or8oMPPpjq+6NHjzb9+/cPedl6vHtVVeqG23bojJj36SXdh2rldroUB4lBMzO19VljEcqVK5ch1bQAAAAZjY8+EVAkb36RflOnTnV8rIIvBWDXXXddzN9IqU1Ob6Bi/ThR9Z7audSW5ws/dS5q71X1ldqQw3HbJqpWYd/vqbZm3eYKa956661UC0TUhqoWULUXa/6efqZgwYKuK0xUmaIFJp9//rlxS4tiNMfu9ddfN9GiFmqFkhn9GqEAPFp8MyPVOh5JxZHmCKoVftKkSebnn3+2VZx6bDZu3Nj+u/9tp8fxs88+63g2qLZLa6FKrOj1xc1zXZWKGf3YSAYZ+ToLZzSbU38P6zmt18VYLuaJR77HKY9XJAJeY5FoeI2FVwgAEZCXLXVw7rfffnN1c2lBQKzvK80n84nldavtuVmzZqfM7tN2W7XuqepNywpatmwZ8nJUheXG+eefn+r3VEWUtuj27t3brFq1yhw8eNAGgwoAVcmlZSG+RRC6rdq2bWsDPSfbb9WeppBI7YduafGKllloOUy0qrD0u2vGm0KJjHyNOHr0qH08RJPC3fT8jgp/01b6SdrL1ONWz2M3VcIVK1Y0saJgQxuzFT6Go8eFtiln1GND4b7mTqrKV68Tek7o9SCWt1eiv84iPL3ua26ktqv7PojSY03V12rXz5cvX6a+Gd3OrQUyAq+xSFS8xiK9CAAR+IHBXJwMoYBFgZJTefPmjfl9pfly+hRKb/ZjtehDVVTaxBlqcYf+QtQbsEsvvdRceeWVQY9TwJY7d27Hiw1at24d8DbWZfiqLzVbqkqVKqcEuNqKqjeKCm00bL5evXpBr0chkDYnuw3/9D+xmjn46KOP2tZFUWDjdeWQfj9V3aktOaOp+jLaNOcwFs8tVXy6ocUusX7Oa86itnz7V7wG8vTTT0dUNekFLZ3RQhhV3/rT86927dp2O7FCmkSREa+zCE/Vvar01gdP/nbt2mWeeeYZ+zjThxNebYFPJHq86u9hVVbRYo14x2ssEg2vsfAKASAC4n/eMoYG0euNrNNWw5o1a8b8vtL/4OvNj689LRa0rdFJMKZKGYUVoTaRajNkx44d7SIGJ9VPqjoM9Xsq9FPgFqp6UxVr2i67bNkyc/XVVwc8RiGhm/DXZ9q0aXZ5RNpWYG00VWVkpFS1qEpCBZ16XAYKVTVnUNVWe/futberFmAolI4m3UZPPvlkVK9DFWOq5IzX18FYn5cWy6gl/bbbbrPLFNJSINm3b1+7iTkjbjMtbQm0Vdm/slaz3/T8c1sBnFEy4nUWoX3yySemU6dOIT9Y0dZ4vdZ/++23dp5kZqTHK49ZxDteY5GoeI1FehEAAnFE7UNOA8C77rorU7Qa6X/SnN4mMmPGDDsDz7+9I61+/frZN2ifffZZ0GMUZM2ePducccYZ9o2fljuoalCtnQoFr7jiipMLI5xsPtWbec3OU6WI3tR7VdWm8C0QLSJR1ZbbtnJRFeVrr70W9E2cAk3NYlTw4n/5Wpygx6Xm30UraHn77bcjapF2G37G6g1suKUyaWmBQUa47LLLzObNm22orConVazqQ4hrr73WdOjQwbbK+9u2bZt9fGiuqR4jCpMVJGvzqqpJvaLnU7du3RxVET/22GP28eM1VWUqwF+5cqV9vSpVqpRdBKOFQAQhyUOzOp1UVW/atMl+MNOmTZuYnBcAAIBjKcD/DB48OKVPnz72n8g4DzzwgN5hhPwqVqxYyi+//JIh57d79+6UXbt22X/Gwm+//Rb29kj7tWbNmrCXe/To0ZQnnngiJV++fKl+9rTTTktp0KBByoYNG1IWLVqUctFFFwW8jpo1a6Zs2bIl5fzzz3d1brNmzQp4Lm5/R9/Xu+++G/R33LRpU0r58uVdXV6hQoVSdu7cGfQy//rrr5TatWuHvIzixYunbNu2LcVrM2fOTMmRI0fEt5WTr6ZNm6b8+++/KbFy7NgxV4+h5cuXp8S78ePHp2TLli3o79C5c+eUEydOeHJd+jvL6W2nc9q7d2+KV/S8bdu2bdDru+qqq0I+l+LpdRahbdy40dXrSI0aNTLdTfrff//Z1zP9E4h3vMYi0fAaC6+ym1PLUABkKM2s0jy3QFVicvnll5uFCxeawoULm8wgknlnTrYxalmGqth27txph7mrzXjs2LG2hWvevHl2kYdaa7UNNpAlS5aYGjVquFrgIEOHDj3le8Huaye3TdWqVYP+uRaT1KlTJ2ArWtrKJFU6apbgmjVrQs5Ke/jhh21LZShbt241TZo0OaVaRv+taklVh4Wa5xhs9pYu0+0W52D3fVq6jTRDTu3jkd4fkdDt7rSluX79+jHdABwJVQhq8c2xY8eCHqOqWW3t9ur6nNI5ebU8Ro/lVq1ahawoVEWgnn/hZici/q1fv951VSgAAEC8oQUYiDMKH1544QXbKqetsppbpVlr2iJ79913mxtuuCGmAUVGUyuvBqqrhc8Jte6qBc8pta1qtpk/3d7aHhoqxJBI2msDBYoKgdRSrGUibui8gwXBCsq0dERBZbAAQ6GXAr3KlSvbVs78+fOHHZrttFVZmzI1H1ALGNSyq8eyWrO3bNli/zxbtmy2lVqbckMtbRH9jAbvp4dCYd1eahfVIhO16KkNXLeDZtzp/g73+0eL5tcpiFYgHUz16tXNO++8E9ctpWpzf+SRRxy1Sb7yyiuma9eujrZjh6JFO9E8PhhtRda4ASfP94EDB9rXdCSueH7eAQAAOJV5UgQgweiNcf/+/e2cuqVLl5rJkyfbGVqZKfzzvfHS4HWnFJKmd/j6zJkzbQVgLCsa3QZcmv+ox0cwWsgQLPzzn+X35ptv2iUmTsIvhWbhQlF/qo7S7ajwSkGjL/wTXc6kSZPsPDjNTwtFFWOarRbJY0chnyoS9+/fb89fi0q0bVvVjppzqIpMzfxL+/srxFKAqSovBYb60kwv3aZeblf2nefzzz9vPvroo5MbnH0uueQSW52q1wGvF6zo/te8Mm0i9mKuohaF+N/H4cLCMWPGpPs63Ya2Xs1N1WPSKT3HdFsjcbmdvel2ticAAEAsZK4kAUBCUgCoKsBwzjnnHNvGmV6zZs0ysX4j2bp1a8dvMs8991y7mKRMmTIB//zPP/+0oYMTaslVZZkTat11Q1WbjRo1Mt99913IIEjh5/z584Meo0USkWjcuLGtrCxWrJit9HRKLZta4KDqRYWUChH1NWHCBBsgqrLSq0oyfwr4VVmm61flmBZcqPVQ1cCB2pYjpUBU1Xd6HClg1NIXLbdp165duloXVa0czeMDSVu9G4qWlqiNOr0UAC9YsMDx8bo/3Vb3Ir6oSlibpJ3SpnkAAIB4QwAI4GQQc/DgwahvWI20DVizu0qWLBn0GG2dVQWV5t6ll6rFoiXYG0MFVNo0HKpyRNWDmhenYE1tu8FohuHhw4cdn5OqS51wG0IpiNQcNCf69u3raat16dKl7RZatzSbUAGfqtmCUfiqSr1oVXXp8a5wV5t1vW49VDWxQlFVFWqrtf/vrfZutWMrhIyEm+rQSI4PRKGl08el2ry9qABUNarGBLjh5vmI+PT00087qsDXBzkabwAAABBvCACBTE7VQJpBljt3bhs85MqVywYPgwcPjqs3rQp0VEWjlk3/SjnN+9OMLVVKqU3TC7od3HBSnehb4NKgQYOgf37BBReYFStW2NZIBXy+N5sKPtXuq4Uj/fr1C1vNtnv3blfnr0ozJ6pVq+bqct08fjQzUFV2gegx6YYq9xR0qcLNLbUj61zC+eqrr0LOQ9R98MEHH5i5c+dGXFWnKkNdjtuwKdT9fMstt9igPxgFgU2bNo3onN3O8ytevLhJr0KFCoVtIfdVcA0aNMh4QUF8gQIFXJ8nEpuqglVZHWrJ1EUXXWQDdC8rdgEAALxCAAhkYu+9956tNFKllP92VYUO2kSscM1t22c0KaTUvLZ169aZ48eP2wqiH374wW4UdfuGPJSGDRu6Ot7pghIt2gi3oVhtiu3bt7chlH7HEydO2M3EmumnNs1obE52GjCpRdVp2KlzcBsgr127NuD3tY3ZqTx58th24kjCP7V2alGJmzlwaecBqt1Z24pViXrzzTfbFmgF1trWPHv27LCXqce0AuCKFSvaajWF8fqdVL2mcDg9VPX3xx9/hD1OIaA+AHBLwaGbVmvN6/SCtg6rTVxVwIHoftA8Ry9fI+68807Hx6qq1+0MOcQnPWZV1azHnH/IpzBbH0TpOaqRAwAAAPGIABCIYwrftLhAs8cWL15s23S98vXXX5vbb7/dBkyhWi/VEqhAIN4oYNL23PTS9tU1a9bY29oX5ujNvdPlAsFCh0CmTJniqu1RFYDhAsNA3D5OnC610Lm8/PLLjtpSe/bs6dnCms6dOzs+Vss9tOQj0gq5QFuag1HVqX97subCqUry3XffPWVpyfLly+28ulCbflWZV6dOHdsm7j8zTo8ZPXa0MEXbcyOhx4TTuZCi6/NvEXZCS0qcLrNRta5+V6/ccccdZvv27TYI1ONFj4OnnnrKLjiJNBAORXMZnT43u3fvzhbZJKJwfty4cTZM14c/et3QhzT6IMrrRT0AAABeIgAE4pCqiNSqp2qr5s2b2+2jGkCu9qJAVUfB3vBrjtno0aPtG/+0Q+j1BtlJULRv3z67oTSZ6PfWhlqFEKrU0kw0VXCoUkfthAoW1d4ZLsBSq3CoADUthUVqHY02twGgm4pBLdbQm99s2bIFPeaRRx4xzzzzjF0u4Uaw41U5qcerkzbx3r17m0j5V8G6/RlVzSpQD3cZquTUjMa09JzW3DC1LoeibcqRLEXRXMu9e/c6Pl7zDSOp/lXAGW7Rhp5rCkm9nm+ox6SCwOHDh9vn73PPPWcuvvhiEw1anuJkE7C2SN97771ROQdkLFVr67GsKl2vPuwAAACIJv6PBYgzixYtslVECgnSBn2qMlDliapsgoWA+r5aCNXaqwobbdBVS6mqFlRB9Omnn9pZcsHaLQOJZJlCODpPp5VnXlJbrVoV1cqVduac5p7pttWCBy2CUMtmsAo/hVVqK9SiCzectGB68cbUDbWYuqFAWq3XWkiix5laVdX21qFDBxs0v/jiizbc0X87pRA22GITXZaCbLV/BwuNsmfPbipUqGA2bdoU8eNKVWJuQilVgPnasvUccfpY0O2Tlip8tVzEiYceesiGrAoDFXZpy2w4kYRtkfyMQrg5c+bYIFAzLf2pMlPPL4XgbucFxiNVas6cOdN+MJOWKogVQOqDBsIhAAAAxIPTUjLiHTji0ksvvWRbvjRnrUePHhl9OpmS3sirislJSKTAQeFeWprdF2p+l96Mtm7d2r4xdVtVpkDg119/tf+uy9Fge72EqN3RSRWZKpAU5Kg6R61T+hm1GCsUUNttqKoyN3SOb7zxhm1j1L8reNAAd7UG6vdWaBKOzsfXsqs3+dowrIBHgY+qjBSu6vZQQOhmS60CXlVzRpPC3csuu8zx8QqU1NobjbD1qquusi3W4agiTC2y/hVo06dPtyGsnhcKGVUVqxB7yJAhZuLEiUFb01WlqD/3tQLrMapKTT3ewoVaWtLidAuuzlfnLQq01ILqlAJUzdj00XNS5xwJhZ96LXjhhReCPof0nFW1q8J/J3Tb7dmzJ+J2atFtvmzZMns5+ntFH2y4DZsTgW7bhQsX2rmd+p11v9566632folU2tdZIN65eZ0FMhqvsUg0vMbCq+yGABDpfhDB2/tAlT1OqPJK1U7+1SUKqlTdFg0Kc/Q/9vqfJgV+alVUQPbhhx/asEbtsGphVJVWoPBpyZIl9k1xsGolVX9pVpebmXqBKDC66667grZi6o2J0889tCE5XKWSqtwUNjqh8HDHjh0x2RCpwExbZJ1Qq7jabIPR7aXL0mNAlU1uWoY1Y/GGG24wmzdvDnqMwkeFkD4ff/yxDcQCBav6vXQfhqt6q1Wrlg1l9Pxw8z9NqpB1unREl6+Nw04D8LTXo1DaR88ZN1W5wcJLPf6DnUvfvn1ta7YTCuXdLESBt3hzikTDm1MkEl5jkWh4jYVX2Q0twEAccVOVt2XLFrtYIO0LQbT4QgUFKWo91GxChQ0K/0QBkVqP1cqZtppMQaU2cYYKbbSURAGG0420wYIshZCh5rC5KXoOtbDBRy3ZbloGYxH+6bHhNPyTYK2nqnjUY0otjgr+FM6ec845plu3bvY6nFAbqB6n/fr1sxVo/u2zmpmnNmr/8O+zzz6zW5iDVVWqOtZJy6taarWN1+08RIWVTz/9dNjj1N6p8C/SZS1pF9h4UYyvAD1UdasqYJ0E7KrS40MgAAAAILkQAAJxxE0LYdrjf/rpJ9tuFy2+7bWqItJm4mAUZCg88A8zFf442SiqEDDUZYei61Uw6WYph5NAMRwFnn369Al7nFqdtRlXdFtMmjTJDBw40Lz66qvmm2++MV7SNlq31WiBqh91zqpIVbuq/6baoUOH2oo1zXpzQpt1Nb9SIbLm7GlWnxbLqBVclXo+qqTTvEpVGnpBAbXmFLqlKjlVdQaq/tRiHi1B0YZZH1UVqjXZKbWGpq2S1VIJLygADBZ66rbv2rVryJ/X76LL0CgCAAAAAMmDABCII25nRvkfv2vXLhNNqljSVtCxY8c6Ol7bThXkaPuoZrk5FWnb4YoVK07ZdJxeTrfCKgBUpVyuXLkC/rkq3RSyKQBToFakSBG7HVSB4IMPPmjbnxUghdsA69SRI0dcHX/48OFTfm8tQglV5afKT1Vbau5ZMLr/tb336quvto8bzX1UZZ9aXR9//HE7K02Vej5afKNjvDRo0CAbjrvVrl07G1p+8MEHdqam7l/NgVQY2rZt24Ats061bNnStsz7U/DpBd1n2iIeiG7rcGG1gnRVCur+USCflip09XhhfDAAAACQWAgAgThSo0YNx8cqTFKwEunmV7fhnyqDVBXltKVSywbUkqgwwlc96IQCpUjChS+//NJ4TW2vTui2UfWhfmcFmNowrDmEqhJT9ZtmMyqsVWurb15DoABTi0UUMqWX2zmKaZcMqDpRbdvh6H5VdWcwWkyharlgFA4raNSSEM3jcbM12Ck9lkaNGhXRz6qtt379+raiVfdv3bp1g250VZjpZA6gZhgqHA/Uely1alXjhX379gX8fv/+/W2VZTh6fGqhiCpAtbhDz2E99/Xfehxr1ohawXWbKCQFAAAAEP/cTS0HEFX333//ya2i4WjTaeHChU/+d7ly5Wy44GSDsCiscNouq1lqEqraK5CVK1eGXC4RrGpMoY3bLYLpmR0YjH/A6oSCEVWCBaoGU1AWqNU2baCmDcNqv9V9GSkFjTly5HBcwdiiRYtU/61NzU7NnTvXBp/nn39+qu+resxJtaiqFVUVqdBKW6KjQXMGo0nVt40aNQr7fNJjWoGo//ZfHwWLalnWApL0LgMJtGlX1buRhMtfffWVqVSp0inBoeYwvvLKKzbw1jIgvR7FmhbLKDzWuZUtW9ZUrFiR7aMAAABAEFQAAnFEW0G1KTecvHnz2iUE/lQBqBDQKafbgrW04s0337T/7na+no5329Ysqj5yq1ixYsZrbhdIhGqXddrarMUbbpbBBKL2UlUhOqFKLv8AUOGrQhU3t9H69etP+f6IESMcX4aCUa/bt/39/fffJpo0E1HVjOHotg01V1KVm2oD13zEcNunQ1Vzai5lWhs3bjSRClU1qMe2Qutozh8NFOhed9115uKLL7bLiNRSrTZ6fanaFgAAAMCpCACBOKIKocmTJ4esptEgf1Xy6M1v2jfpqhxzE4r4gr1gFN6pGknVZBKocikUHR9JZZ5m4y1atMjVzyg4DVT5lB5uNumGC7icBET+LbhOqDWze/futk1VG5S18ML3GNDsu3AVjAqNZ8yYYXLmzJnq+25bsAMFRP6z/TKaZi5Gi0LucM8jf6qKDPWcUBWpHv9qrdU8P4WxbkIttVFny5btlO+7rah1W7WrxSmxMHXqVNsqv3DhwlP+7Ntvv7UfbETyAQIAAACQ7AgAgTijsE1twKoU0pKFCy64wIZ+mr81bNgwGwoE2ji6bt06s3PnTsfX8/7779sqMS1IUMuo//wyBUKae6bQqkyZMie/f++99zq+fIUQqs6JNHgYMmSI4wo0babVvDYtL/CSwhgvaL6dl8fr91XL6eWXX25ee+01Gwjr/lTlWMmSJW0Lsio3tQ24Y8eOAaswNW9OIUrt2rVTfV/3V9pwORwtOdFjw3+bsSrD4oXmMUaL7qtgM/eC3Xd6nqpVf8eOHUEXtujxrE282hZ82223OZqPqMq/Rx99NOCfXXrppSaa9BiMZNmK25bf1q1bh51jqAUm4drtgWSlIFwhuBb+aKP37t27M/qUAABAnGAGIBCHFMJodp6b+XkKFtxW7SikKVGihJ3jpqovVQUqCAxUQSQFChRwfPm6HFWYKXjQfDO37bRz5syx7bDBqvq0XEOtlxMmTDj5u2tWmQKTYFtQ3VJlnRd8FZROpa3I86f7qF69emb58uUhl16oelGz2fTvAwYMMLNmzbKz+nTZap/UvLRgNIdOgbJTOidVtulLG3MVHhctWtQGXNGgYPaSSy6xi1PC0Xn4ZlhGQyQLaxTo+eb86bmhAL5bt252BECw1wO1kKv1X3P3AgVgeqyqcjRYaK3z1PMxmu3QauNWAB0ter7rdcsJLdvRYhWkpuBZIwb0IZPmOGpcwC233GID/IIFC8bdzaXHrV7r3nrrLRsw6++Vq666ygbi0Rj7kMj0AcwDDzxwSju+Ns3rwzh9WOR0sRUAAEhSKcD/DB48OKVPnz72n0g8a9euVRLh+Ct79uwp//3338mfP3HiRMqsWbNS2rRpk9KwYcOUFi1apIwdOzblr7/+OnlMz549XV3H9OnT7c81btzY1c/5vr7//vuAv+uUKVNSzjjjjKA/d8EFF6QUKlQo1feyZcuWctddd6UUL17c0XXr5//55x9P7pudO3emZMmSxfHv3blz56CXNWjQIMeXM378+IjOt0mTJhHdX/7XO3LkSMfHn3766a4uf8GCBSl///13yrXXXhvyuLPPPjvl66+/to/zY8eOpXq8e0WXq+tJz+3l+3riiSfCnuOuXbtSnn322ZRGjRql3HzzzSldu3ZN+fbbb0P+jC6zUqVKnpxjqK9p06alRMu///6bkidPHlfns3v37pREpXPXfe3l76DX45w5cwb9++Ctt95KiSd79uwJ+hzXa8aDDz6Ycvz48Yw+zbiwdOnSlBw5coR8PpQrVy5l//79IS9Hj7fvvvsuZevWra5fL6P5OgskwmssEE28xsKr7IYAEOl+ECE+6A1ymTJlHL85VsAn27ZtS7n33nuDBlT58+c/GeTVq1fP1RvwXr162Z9btWqVDeDcBgo7duw45fdcuHChozCtevXqKR9//HHKxIkTU2bPnp2yd+/ekz8f7lz05nLu3Lme3j+33367499bYW4gCmmdBpj6Ou2001JGjBjh6jwVrEVyX/l/KWRYs2ZNynnnnefo+Dp16ji+7Ouvvz7VuT7++OMp+fLlO+X3Voi9cePGmPxPk4KI9Nxe/l9Dhw71/Pw+/fRTz84v1Nfq1atTouX33393fT4rVqxISVRevznV65mToF2vlxnh119/TRkzZkzK888/nzJ8+HAbaiuwCne++rsrswdOR48eTTn//PMdPSf0IVhauv2mTp2aUrNmzVTHXnrppSnDhg1z/EEYb06RSAgAkWh4jUVaBIBINwLAxPfaa685fnOsigEFZOGqBnxf77zzTsoNN9zg6g24whkfhXAKZpz+bOnSpQO+sbvmmmscX0awEE+BSLBwSoGnztVrW7ZsSSlQoEDYc37ooYeCXsb69esjCmZef/11V9WKkVxH2i9Va6kSMHfu3CGPa9q0qQ168+bN6+hyP/roo1PO+ciRIynvvvuuDQ5Utfrzzz/H9H+adH1uq9OCfZ177rmeVZ76tGrVypNzC/V15ZVXpkST7mO356QQ2j8snjBhQkqHDh1sCPLYY4/ZSqfM8OZUVXJFixZ1dJvp9c+/6jva9MGMHp+hKrrDfX322WcpsabXknipPpw0aZLj20q3s/9jSh8cKkQN9TO1a9dOOXToUNjz4M0pEgkBIBINr7HwKrthCQiQRO6//35z0003hT3uiSeesLPCtDn3r7/+cnTZmrlUvHhxV+fjv0BE16Xtpk5pkUXaBSIbN240X3zxhePLGDlyZMDva9batm3bzMSJE+0CC81a1OZlbXPV3Dqdq9e00EGLXYLdhvpdtcBBM/SC0UzESDz88MN23lc05hWGOtdevXrZRSSaMaZZd/7OP/98u6n4nXfesYtuZs+eHXL2oW+uW926dQOes+bqaQmMFtu4fZyGcuzYMTtEXwtxgs370/WNGDHilN8xEr/99pt57733jJfcbAePlJvndiR0H2vpjVOaV1q2bFn779qsrnlxWiAyZswYOytRSxI0L1TzLt0u6Uk08+bNczyPU68T06ZNM7Gwd+9eU7NmTfs67HS2YyBadBELev7Pnz/fblzXPM0zzjjDzk3U/E7NpM0o2oztlG5nzYP16devn52vGMqiRYvMPffck65zBAAA8YEAEEgiGpCu/7lXeKY3J2lpiYACJm2L1f/4u1kIcOjQIVdLQHLlymXuuOOOVN978skn7aIOJ9tM9TsEWjLgRqjjtSVX22FnzpxpgzndbhqE71UAFkiFChXsJlO9YdPiB/2e2sar4E/bnRVKhAqRIh3Sr/t53Lhxjo7Nly+fDUa8oG23Tz/9tF3e8PPPP9sgRiGrNsYqlHrsscfstltRCKth/3feeWeqjdSiTcXacqwgM1a0pKN9+/b29lBYec4555jChQubTp06nRKm6r+feuop14tuQl23G3pu6vbR7fvxxx+f8rwO9FrglH7ncM/7gQMH2iDdR7eDAuATJ04Yrz/gcKpdu3b2Oa7Hm57nCpsC0bZghVAKXpOVXt/cUGgfC9pQrtfD9NLrSbT9888/plmzZvZ1W881/bdoA7he37TsSo+1jLBnz56Ijj98+LD9UMWJGTNm2A/gAABAYiMABJKM3vRqY6gqPhT2KbBQZZTenOzatctuaNWbYW2BjOSNpNPNxF27dj1lI6nCNb1Z0xvuYKpXr26PCVQNFmj7aShuj48FbVhWMKoNvbqNrr76aruNWb+zNnSGog2robb3hqKgIxpBSzgffvih3dirzcwtWrSwIauq+AKFUuXKlbO3i4JbVQc+99xz9rwXLlzoqLLVK9osraBazxn/Clm9cR49erQ599xzbRip6kBR9Z+XVXbBKg0VrOm2UMWOzlHbPrX1s0iRIrYqSUGXNkSrolJVvkeOHLE/V61aNVfXX6VKFdOmTRsbim/fvt3ed927d7cfIPhT9Zzu38cff9z+twLcVq1a2eeujtVrkc5HG70j2ZacVtu2bR19gKDNz3qdU+WmXvvC+fHHH0/+DsnI9zhwymlVeHroAwGvKl0VZHkVvoeqgNeHRaH+rtEHBnqsx5o+bIvk+OnTp7uqKlf1LAAASHCuGoaR1JgBmHloi2oks5Y0z23Dhg0pl112WcjjmjdvHnI+kuYOffLJJynNmjVLueSSS1Iuvvhiu3lW8930Z8EsX77c1flqXmA8zvAYMGBAwJlxZ511lp1NFuq206bOSO67WrVquRoqX7VqVU9nxGmxyFdffRXyejWTTY+JrFmzpvpZDaefN29eSizmpmiemNOtxHXr1rWz5bR12svbavLkyaecv7YqlyxZ0tXlXH311SkHDx60Gz2dzt/UIqFgz0HN4dNCH80PTbugR5uJw70m6D7wYjNslSpVgl5PqVKlUjZv3uzonPy/zjzzzJOLgpJtPtVTTz3l6nHzwAMPpETbwIEDPXu+aLZqNOl1yem56O+zWC8lcXtb+pb1PProo65+rn79+iHPg/lUSCTMAESi4TUWaTEDEEDUK+PUWqiWSFVCqGJGlUb+1Dr6xhtv2FZEtXGq8mTUqFHmqquustWAefLkMbVq1bIzuPRPzZrasGGDbS1Si5Eqw0K1wOpy1EbrlCoy4o0qxzQvLVDlhW5ftQFrVlmwihZVQalN1q3zzjvP8bGq3FKbW506dYxXVC3Xt2/foH/+2Wef2Uo1VaWkbR1dsmSJbb1z2q6WHjpHp9VEardVpZlanb10zTXXnPx3Vc49+OCDtiX+p59+cnU5K1assNWcF154oXnooYfCHq85lKoaDvYcVAVv5cqVbZWu/3Nfz3G1eoeitndVvKaXqi/1eFB1oqoL9bhWa7yqitXmrvbpiy66yB7rphpLLZ2xaCXNCKq8dUOVpNGm6kyvpB014TU9vp3S32WLFy82saSqar1mO1GjRo2TszTTztgNx+3xAAAg/tACDGRC/ss53PAFIwoCFEqojWvNmjX2DblmOal1U7O3FCDovxXWKbhYtWqVbdPSrDIdq/ZChXlugxO9AdEcQadLNzSzKZ6onXXIkCFhj9NiDIWkgei21dB8tX5GMwRQ0KvzVdu3Ake15ypYcdtu5k/tonrMBAoDtMQjXKviI488Yi/DaeA4fvx4u9zlhhtusGHwN998E/JnNm3a5GrJjKgV12tqg/bR4+C1116L+LL0WNI4AAXLoVq71ZKtAK1Ro0auLl+3c7jwz0ft025DzED04YLuVz0WtMBD8/sUuigc13IGH6eLb/xn3/Xp08eGpZqT6sV8unig+XQKS53QSAK1gEdbuIU/bv5O6NKli4mmlStXRvX49FIA7uTDEb12Dxs27OR/u5316tVsWAAAkHEIAIFMSFtLtQk3kgDQP6TRG3G9KVBVgcIhX4WA3pArdAkU9vioUkcVfwoG3WjevLmdDRduBpgq2LJnz27iiYbFO+X/Ri0tLc7QZfkvXghFFWDaxOuW7k/NfFQgtW7dOhuI/PLLL3YWYaS+/fbbU76nmZVOZ1G9+OKLYY8ZO3asDTAVCGnOmKoLFQZeeeWVdjOs5tp5sXxDFGprrqOXfJVoqv5Lb9WjnrMKjPWY0axCzQ3UnD5VzinIL1GihJ0XqC2mCubd0u3rdIGGfh9VCMdK/vz5XR2vx82zzz5rQ3p90HDxxReb+vXrO96gG88U7pYqVSrkMVp2o8A4FpVeXlUXv/LKK/bDiWhyu8zG6+U3TigE1d8ZwSoBVbGrD3S0eMpHf3+4eY5oDiIAAEhsBIBAJtWrV6+Ifs7J8pCXX37ZUXWf2qUiCQS0cVUBX9oQU29m1JKpisNIqxyjRe298+bNc9W+GS54UEWVFmyEotZrtWynZxNs2stTIBhp6BWo/VzBi1MK80It3FAwqpa4YIsMFHSpIirQ4zPSRRX+b6q94AvF169f73rzdSAjR460i0N0m2jrtKoWVTmnMF8VeQMGDLAfCngV6Hp5fHq4rWYMFsbq8aLXHIXfiapQoUJm6dKlpmXLlqe8FigcbtKkifnqq69sIBwLCgAVxkdKgZYex1pOE23hgtP0Hu9lCKjXNVX7akGPRiqoUlahrhbdpK3sVLWs0/8P0IcpGfV7AQAA7xAAApmU3oDpzaBb4QIJtQRqe6pTqv6KJHjRVlhVNOgNj6qaFCxoy7FmmGlOWLw5ePCg602V+/btC/nnBQoUsK2Pmtmlasy0ateubd/0a26bl9QmOHv27IjagdWanbZaxm0reLAAULeXWtPDUfB18803n/J9VXxFQkG0l1WAaukTryrPVPGo1vxixYqZDz74wHgpnjdzq+3bi/tFgWz//v3t7acgxG3VcrxQ1adayvV40AcvqqbVhwh6PmkGqyqnY0VVhnrtd/LBhFrgdZ6aO6vKTL32qLpclayxoA8UnDrnnHMiqrb2iq7/0UcftfNJv/zySzsrU1XzwZ4HmkmrD81C0e+jDxEAAEDiO/UdI4BMQ3OutLDDy/YmVRqEC67SVmQdOHDAtmxGokiRIvYr3qlyzq28efOGPUYhoFo8FXzqzZ7aMXVdaq8uX7686+tUQKM5g+HaABXA6r7r2LGj48rGihUrnlIt57suNyFwoLBTtFzFaciqdl9Vv/m3M6udXeGmqi/d0KxJ/W4K1L1o/9MbdvGfZ+eF/fv326o4hYBq0feCb+GGU24qc3Vbzp8/3wY+Ovezzz7bhhGqanISHBUuXNi2PXu1DEjPDbWSb9myxX74oBbqRKRqQAXCGe26666zLeR63ujvgLTUzvrqq6+aTp06mYyk11I9v51Ur2p+pNOFHPHAt/hHv6NaiPV8872GqoJQVYWaAasqUQAAkPioAAQyMc2GczsnTz8TyvHjx12fh6oGk52G3odr1/WnKkY37Xh6U68lD1pioKoON+GfQltVgegyFK7pMaGlAXpzHipQ07Fa5uK0vViz5vyDRS1p0Lw1bYd2SqFYsN9NQZEbapVLq3fv3q4uQ211Cgd0XqFCU6dz1RRaNW3a1P67LtfrkEmhmgIVt9WoocJPN5WgToMnVS8pLFTYp/l1c+fOtS2f2viqdmUFcE6vT1VvqozyiiqO+/Xr59nlZWb6IEEViaowUyWtNtRqQ7w+nNL3Mzr8831IodfCcC2w2t6u17hEpABQW7M1i1WVxwpk9RxUdTnhHwAAyYMKQCAT01bUo0ePOj5eIYb/Zl1VxGiOnxYhqG1Rb5A0m0lvGJy2+qlaTVVsmYGb9kcdq6q4aA/k1zy/u+++O1UIq39XC5m+GjZsaKZOnWqDKIVHmsG3bds2uxBEb9rDbe710XIFhTc+qszSVl/NRnS7zViVYIG4bc0MtAxEv69aDrt16xb259VWp3mXqoTU7xYq/HZS4agQcdq0aScriFQBqjfgY8aMMV5S5aM26AZqg3Z6uymMUxumwl+1mqtyKBwt1KhUqVKq76myTzM79TqkFltViC5fvtxWKAZ7bGgWn4Ij3eYKKvRc0Tw5VfopHFY4qMeXNlhr7qGWW2jBiW5HvVZ5QS2p2n4c6AMUhauqEvzjjz/sXFIFmbFYrJGo9HeAgr54CPuCUXu0ZiRqXqZmluq+9dFjTrMIFTYn+v2sD6q82tAMAADiDwEgkIn5to06peokvRFS6KM5f755Uj568961a1fbpue0GktznIK1dAaicEBv7hVE6c29zkmhkN78a8ZVvFLwoKDIKQUjqsyL5jITBXy6/UNVg6m9V5Ut1atXtxs3NWfRDYVDqi70n4ulVjM9TtxSm3ioofVuHkcSrHJN51ahQgX7hl5hWSCqWlRYp9ulc+fOroPMYAGZNmr709wzhW1ugnon3n77bfPJJ5+YvXv32gBG192gQYOQt6ECVlWZamxA2seMgsBQAag2MPuPG9Dt2rdvX3sb/vPPP6nCFD32w92eCqP9L0+vZQpuFfalXdahwFpBrZd0jl988YWtnPIPzhWKDx8+PNVzXUtE9JjSa5Tbxyjih6pItZVb1Z+ahavng/7+0RbiRA/+AABAJpEC/M/gwYNT+vTpY/+JzKFnz54qS3L8Va1atZSNGzemXH755SGPu+GGGxxdXrZs2ezlOXH8+PGUDh06BL2snDlzprz33nsp8Wr37t2ubmt9ffvtt1E7n//++y+lUqVKrs/J7deaNWtSXe+vv/5q73e3l1OwYMGU5cuXB/19Dhw4kFK+fHlXlzlz5sywt9OiRYtSmjVrllK8ePGU888/P6Vy5copL730Usr+/fvtn//zzz8puXLl8uz26t+/f6r7qEWLFmF/JkuWLCnZs2dP93UXK1Ys5eOPPw54O/z1118p1atXD3sZhQoVSvXfRYsWtb/T4cOHT17WN998k5I/f/6oP/ai/TVp0qSTv9ORI0dSrr/++pDHN2zY0D5enL5e7Nq1y/4TSAR6vTp27Jj9JxDveI1FouE1Fl5lN8wABDIxt9tyVe2goeBr1qwJeZxa8FRRFKoqQpUwWl7hdPOqWqxCtUKqKlGz0xYtWmTikdvFEhKtikZVT6mSRS3g0aZqTX/aPupm5qOWdGhb6aZNm+yCjrRUJalKPc0vXLdunePLVQXfbbfdFva4a665xlapqd1V1Y9qV9WMRbV2yq+//urpVlhVxWkOl6jKVS3a4agF1s28yGBUzau24ECbgjUvUTPBwtHtoXl92j6tRSu63VS16Wsr1G2lNmvNf0x0/kt67rvvPrNgwYKQx6ua1smW6mjwzdtUxa+WOmibrtqUAQAAkHkQAAKZ2O233+6qdUkLHxRKOKEAYObMmXage1paMLFw4cJU8wRD0ZzBtEFSIGpBfPTRR008cjvHTcGTAlev7d6921StWjVmt5PmZa1cuTJV27EbCkw0K9AXuKVtB1dr6VtvveW6RVbtol607Xk9IF+PYYWA4uQx7xOsVTmScFjz8vxbcHVOam11SkGXWqPVzpv29lHbbtoW3USkQNP32rZ161b7YYYTCsDXr19vAzk3m68jpetQy6o2pWtDrcY2aKanlmxog7PmKPoCZwAAACQ3AkAgE/vtt98cH6swSm903cy806B0zclS9Za2KGrLoG8BQdpZZ6GMGjXK8bEKm1SlFU80L02/sxu33nqr5+eh6ivNLPv6669NrKjar06dOubbb7+1/+12CUOw4zWDTZVkWgLhlqof27Zta9JLlXda3OF1UKuKQ9ESC6c0R0/bSr2wb98+M3369FRBqyr7nJo1a1bQP9NG32SgkNS3vVoht9MwT2GqglEtPlJ168CBA1MtlPCawnNttg4WkOt+1gcymqcKAACA5EYACGRiaq10+sb1+uuvt+2WbvgG4WtDZ6NGjewiiEhaFZ20Hqbn+GhTNZUqq9xQZZvXVMXlpk3Wy+CxY8eOEbWdBztelVQKqpxSOKbKR7WlqoU3PRYvXmwrp7QZWUGOm3DMCbUaKzR2G8qEWubilv8SH7ftuqECLbUEJ7rSpUvbrdY+2ogdCX2g0rNnT1OxYsWotOPqddDJ8hNtt/V6SQoAAADiDwEgkEnpTfq7777r+Hht2XRbYeRVRZL/ltBoHB9tCopUKeZGwYIFPT0HBb1u2ji9pqpMzUF02vYt2bJls8Gxgi21Dnfo0ME0btzYbiXWPDM3dBkKOhRk65+R3obayqv2bFVO+WYZRqOVU+erjbYZxT/EO/vssyOejZeWtgXHM7WFq2ruzDPPDPjnNWvWtHNGtRHWqzZwbSlWFZ7XrbjaRuyUXhvcfkgBAACAxEIACGRSqsRx84Zv79695tJLL3V1Haps8UKxYsVcHX/hhRcar3z33Xd2wL/CGIV4mqWlRSia4+UmVGjSpInj48uVK+d4OYqb2X9uKzi9puUSLVq0SBWehKJjNS9Ot4cCElX9qZVc89YirbpT27taknW/RtI6rGUYsZA7d25PZhRGKl++fCf/vUqVKq4CaYW2wXixrCSatBxDldGqwhw8eLCdk9qgQQPTuXNn2wqtkQZpg9krrrjCk9djzbL0kkYuOKXfNxZLgQAAAJBxCACBDKaNup06dbJtZZolptBMIYOb9sZIRFK1og2STqnSR8sAVHGlzaIaOr9nz55T5mGpfU5vrPUGNFgllaq+3FyvZsOll87lmWeeMZdffrmdQagATXO0FEhpOUOFChXMgAEDHF9e165dHR/7wAMPeB7+uF2SEQ0HDx601ZBaQhCswspHoZ8q/q699lo7Q9Lrluz777/f1c9oy/Rzzz3n+ro0501biiO5v7xa7BEJ/+ec7ivdF04pIA9Gy0HikaqVn3766ZOtvWrt7tGjh11kpNcxVdNpC3Wg56XmSapaNb1Gjx5tvKL5lG63U+v5CQAAgORFAAhkELX4de/e3VaP6I2fqrNU1bR69WrbZqhKGb3xjBYFjrly5XIVZLipulK4N378eLs1WJVfqqy54IILTJ8+fWwVlgIxtRaq0k2z2fRnCoeaNm1qFzz46N9V+eXmelWtmF5qMfVtYw0WEPbq1ctxm53CAwWK4dx2222uwhanzjvvvAxvv/RV/qkCT4+LQJVTCqZV+adKK20qjlYooflo2i7tlEJLNy2aCpIU4ul53a1bN5NIdD9pxqE/zaqrVKlS2J/VcyLUcdGYbelGy5Yt7evSTTfdZMP9atWq2XNW2KrXph9++MEuydm+fXvI1xh9mOF7bGpOpTbsppcej7628vTS88i3pCSSqk8AAAAkHwJAIIMo5HvttdeC/rmqN9R+piAkGnLmzOmqok9VilOmTEnXdarlWMFI8eLFzbBhw05ZcqDARBU3aje888477TZRtR+6ndnm27irKhi9kVcI42ahgoIeVQM5oWBT1WFO6DJVPRionVLtxao4UtCU3pliwe5vPZ4ykn8btCrB1HKoIE6VdU888YQNXTUPbfLkyXZBwrJly6J6PgsWLHB8rG+LsVNaNuKrclS16CWXXGISQdasWW1Alj179lTf14cFur2CbadWeK+Ntv369Uv1Icenn35qXn31VXvf6t+1/Tu9QbSWuARqI9c56oMFBeg6H39aRKTn3oQJE+wMyffff99+2KLHn7bkah6qjrnoootsSKkxAgrt1W7uq0xW27iqOTXjsFChQvYDjMsuu8zOz9NlRFLpmZaX8yT1YYJT+n2djGzQ+Wmep1rxP/nkk4i2cCM1/f302GOP2edG5cqV7f2mJTzMZAQAAF7L6vklAghL1SaaJxaOKk30ZldvuKJBbzoUOIXa2ikK7LTFVbOwvGrBDPcmU+elr0ioXVdBoyor1VosCmOaN29uK3XCzexSAOW0fU5VQDrPe++919Hxaj3VsQo3VWmkkLJMmTK26s3tsgWnduzYYQOP/Pnzm4xy44032oDFn9opVYGlr7R0vtHmX2kaju4nN/yP1++ptli1dsc7PTcUAgaix6eCCbVkv/3223ZuncI8hfQK1fyXfyhEVMVr2jZmVRIr5Ih0EYt+VrP5NFJAoZ1CPAWNemypatFX9aY5fitXrrTBv2b26ecCte8q7NeIgqVLl57yZ/p5/V5aQKPFL5oFmvZxoKBXz2lVKavSWRXMqgrW49ftVma9zoZrjXdDjzndT05oxmGoDx70u2gUgoJc33Z33wcXqqpUtbSquOGcHkuqcn7llVdSfV8fjOh5pjBaQavX82ABAEAmlgL8z+DBg1P69Olj/5mo/vvvv5QlS5aktGnTJuXyyy9PqVChQkqzZs1SPvroo5R///03JV48+uijKvNw/LVixYqoncuyZctSChQoEPS6ixcvnrJ582Z7bJkyZVydd0Z95c6dO+ifZc2aNWXChAkhb5O2bdu6ur4OHTpEdNtv3bo1Ze7cuSlz5sxJ+f7771O8tmPHjpTbb7895fTTT8/w++S7775zde49evSI+jmNHDnS8fm88sorri77gQceSFm1alXK+vXrU44dO2bvh4y+D9x89evXLyVS+tlwl58zZ07X55QvX76Tr0Veady4sWe3WbVq1VJOnDhhL/eff/5J+f3331MaNWrk+Of79+9/8rx2796dsmvXLvvP9HjqqafCXu+1116bcvTo0aCXob879XdqqMsoXLhwysaNG9N1rplNly5dwt435513Xsq2bdtSEuX/v/Rap38C8c6r11ggVniNhVfZDS3ASBq+So6aNWva6hMt11B1xvTp0+0GUbUcRro51GuBqk1CWbx4cdTORfP3tNFW1Tr+FRyqPnj55ZdthY3+3TcoPxEcOnQo6J+preruu+8O2Vrtdg6X2+PV2qoZZKr4ueWWW+zWVN3GtWvXttVG/lRtoyqRG264wVx33XW2FXvFihVhr0MttLpvVSXlthIpGtyeg9NNwT6RVE6lnXMXyl133eVq0YNa3NVKqmUmqrzU/ZBInnrqKVsJ69bChQvtz4ajtvm023RD0e2ox73vtcgL69ats5VWXtHzetq0afbf9VjRTD3NFwxWUelPcwSjMftTldB6HQ80D1AVf3otnD9/fsjnj6rV9XdquKprvZapah3hqfrbyfxYzZrUmAkAAAAvJMa7eSAMvenQmw/f7LdAtGlWIUqocChW3G5k/eeff0w0aUGE5tNpXp7emKttTtt51S7r39anuVfJ0nrlP6ssLTfLUXzzs5zSjEMFfYEeqwol69evb1vtFCq2adPGtjaq5VHz1xSuqK1ZLZd6LIdqYVVg5Wt/jgdu5xq62fwsvu2tbvz++++Oj9XcRoWvkXC7jTUSep46CZrc0GxGtzPpNO/PKbXl6vmgALxo0aIBQ6hixYqZN99804Z1WlzkJV2u19RKq7EA+vBJIY9anhWehbpvFHarZTjQbND0UtuzXse1vVxtynoMa1ahWqg1b3Ps2LGnzEv0p9chBYhOaIGKRhsgPM2jdEojJrxYbAUAAMAMQCQFDWp3sixDlW56g+qkQiWa9GZXc37cHB8LerMY6s2gZhEtWrTIJAMNsNcMM21bdjujMK1SpUo5Ok6hqoK5UFUyClw0U2zMmDE2QAhGgaC26aqaNG1gqdllWm4QL1R95PQ2UvisKir97qqiclpd6WRDbVpbtmxxfF6iIFahyZw5c0y80HO2YcOGtuJQFbp63CiEUTisIMrpgppANOtPizv0O+s1dufOnXbmW61atWyIrQ9T9HjVv6syT//t5rZR5Zku17ecRlWiqnbW/aLAWAGhlmxEi34/r2kphiobfUuHfPfP66+/bjdfz5gx4+TzX6GtKvC0/Cfar/FaAqTgz+2iko8++shV5bwCRTeVtZmVmxmnerwsWbLE1VIXAACAQAgAkek+TVd1lTaOel0t44YquzTc24ncuXMH3bwZa/fcc4+9/ZLFxo0bAwaAaRcXhKP2Nye09dlJNadClVDhn4+2kqo6J+3G4vRua/Za27ZtbXAU7nfW7aNlApFsFtXjUmGLm4o1t1WJCiTVyqsgUFtfM7rdUVtDFaCpldxHrfz68lEVaPny5SPe1qrNzWmrplWNp0DLX+HChU337t1dtXrrWLU4+tpTFWAqTNSXVxSEqpVZ1Wl6zVeoqMBRW46jNdLAf+O4Ho9z58418+bNs49v/V2lSms99hQ+p9227IaCflVQ7tu3z96GWtL0/9g7DyipqfcNXzpIF0EQCyqgFDuIXbD3XhAriAqKHUEUxYb9p4JdUcEugl1RQVGsoCCigiJiQTooIkpn/ue5kv1ns0nm3kwybb/nnJyF3dmZ2ZlMZu6b93tfTgr4lZ1EhZMkNhA9IKQnXfGWl3xycwuCIAiCULiIACgUPCxObVpycbH89NNPZRpJswkjb4yzsShNByNbiID5wK677qqzFPPJXZYpLNBx/LkFAdvGV3IFTS7z1FNPqbhBVPDmjJkKklFxWm1xeyFmhNGgQQPVu3fvtNeJ8BdljNdh7NixVuIfj1cUdxmiFeJXrsU/wP2Z7n40bdpUZ9FFFQBNIxPY5zixEsWZlgQ4R2k5f+ihh8qI7ozcsq/tsMMOWWmbBvbNCy+8UIt+5H9mArmgnEQi1sINbbK4tB9//HHfZu0o2OReAq3QQvyZqAsWLJCHVRAEQRCEjJEMQKHgsR3X9Do0cgHiAw7AdJlP5F8hbCBUIBri9sil8IDwg9Mql+JpnCAOMPKMCIFDDbcTY3o2Y6Fgkk1G3lwS+ZM4nHAyJiWq8JiccMIJWvxl9BORBwH93nvv1eOhfg5KB/bvUaNG6f04DModMhH/gHFX24xBsi9twV3HSGy+YOLI3W677VQ+wnEE52DcILaz3xL34Oe4xTFHVh/vHXG65Uwgey8TGI/G+ekV/9xjzbgAGRmNA/JGk7x8ecVWWHW7fAVBEARBEKIiAqBQ8NSrV8+6ATQfyixat26tF3GdO3cu45pwxiVxVzEKSqA8Y2QIMbRhJpFdZQruGZozcbPYNrXmGzymTiELjiHGO/fff3+r0gYaXk1GtJN0xniFRQSAOKAVmqZKmrTZV8nZvOWWW0pEvxYtWuiWaMd55C5FoWSFzM327dunvR3y6zLFxIXpJmqhB8JnPsEYaDrOPfdclY+QdYkAh+OW12KXLl100zWZeQjCzz//vM7MY9+zcUzh0GTkNh333HOPPrGSTRDmMjl+d+vWTQuYYXBMI2vU9jXhx0477WQl6vGcCvEWR0G6kyiCIAiCIAgmiAAoFMWZdJvQccSRJFwnUUBIIa8NoY/iAwLUDzrooFBXIw4QFsnpRi+ThLwpxk4Zp2YcmEZbGkOLBUZbGZ004bLLLjPK8UKopighCXA6uRf7uJ8ybRTFcUJRSjqXHPvCJZdcol2ICA/su+SAXX311Ub3gdFIhNdsY+qo4f6xfyPyUraydOlSlU94HcGM+k6dOlW7NJ19gmbp3XbbTeUT7dq108IkJzdatWqlhTiOhTRdUw4yYMAAdcopp6gTTzxR33cEZhy76ca8+bmNoMz+65SQBIHrNczpagtlQFFAbDd19vH+gKgaB7fddptRZi4CbpQynvIII9ym8HklzlxMQRAEQRDKLyIACkXBRRddZDzKhViRb+BIZKGLQPTuu++mvTytjJQQ5Bqcl2RNHXzwwWqvvfZSxcTChQvTjvayiOvXr5/R9bF/JuWOQTymgMH9vODcM4GFPU4/xC1GhxFmEFoQZtyuPhO4XdtSAwSsTJpqHWxGOcl6NBn/RdDkdUlmG6JwHPczbrbaaiv9FWEIIQtXLi5h9l1cRowsI1oSOYCbK1uEvXYQMxBVEan4Nyc10sFleP1079491A1IQQkZeaYgPvP6weXasWPHUq8LHk8ESVyvpq8nE6KWj9DubENcwjrP0QsvvBD62ianlvbjfBqPz2dwcppm+/bq1UuyFQVBEARBiAURAIWiANGCMcR0EAp/5JFHqmJoM2Y8jvy3XMAC/MMPP1TnnHOOzlI7/fTT9WJ+s802U/mUL+Z28bF4pcDEFEaCHYHP62SjPOCxxx5TQ4cOtVrMI16YiGpRGqrZd9yjhQhXNMSScRgGLjGcnDjcEIoYKWU8FkEwGzAabZuH5YdNAQh/q8ni++yzz9a5m/kMAiquK/IZEYjcBTZz5szR5SqMYZN7ikiIWzRs/BC3URwnF4gIIL8UVxgZpmw4+vgeG+UwiNa2bagUXISNYacbj/WCqMtjSLwC94v/00xMDADPveO8QgTONL/PEaqjlM84OaJJXj4MxFBE2P79++vnzi+GgHZshN84RvqLHd5TeA9Pd+xjHJ7PLYIgCIIgCLGQEoT13HnnnakBAwbor4XK8OHDU9tssw1KQKlt8803Tz300EOpdevWpfKZhg0blrnvYdtrr72W9fv4/vvvp1q2bOl7f2rVqmV1/023ihUrWl3+vPPOS61evTq1du3a1KxZs1I//fRT6p9//kn17NnT6no6d+6s/+YVK1akJkyYkBo7dmxq6tSppfYj/n/JJZekOnbsmNp7771T3bt3T33++eeB+9pvv/2Watu2beBtbrHFFqnbbrst0uN08cUXl7m9V155xfj3n3zySev9YdWqVam33npLv76GDh2a+vHHH62vo2nTponsN0HbBx98kPY+TZw4Mav3KemtdevWej8G9s0FCxakRo4cmerbt2/q3HPPTV1xxRWpyZMn658vX7481aBBg4xub8yYMaGP7/Tp0yNfN8fzNWvWxPK8Va1a1ep9gcesffv2pa6jQoUKxrd36KGHGt3O3LlzU7Nnz9ZfHfr372/1t51yyimpuOE1bnLbjz32WOy3XYx8/PHHqQ4dOpR5/OrXr5+6+uqr9fG1UOB1xP3N989ZghB0jBWEfEaOsUJc2o29zUQQ8hhcTzg5KCv4+uuvtVMNx9WBBx6oKlWqpPId2yZTW/dMppAtduyxxwbeT5vyDBsYLcOlZgotvo6LjvFWB7c7ygTn8oy2esssGA/F0ffMM8+U+v5HH32khgwZog444AA9NkdJiNtViOOOYoNPPvlEu5nc+ymOytNOO02P4jLmbeJqdUMeo5dhw4YZ/z7OHdycpo/NHXfcoR1l3Fc3vN7IDTMZOcW5h+MqWzDO6c7TIo9t1qxZ2iG64447ljgfGYMuJnjt4mjDkYcLDQcSri6//DseiwsuuCByMzN5l+SUhkG+ZFRwG+PW4zXmBXcdzt/Zs2cbXddhhx1mNT7uPGaMyOOI432FkWved3gtp3O7XnvttSoquNcp1zEl7oITjnmXX3650WV79+6tHZ9OoZXgD43On3/+uc535D2Bx5jCj8MPPzyte1sQBEEQBMEWEQCFooPFHAv8QgzNthljhGwKJ9CjRw9rkTIObFuegy5Pa20cOWaIXxTPhIXsjxkzRhe6MCq9YMEC3TiKGOc8fogkXbt21QKi30jm//73Py16kk1mysqVK8v8n+w6UyZMmKDFlXSNk/z9LO6D7hviDovZt956K+3rkPHLONpKHRjJRvT1luRQ+oF4QjsqrzNy33iM3S26iH8IoBSY8FjkGvYLRKMZM2bEcn2PPvqoFgBNYNTzyy+/1M+hLQjDQaPxPNfvvfeeUdZpGBTN+IHwzwi7qdBGvloUtttuO705UFxC2QoZhEHHJEpOMilj4SQEcRc8Lya5sunKTWzhxIVp7AQnpzgBctZZZ8V6H4oVTj6wCYIgCIIgJIlkAApCHmEbDm/aVBsHU6ZM0e62bIODhOZmGygm8QN3HYKKTVB70ELYpGFz4sSJ6tJLL9ULu8GDB5cST2lrxeHHzxDL/IRsXEU2eIU7bsPW9WiSoYZwlk6YJHMOtyj3IQwb95UJuCnJ90N4qFu3binBCFcfzx3upM6dO5cS/xwH64MPPqiFlnT3O2kQcBCTcCiyHyEemZYGBEFTsym8Tl555RWdB+iX+RYE7k+csV4QXcnuo7QEoYxSkqROCtDMjVBmkvFoe2wJOxbj5OJvbN26dcn32QfJQ8QxyOshE3itkD2abj9ABKVRPo5sTTc4623I5vsFGYRk6nGiBaE7LtFcEARBEAShmBABUBDyCG/ZRDpsFuaZgsMlF+BYsmlu3mWXXQIX/4gqQaKeFxx+QQ5Am7IWxoEp1wgCoYmgd69jDfh+/fr1jW/rzDPPLPX/KIJRnTp10jr2GPs1dQGlG0FOYjT/u+++0wUtXrcqJRjEBNx1112hvz937tyct5kiQuJI5KQAJR+M8CJyZIKt2IoIyBgwTlScqozWh4Fg/c4775T8/6efftIOwlGjRul9k7Z2xq3joEOHDoE/Y4QeFyqvnyCBjFHWhx9+OFYBmtvFUcj+x2seMR3HHOI/xxIeR4p6MilvYsQZIS6oTAgh0nEjxg3jqUlePgqcaOD9gZgIXMmccDn33HO125vHgNeNIAiCIAiC8B8iAApCHmHTDskilubPbJELRxRuIZo3cdSwqDN5TBg/DFvU4xDBpZRuIX/99dcHLmptnDAmY908togEXsiAIovNFO8oLb/fsWNH499v2bKlfszDYKSZdllTnnrqqdCfI3DZCt+FSKNGjawuT+usex/y2z9scY+s2kAmIEI8YgoOSe/18HpC5MMVymsP8Y0MQEQvsszI2Uu3H9iw//776301DEbscenivEMUIj+PxvIbb7xRi7s01iaZC4v4zgkaBHPHFUhLeqtWrdRGG22k4wGinlTBNYzIyBg1x8Xjjz9exwnw+P/888/6upPAtuXdnb+aBDQ2s+9xQsIvfxYxmuZ3HLSCIAiCIAiCCICCkFfYuGMQe7zlC0nCojVuttlmGy22+YG4yQiZI5xQUBGWJ8WoMLlu6coHGItLNxrHwhLBwM+pw8+SgEIQxAIvZJmlc1454G4kb9CNjYDYs2fPtGPoNmUsYFLGgDOsGEEMw5HFGC2Pm02ov/uyOP/iyN40EdHD4HVDDihlF7gkKcHA5YkQ5TjOGLM++OCD1QcffKCSgNFfTgqY0rZtW+34JAvz5Zdf1tmGuMXiApcjfyvjv95jA88ZI8bs3zj/3DgORcbRbbNfgdcp4hcuRsbaOX7gwLSJOLCFCAUbTAuFotK3b1/f4iPvc8DoNQVMgiAIgiAI5R1xAApCHmGT0QXpFj9xcvTRR8e+kMeZgZvs/vvv15lsLNTIy6KAAZede6HOwpZcK/LycCMxzovLBicQbj0W4iYZWwgBJs4bMqRosvUbkY07WwsQUvwEXRauCxcuNLqO5cuX64wwNxQB4BBKB4IrAmA6bFs9TS6PQytICC5kEHYQQHGdIUzb5DGyrzvg9soUGpmDXsMIV2QMsr/jkPVmI/oJm7z+cPjhtHOPWJ9//vmRBC0TeL2THbjrrruqXPPSSy9pdxmPAc8tuaNNmjTRxy/HIctI6meffZY2TxOHYCGAexE3pwm4EBFfkwLXNKKn6Yk1ni9BEARBEITyjgiAgpBH2Lahvv/++ypbsOiPMy8L4QDRB0EN0QABgkUao47knwXBops8MhxI5GxRkoBLjsW3CTaLbRaY3hwrhEgTQS0uaBMOyxD0ggvS6xR69tlntfsr6Pnj7yGrzaRtmcffpqzGZEyd/YDbty3BKSQQrr0tzWEgHDlCms3v+YEQg+jtdYfhOL3qqqu0SxFR/corr9RiLAIbr0HGvW1grDYJ8Y/9Y+DAgVqUx12Ya3jMeM14xT2cmjiVeewYx2Us2oRbbrmlYBxqZGsiBKZzdsc58u0HBTWc8DDl6aefTvT+CIIgCIIgFALFu9oShHJANkLWHRAG4lzcB4XYJwkNsWPHjjW+PCPAtB97weUTN5R94KryYur+C7s8jkVGBWfOnKmuvvpqPXqIk4e2VNxljBBSOGGaA+ZtGw7jqKOOMrrcXnvtldVW63zHPQ6eyfg9jz9ClVcg5/pxzCI++Y0Xf/nll3rE1KTtGii8ML2sLQiSiG62OYpJQKkNj1kYOABpGDYF5+8bb7yhCgHyOnF6Mgrude0ytn7eeedpsTvp58omhzTK5QVBEARBEIqRyrm+A4IgRIemw2zAAtXUzZKtPLIo/PLLL9Yipl/mH+N+N910k84TC4Pgf9MWSvL7/PK7bJt8wy7frFkzfb8zAbHIJnty/PjxRo5JAvvjaogtBrbYYosSx2abNm10DiRj7rbcfvvtvuIu3083Co9IePLJJ2uReMsttwy9LC3WCOxJkC/CMMeOdOKfg21jM8cJxvULgQ033FCXwdx6663qvffe0/EFnMAg79A9Ep4kNnmaUS4vCIIgCIJQjIgAKAh5BCOQNovobGVh4SCKc3GP+y+bY7QOjBnbggjCqDUuOlqaGVkGnHQ49hg/9rpLWAwT7o94svPOO6cd4UW0CyrCIF+MdmPT8XCnjCEpcFDaOE/JXERswiGGMwhBFTcao8H8XQ4jR45M6B4XJu7CG4RA9iNbAfCAAw7Q45h++zS5myYwZknOHQ26F198sdpnn330c/n8889rRymvC45D6QTCTDj11FNVPkDmKpEDwn/UrVs3Z6KlTbs5pCuHEgRBEARBKA8kIgByFjgJWARxtlkQihVbkY3mycMPP1wljU3WUjq22mor47y5uLHNTOSY484cw0WCGIH4h0OLMb8zzzxTO6kmT56snz8EF0YrnfILssvSjQwj7tHe6zdayygdGW5cfxRRGNcSLaXkAJKbyN/AYphGT1t3IeD2sYExatpAySZ055xVr15di8BDhgzR/0ZUEv6D58XrkF22bJnVw8P+FyTyke3HvmAK+zX5nGwdOnTQ+6I3lxAxnOcx7lgC8uYolMgHyCBMiu222y6x6y5GdtxxR+3ETley4pxYy4XjXBAEQRAEoVwIgCw24ywLcBaxcV+nIBQ6kyZNysrtxDGC16BBA132cckll+gRslxgm6fnHRf+999/1aOPPqpefvllNXr0aL0IxcVGu6pfw+pHH32k/14TgZXG0O+//15VqlSp1M9ojrURx8gS47rgxx9/VCeddFIZ8ZCCgr59+6q77rpLde/ePXBcmtxARB9un9E+xGbb7EYEQ78AfoQiylx4LHEG4iYS/hPueMy9mX20ntqAwEtDth82I9x+I91xX2dY3hzO0Hwph3E7VuOEtnPTdl3h/6GxGidguhNU11xzjc4uFQRBEARBKO8k9qmahbN78ez832+zuYwgCKVFmmxAQUOmjj2cYG+//bZv4UC2iEt4RBCjSCMs5+vnn3/WghkCnqm7iBw8L5SQ/P7771btmBwz2TcYsw1yDnLfzznnHPXQQw+V+dkjjzyi8yXJ+Jo+fbr6448/9LgnDcq9evXSY5+mpPv7EVX33HNPLYKUZzjBhYjMmCmju16nr63YHybU5nsemvNY8Hena5zNJoxh2+BX6hMkUPnlfwrp3c64yYNKctiPiGgYMGCAPJSCIAiCIAhJCYCMC+FWIBuGhShnXm+77TbdKsj3yR/iK//n+4zScTnGwRAH+H2/zXQhLQjlhWyJ47jSyL/LlC+++EKLPRQG5IJ99903tuuaPXu2r7PN4X//+591EQDOPC+IbzYgqHGMpbV5/vz5aS9PrpvbvcWoME2eQZmD7HPuUd444D7jRswWuXShBoGo+thjj2lXqRsKOBiB9Y7choHwwRh6mKCfz4IT7keaqYkLyCcQI8lANIWijHTHHOIEeL0J0cAByMkW3Mr8G+F7l112UX369NGZmddff71MjwiCIAiCICQtAHL2ntEuxs+mTZumrrjiCn32nAB9xAS+8n++T/sdYfmMPRE0Lo4/QTDDOy6aJO3bt4/lesgeQ5zKBV27do11MYhg4wcjacOGDbO+Pgoz3n333TKFIjbg7uIx5rpMQMwjhw8QDMk1NCHuSIa4RcV0WZDZFBxNQOCjWMMLQoatkIw7NayUg1zJE088UeXrcYlSnTFjxqh8hBZtk1Hg/fffXx111FH69Yyj1i3sMtLMz/gbub5iiTf56quvdKQAjjz+RmIfOOZysjdJaLkm44+CIj5vOieXkyymEQRBEARBKEQSEQAff/xxHTJOGD4OGScMPwiCw5988kmdV0R+IL8vCEJ6gkafklpkxQVjqjZjrXHRrFmzWIWPoFbWX3/91bq0wXH70eKLm8Vhhx128C0HCYKTL4gONoUyjNExot2uXTvjEgdO1FBOkk8w0mwipjBWTXELuYb5PNLP2PWoUaOsroN9BedZOm6++ebEXJCIP4yQZ4Jt43FcILY+8MAD+oQHjw9iKaP8r7/+up5CYKweoTYsEgGXIA5GHgecneyXiGNkkOJWY9Lh1Vdf1SJhNuC2+/fvr52GCMp8zorzRCvXdd111+mTupwU4VjC9zieDR06VD+WOB0L9eQujuqPP/5Yv28hMsZZiiUIgiAIglDwAiCiH4sw2jFNQ7MZR+JMMR8Qn3rqqSTuliAUHdnMTYvTbYg4heiUC3DjMCIWB0HHt0wWuvxuz549dRac87hTnmLKBRdcYJ2zyOX5PVtRlnzAyy67TOds4RzkfjJemsuFuuljj+O8W7duKp/wZisiOtjsSzVr1tT7jUlpD9EbSTWj0mJM9iTOUnLacKXautySKtwIg/vMCCmvBVxkFNgg2nGswrFHNiPfI64Ep1nv3r21QAiIfYiDjNC/9957vuIyJ2w4CRHnyZR0uaLcJ4Q52sg59t1xxx26BZzW4aBCF1sGDRqkR23TCc533nmnKiRw5eLQ5DnjcWSsfr/99tOvL6ZXcplnKwiCIAiCkDcCIE2WYJvf44xrOL8vCEI4zuIzGzRv3jzW68vV4om2WRwwLOC847W2C/MgIREXVibNpYg+ZAi6c/pMsscuv/xynbFo6wxFsMGxFGVsl1FaHI+0IyMukPOYCxAecVWZgpuLEUUer3yB1mY3tk4jLk+MBmUtYa+viRMnanGO+I0kOPTQQ7XohyiMyPTPP/+o008/PSeRAzbuywMPPFCPHwfBcQOHLfmYfF5hf2dsHtcs4vO4ceN0A3cuxEs/8Y99GxHZD7IlEQJp4M4EnM6cADABkXDp0qWqEOC1hBubghbvPoEIjJjJ42vbLC8IgiAIglB0AqCz8GAMxAbn8oXyAVEQck02R6pOOOGEWBe2uSxhQOi7/fbbdZEHI5bPPPOMeuONN3R23mGHHWZ8PTj1gpxYmRYYIGY5BSDEJOBCOvXUU32dVIgtOHwQJICRRZumXpykmZQskXeIsIpIbFNWEScXXnih9XsHIgjNy4xGZtpyHQeUwAwfPjyywxdnLc61iy66SIvQjCy6YTQcYY1Rb8ZSTXMibaEp2kuPHj2Mf5/7aNu4myk4vWj3TsdHH32k3aNu2HcyEfyTAHfrggUL0opcXbp0CSz8MeG5554zzqhECA4rTsonOOmC4Jvu+MHjJwiCIAiCUChUTKrBD0aOHGn1e87lGzdunMTdEoS8x3ZMLptNnhT3UC4QB9xvRKpcQz4pLg8WcdwfhEFcKiZiEI4z5/FgAe1dRCPCZAKC3KxZs0qJiiyecRnRdokDCcGNTEOcXFdddVXJ/tOwYUPtRDJ1/zEOmimIAAiouQAxK6z1Nmw/5HF96KGHtBhMdl6m2XWZ4oi4kElGIWIoo6pvv/22/j/RGjjzki5kQIjdbbfdynyf75k8RwhpjIsCzjrygc866yxdKMZr6rPPPov9xMeSJUv06K4pJhmLuQSRks0EGtnJN4zKhAkTEr18LsDVSXahCRS5kLEoCIIgCIJQbgVAcnL4gE7TIqNIJhC6TW4OC1jGcAShPJKuMMcLTp5swiIZN1qmIFolJfRz7KGEqHPnztoFtfHGG2tH0X333WfkEOMxpcEcYSiI3XffXQsTZF+RGYaQxEaREaNhCAq4AzMd0Xa7+HDPnHbaaXoUGGcKZQKM+eEaa926tXYAuoURRoi5b2GQL4gwhAhQiCCQ3XjjjdotRi6XrYvR/V7DODAutUydm5mCQEeOH38LObqZgCOQ/RCnEo4wm2KYINfuTjvt5Psz3MH9+vVT99xzj+/PeW93RMiw/R2Rm88QFG1suumm+jHAYcp+zueJPfbYQ7/+KEiJi6+//tpq3Jqx2XwttGAUGaewDV5Ho+3t2ZCJ2zCb73M2f9cTTzyR6P0RBEEQBEGIjVQCTJs2LVWtWrVUxYoV9XbyySenxo8f73vZCRMmpDp37qwvV6FChVT16tVT33//fRJ3S0jDnXfemRowYID+KuSGgw8+mFWl0VapUqXU0qVLs34fX3zxxVTlypWN76d323rrrVPz589P5L79+++/qeOOOy7wths2bJj67LPPjK5r1qxZqauvvjrVtGnTksd7zz33TD399NOpyZMnpzbbbLPA2+F3vvnmm9THH3+sj2lRHqeNNtootXLlSn1fli9fntpnn33S/s7ll19e6m9YsGBB6phjjtHHVr/n4e2339aXa9++feTnMxfbSSedlOratWvqsMMOS9WrVy/SdWywwQapNWvWlHnezznnnJz/fZtvvnnq+eefj+36DjnkkNiui/15yJAhqZ49e+rrPfLII1M33XRTas6cOUavq7Vr16Zefvnl1EEHHZSqWrWqvs6NN95Y77szZszQlxk2bJjRfdl0001T1157bWrUqFF64/XGa8WWd955x/px4O9IEh5PjiFsfvtpEE8++aT133LooYdGvp98ZrC5rf79+6fynQsvvNDqbzriiCNyfZfzgnXr1qVWrVqlvwpCvjN37tzU7Nmz9VdBKATkGCvEpd0kIgDCo48+WiIAOludOnVSO+64Y2qPPfbQX/m/8zMWqHxlYSHkBhEAc8uDDz6YqlKlivGio0GDBjm5n3xYYgG/1VZb+d6vbbbZJtW4cWPfnyFwJvVhizfGY489Nu3jxnFn6tSpVte9evXqkgU/opojCoZtTZo0Sc2bNy/1+eefp9q0aWO9KO/bt2/J7d96663Gv4cI4ubdd99N7bvvvqVEQO7b7bffnlq2bJm+TIcOHazvXy43xNhMr+PGG2/0fa4/+uijnP99bM2bN4/tuvwE4Ey21q1bx7LI5zq84taiRYtSNWrUiHzfOC7y2vnzzz+N7wcnHW0F2qTg72ff3GSTTUpub8MNN9QC6S+//JL293fffXfrx4yTsLYgTCKW2z5Xjsibz1x22WVWfxMnnYR4FqdLlixJDR48WL+Xc4KBEz2jR48WUVGIHREAhUJDBEAh7wVAGDlyZKpRo0Z68eFsbkHQ/X0ux+WF3CECYO7gA2+UxS5OtFx9aGJDXLr00ktT3bp1S/Xp00c7eh3B7NVXX01dfPHFqe7du6euueYaa9HNlvfeey8rCzYcR6a3c9VVV5W8aY8dOzZ1ySWXGDnWEBgRDwGBBMHB9DZPOeUU4/u60047pRYuXJg6+uijIwsuhbidffbZgc8vz5WpIOq8l+GmHDhwYOr6668vcbUV+/b++++n4gIhmpOGhx9+eGqLLbaITaR0XkMm2IjgvK6S4LvvvtOuxqDbrV27dujjzrEiitiLq9mGxx57LJIIf8IJJ6QKgeHDh1v9Xbfddluu73JRLE45CVqzZk3fx3i77bZL/fDDD7HfZ6H8IgKgUGiIACgUhAAIf/31V2rQoEGpjh07pmrVqlVK9OP/nTp10uIHlxNyiwiAueH333+PPFLLQiXb5OuHphNPPNH4cWPxyt9gCwvsIHdj0MgxYqib3377LdW2bdvA30EAcYulEydOtB5t5UMCi3STy++9996pcePGRdr/Cm3D/YkwnQ6eo2bNmhm59D799FP9Oz/99JMe287135it7YorrjB+3TgCOK9Rxn15HhDobr755tRTTz2Vql+/fiL3kbF5UzFixIgRRtfJ55Yox450/PHHH6GxAu7bD4pJWbFihfVjxAkJfs+UN998M5LIiMBaKJ/ziF5gPzX5uxD8cYULmS1OTU6C8pzMnDlTHmqhqD/LCkIQIgAKcWk3iZSAeJtDae4bO3asbon8888/dbMlX/k/RSG0BnI5QSiPPProo5GD0SlxEP7j448/Nn4oKFgYP3689UNHy+28efOML79w4UL1+++/l/reZpttpr744gtdbLDnnnvq5uENNthAF1nQLvrtt9+qVq1alVyeY6UN//77r25PpRzDBNpC2f+c9vZihvKIo446Ku3leI4+//xzddxxx4VejhKW/fffX5d20MK8aNEiVV4wKdSBlStX6kKeTp066SIPGlb5Xae5+vTTT7fex02hMdv0dU5j8tVXXx16GQqQ+Bs22WQTFTePPPJIqdbvIJYtW6Zuv/1235/RXm5bPERZkEnrOXDSuH///lYFKJQ9DRgwQH/WK5TPeZTR3HbbbUaXpfiG1nUhOnPmzFGXX3552stx7Lj00kvloRYEQRCEDEhcAPRSt25d3dbIVxt++OEHdcMNN+hNEIqJN998M/LvtmjRItb7UsggNNiASGaLbcss+Im7CAlnnHGGFi05EULD78SJE3ULLYKgt3nVBsREhI9ffvnFSnx4++23dZNrMcOJKAQnxL10IKSYPIa0x3bs2FG98MILqjyx0UYbpb0MQhHtw8OHD1e54vHHHze+7E033aSeeeYZtd1225VpMD788MP16/WQQw6J/T7yOPEatGmpDRJgOa6Y0qZNG/38mMIx6quvvjK+PKIvDePXXXedPi4VErRP02hdsWLwx2REK8RNIfOToKaty6+//nrBttYLgiAIQrkUAKPy/fff6w+R119/fa7viiDkxEnjx+zZs40Wl7hgEJcOOuggddhhh+nXkteZlg1+/fVX9dprr6mXX35ZO93iBNeWDZtvvrn1beBmsVnI1qhRI2O30Pbbb6+22GIL48sfc8wxatq0aVa3gRuL2/nyyy/Vxhtv7HsZxEHcbjwGhcqqVavU008/rZ2Al112WaiTCZFw0qRJRtdrungtJk444YS0l8HpiliVS3766Sery3fp0kV9/fXX+rWAqDty5Ej1888/qzfeeEPtsssuidxHTgDMnDnT6uTFjz/+6Puz888/X59gMGHgwIHKhsmTJ1tdnveYKlWqqELl4osvVt99952eUuE4jlMStx/i4IQJE9Sdd96pxWEhM0aNGmV82XXr1ql3331XHnJBEARBKHYBUBCKlQYNGkT+3SVLloT+fMGCBWq//fZTu+22m3r44YfV6NGj9YdthPRmzZqp3r17R3K12cJiCeFxyy23VEcffbQercRl06FDBy0IxoGN8wWaN29ufRsIAfwNNmJCps4XxrxZ1JtywQUXWC9KWVQBI3pBrlJESEYk+ZuKgbvvvjv0hNIrr7yiyhOMnZvu23vttZdq3bq1eu+999Rzzz2nxTG/YxEj7bkmigDF6wex76STTtLHKhsBPgo2I7Xpfofn8Pnnn0/7d+Nc41hsg+17hXNcKWS23XZbNXjwYH2yDeGV99ShQ4eq9u3b5/quFQ1//fVX1k6aCoIgCEJ5RwRAQcgxZE9FJWw8lAU5I1gffPBB4GKO/CcbcSkKCHx77723Fh69i1aEQRahOCkyZd9997W6/GOPPWZ1+SFDhqi2bdtqR4hpjlRceUU4URgzTccVV1yh9thjDyuR0tkXGHclkzAoSxEn1cEHH6xq1qypioVbbrklMLfvjz/+UMUMLrHatWurrbfeWh8HcL3hduN7YeAQRRxDFDvggAO0IHzkkUdqh9Q555xTKiPzs88+U7mmEIQaxv6JRjEFcW+rrbYK/DnH1A8//FAdeOCBZX7GiRdcmbjAbdlmm20SvbxQPrHNUDSJHxAEQRAEwR8RAAUhx3Tt2rVM7pupc3CfffYJFTcY7UwH2VMsFqO4UEwccxQAMHqZTrjCnZgJuJFssMncYmQZccPUAYP4hzOKjK0gZ8yYMWO0w4hFcsuWLXU5BWKp320wekZWJC5Hv0wq9p9bb721JLj+k08+UTYg2px33nm65CTdqOsDDzwQmotVSLBfPvHEE74/q1evXmK3i0BjOqaZFLiZyJ9E2CXLDHGXYwoC8K677hoosiMYDho0qEwZDlmIiOS4ep3sxHSv+6RhP+V1m+/gODz77LOtThqlywZlzJ1RSUaFyWBE9OOEC0LvKaecEul+8n5j45zu3r17pNsRyhcmcQIOHDfJ4xQEQRAEIRrFsYoThAKGhRyNsLaiCgvbIBGBxb2Nw40xYTLeWNzdfPPNsbWZ3n///VoYMAEXUibYjhKb5CcCwuiVV15pfL24bhDgghpkcZaRpcflaBSdPn26XqQTbo4whGPJ774xSsx+gqhKGRJiIAH+CHJcvm/fviWjv2Sm2kCzqGmu0uLFixMRi3MFoogftuORtuPHPGfs8whm+VKQggOU4xGZoTwujIlecsklen/75ptv1A477KAbj8MgoJ99n30k6dHZdJDdFiXrMxf07NnTKA6Ckwt9+vQxvl6O6SeeeKIW/Ti2ZJJZx3tUuqZkt9MQZ6ggpIP3snTOYwccx5nEpgiCIAhCeUcEQEHIA1gwk6NlOrqJQ6d///6BPyfAHqHGFBxpbLiBWOCRe5RuoZ8OBACykkx55513jEU5P+bPn59xO68fjFAj0pnC6HXQeB5NxbgXgsaygZZNRiuDcpEQNK655hotBiLyIhyQ3ecVCZLM9iomATBoP0AMQ/BKApyUCG0UkTz00EMqX6C0wYkEQCxiTBSxkv2NEVXaOk1gH37//fd1WUKuQByPI1ogW1Cug8u3fv36aZ3FO+20k8oVZ511VloREJco72fF3iouxANua8qZyLsNA0d9Ib2mBUEQBCEfEQFQEPKEQw89VM2YMUO99dZb+t80yPo5MHByMC4blsWWaUg24iH3wUb48mu2tBEhHfdQVKKMG1500UV6/Pill14KbHJFTLWB5lMEWhqPvTz55JO6XTYdOPgYs4zKEUccYXX5XI+j5pIg0R2nFOPBUcbz0+EuaEAoyycQbvwaaUeMGGHs5gXE/5NPPlltuummsd4/xuFxJHKcfPXVV7Vg6WSC8VwxTshjyjhyoQlQuEERT3Euuh1RCH+nn366dmU6zuKFCxdq9y9i3E033aQ++uijrAnz3B6OZTJm3TRq1EhdddVV+n4WivNSyA+IwCAn2K+Eis89vK6JKgkTyAVBEARBSE9hfToWhCKHD7oIb2y4xRCmcOIhbjFOd9pppxktrGxDtYNERMaBbVx8mbZvHnTQQVo0YAFs676Kcnv33ntvyb8pMcBd4M3HMnUKusFJidNv0qRJpdx4LNhtMgpZTEcRMRALcAaaCjYIJ//++68qrxmcQeC0YtHJ627atGmx3B7ja5tttpn+N5mLXH8+gYhEAzLuRDd+gnYYXJ6TGAhFOFptTwZ44boY/6NYx52tiXBA1AAOZo6ffGVcmZFmnEXbb799QQmBHOdpneXv5DHk+aB0xXH5Mq7PWPZTTz1V5qQHJUX8riPM4agm8w+HL8IKzu644CQDG7cxZ84c/fyQZWrrPhYEB2IxOPlFni+vX96TeF/mM0Gu4wQEQRAEoVgonE/FglDOwOmCGBUlsH3nnXfWziby4jLh+eef1yOAUc66c/8RUHC0mMLilrFWNkpMbLL3WPhnAotYBAaETwox3ONsUaAtGCGFog/geidPnmz8+yysERKjNGkihFx77bWqX79+aS/brFmz2DIfC43ddttNZ5Wley3xXOIqQ5Anw5GMx1mzZkUuUqBAo3fv3rp1N4rAnDRTpkzxfT3b4Fx+xx131I4wxojJvAxy2oaB+IVYSg5mEIhcuGYRA3ndOCC2IoYjmvm5qvMVR1DjteyIf7iqEVPJaPTj22+/1SdR7rjjDh0zgPjqPi7SEM4xwdYhHAaj4TYNxoIQBvs7QqBfg7UgCIIgCJkjI8CCUISQpdOrV6+MrwcXIm6aqLDwjgoLVZum3jBxwAYeN/cIJA6jdI2bQbgz02zGJzP5HQfEU5yUYbBwRyhGeE2afBwJNBVCGAemuAVxiQy2iRMnqlatWkW6Tcb8GfV84YUXIot/STva/PI0EY9scF+eTMxnnnlGZwxS1mPr7mUcNuz1TekRzyWuRbf4Bwi1OGkRzmg9LmQY9w0S/xzYp3APMh7tPSmCm5xijkwLlwRBEARBEITCRARAQShSEH8OO+ywjK8nE4cSo6iZBNZTdIIIaUJQ8UaUv/fhhx8ulY/HgjoK7jZe05bDKNl8CHiIpYgglFewyMdFeeutt2onEIKTu/2TrK6BAwdqIYBRq2wQ1TGXJFHHFRmxxwWIwG0rPCOo4zbNhKRdg7hCvTBWiiPN9AQELeVe2O/YNxHkbDj44IPTZnmma7FG/Dr77LNVoYJ4+fjjj8dyXbhPyZEVBEEQBEEQyhciAApCkUIm3ssvv5zx6FsmwhoCFsHe7dq1i/T7BN3zN5jghOPHAYUHbhAsEDOjjDM5RHHZmYifjBkz5sjYMi2iCB0UOXTv3l1/H+EAJyKL/hNPPFGLIDjZKD8xbXWNg3xsDrYda3XDWDyZjpm2ZecjjO367csIxm4hOQj2tbDyDwL9TQVxbg+xOghGgylrMYER5B9//FEVIrSkx+lgZExYEARBEARBKF+IACgIRQwOJzL8yJN78MEHteiz9957G//+fvvt5+sGsmHjjTfWIgkjj1yfbVkHrbomUNQQV8YXbcTugH3ED8pQyNWzwT3qGMVtlu53EPqOP/54tWTJEt+fk1eH44oiBBb8CCA4AxECeV5xB5Zn0o1TmlBs4fS8PhHo/ARc8vvSjT5ffPHFujwoCK7nnnvuMRISgRMYjRs3Dvz5008/beWIZDSZlm4iBn755RdVKCxYsCDW68MByEi2IAiCIAiCUH4QAVAQygG4lXr06KFuv/12LQLRjmlCnz59YhMVKMOg3S/dOJ8X08U9uWgDBgyIeA/L3iZChhtEwOuvv16LB6a4y0Tq1q1r1cLJcxZWQIIYc+6550YuP2EMleKE8gzCeKbwWrIR1fOdbt266aZiN+wnfB+X7dSpU31/jyzJzz//XIt7buerV/w7//zz1eWXX65LcdLBaG9YXh33i5ZbGyi84aQC4/G8vnhN56M71UuUCIF02DY7C4IgCIIgCIWNtACv588//9RNj4wHESLORuMeMCaHiykdLCLGjBmjNxxEiAj8Ho4DFk6meV5h2VEEqP/www/6viEQkK+GAyjMISEIbtgnCYgnLy5spIyFt61YZ4Jtq67N5fv27atdLffdd5/KFF73hO57RxlvuOEGdeihh6YVDcjiO+SQQ0r+j+OJzDivsBjEv//+q1/zu+yyS+DoL+OPQu5FlQsuuEB99NFHBf9U8F7lJ7jR4IsDNgwaxyn6IG8yrFX8oYceMrov7N9HH320789oUb733nvVkCFDMnLGIZ5fd911+rVp6+7NNrinyVaMU7S3dWMLgiAIgiAIhU3BOAB33nlnnfMTVwi2F3LKcEeRNzZlypQS8c8UPpSTU8SiZNq0aTq7i0UFQiCLHkoEEBmjMnLkSF2IwMjaX3/9pT+4s/AhFwhB4dtvv4183UL5Y5999tH70qmnnlpmzLRjx4769UCjZhKcddZZVhltXbp0sbp+XoOI8HvttVep79uWNfCa9jveIIryfRbjQZB5iIDhvQz5e23atDG6fY4hjOoGOSDTlR4UMjxXNk7LOLPuosDzdPLJJ6t8BxGP14XXoYc7FVceY6E1a9Ys9TPet4gRMIGYgTBRetCgQcb3lfF2PyZPnqyfN8aM4xqLRdR3l9TQvs1jMXz4cP01kzbuuKCxO0gQjUKtWrVU69atY7s+QRAEQRAEIf8pGAGQMPszzzxTb0mAWEez42677aazxPwaDMN49tln1YQJE7QwhxuEhQMbi5SNNtpIj5ohMEbhq6++Uk8++aR2HOHawmWBqEhT6XbbbacXJ7fccovRSJUgOJDlRX4W++b777+vBaUZM2boVli3cy1uWLybXj9FFrx+bNl///21I4tsPFy9jLsy7obQYQOu4CARk9clxwm3sEjWHiIIt83t8XNyAHmsDz/8cH2CwWZcFFfVW2+9VfJ/Ti4gxjC2yO0XI4gxPF+c9Ekar9gVFQS1p556Sp+MYRQ9H+F1d8YZZ+h9E7GL9xHceOyTHAPuvPPOMiI5DuEbb7xRrVixwug2EKuDCjnYl20yF5977rky4+2M7+K+nT9/vooTxH5atPl7yUlFbDvooIO0qMtXXMC4i8OKfHgf5kQcI8lOJidORbI3iQJg9BlXcZQyIAeeIz6nxAGlRoiAgiAIgiAIQvkhKysVPsQzUouTwHQhgUMpm5BPdsopp5T8f+bMmca/y4d9RioB8dA9Ntm2bVsdNk4rImLCl19+ad2I6oh/7du315lfDk2aNNEjiiwsCPvHJdi1a1er6xYEBLZOnTpl9YFAfECkw80TBCJhWP6XCQh+btEPBw2vpzhAfEc0oAmWYxtuxTp16uhjHHlpCBhuvv/++1JinimI/S1atFC9evXSQm0hgkBmklWIgEruG88Zx7ek4X0pLjj5Q/7dlVdeqYYNG6bHt3kf+eyzz1Q+gAvdKd7YZJNNQp21lGNwUokTBIyi2xDkRrcdV8eFj1jGa8oBwRJRLQkQ7hFD/UR/3l85gYezmBxTd4YqQj/HKZ5z5yQc+wLlMDyOXgcvnwVw8/PVtAjFnbM4btw47Y7NpBEYEZH9VBAEQRAEQShfJCoA0vzJh2ZGaEyFP+BDsU2rXxyEjfOZ/J00huKeOOyww8r8nMU7C1ucAbRu2giAODWcRSpZf164TRwRCCosDHAm2S4qBDOHCCKGPLbxsOGGG+r9FXcMIprb0cMiF7HrwgsvjD2jChHdRgBEwAfEKxb+uCNx+iBOde7cWW2++eba8eW4chDqGat+6aWXYrvPiEhkswU1/cYBY8mMUy5cuDCRnL2bbrrJKPuQ+AXcVzg/2eIqdQkiqpMMYYf9F5EKMQ2XmNNATR4rbjHgmB/XmHGmDnrGz3HQ85oiV5MTU7jAvMe0SZMm6b9n8eLFkW4rKBvT1m3J/XK3enO9HCuSgr833d/MY8PjyMk24IQeJyq8v0dBD25qPxAJKVfCzXjbbbdZ30+KhIgbQSiPAscuTkRw7HLDMY7j2/Tp0/XnIZzLCI3ynicIgiAIglA8JDYCzBlxXHyvv/66XjDz4d1mKyRYtAJ5OriA/KCsA2wbC53rRugLahB1RuVYhFCAIMQDCyEWWY0aNdIiDwvYI488UufjFdo+mo8gDDHuSU4mLqm3335bL6hZOJM/mERAPeKcW1QIg0UwjlpOYPDaQxTBFYXLC4EHoZLsN9xBDmRyxin+OY6qJMU/YDSUBtckxlfvv/9+/Toif87t5goCUY2sOH6HsekksX0dM4JNDMNWW22lxTTc18ccc4weEb3qqqt0bqMbRJRmzZqpXOGIbpxIck6qIU7hRuX+IwS6m5DZz3jMo4p/4M245HZxyHJbJmVaDjxu5N064Hhz5/TlCl7fnJRDLOeEX9THipOjH3/8sfXv4TjEQWgC+yVjvhzzOAk5ePBgvQ+7RWleA4899pg+UXnAAQfofZqRZeJQ+Gzx5ptvWt9HQRAEQRAEoRw5AMkYIkeHM8d8uMTRwYghH0aDBLJCxlmUMPIThPMzFjQ4AEwWwu7r5rHzBrc7uM/kc3ncHkJmsCBiEeRuXETIJpiejZFxnGTFuD9nG0pIWGxmA5qzL7nkEi3kpYP8Phw/NHj7NW/imBkxYoReUHPM47oZB44b20IiW2gnZ2S5R48esTuvOfHhRCsgOOFixsWFgJrutnAj8VwhviJY5boFeOLEiXps3S1KOSACs0998cUX+vjgHBcYWcUtmDQIPIjmCNLss4h8jLMiqodBLh+uWMaVGzRooEXaTEZsHdEcyMRFcOI14gijuCVN4b7xvsl94u/Kp5MujPvyHGfqmEUc95YVpYMTEKZ5v5ywSndMQri+9dZbfX9GRAPXwWsWR64gCIIgCIJQ2CQiALqb/ggQZ9QoSLwqBpx2X8Yag3D/jMubCoCOuyjsulmI4PRAKHC7kYRo0N6abrFDwQuuzKDAeyF/4ZhEyQSL+CCOPfZYXbTRvHlzX/HPDZlh5HkhGjPiX2ggUiFuO2ONcYEYxHuB21WIGwnh1FRopFgDVyiuMtssOhNMCxWIsMDp5yf+uSEj7tprr9WjnRyLk2rSdsDVRS4szlYnl47HittNJ/65s/kYKb3rrrt8W69t4LjJCT/+fr+MOV53NvCcM2rvxGtw3W7HYq7Ahffhhx9mfD2ItLweTD8fIewiiJrC64dpjCDX82uvvRYo/jkgvHIyrEOHDjr3VBAEQRAEQShcEhEAGefD/ceCiZKKYsfJNwxzg7l/xmI7zut2fo4AmO66CXWnsdgPxoJwY7EgSSpoPd9hsYOYYwILMTIXt9lmG1WecMocCnk/wa2F8wbBw13SsMsuu+jnFAHQaQU1gX2BMdokRCobnBMBppC1SGkRTq24QTjlMcHJh8vQLUqYwnglz0lSjyuPl8k+jIvNNF4BQRXBBIewzbE+CjRcM7bJ+wR/B8IqgiAxBTawr7MvcH1RYT/CTYboG2fBBMeZnj176tcpblKacHMNjkZEwDiuB4eot3056DiLgGoTB0CJCm3hjKz7kU78c98XRpbJbBUEQSgGiuGzrCAI5Zt1BgWLWRMAnUwcRkeE/AJxgLB/P9xOp6g7VKFDoYtNMyhiBjl25ZVC3k9wFLHhyGVRTfOs22nLKKfN48CoMI3KUYsl4oARS1MRh1gBygi47+PHj0/k/iBu4DI64YQTSr4XdPwJIklXM6OUJvswAqDNdZIFyVh40iAwMj6Poxyxmi3KGDfvC+TTRinDwl1288036/FuTqBEKbZIB9EWNGBTWoLrOpOMwjggG++FF17I+HrIOXVOuoXh/DzKGDS/43f9iIk2DdW4FTlxUszTHIIglE8K+bOsIAhCXgiALIIZK7Jt/UsKFid+GVJ77723zvnKFNwtnGn3BsC7cf/MtITAuW7v74ddf7rr5jmh1MIP9+KvvH7Ity1p4fLl7bFyf1Aqhr+d7DM2L7YiA0IVDbC5hCIixCDy6tJBK69TtJKkU+3555/XmZkO+fK+AIhlDz74oBZDcFEjppHz5xXCbN0BiMDZcoMiXsdREsP9ZcSTMhgb2Hd23313vS+9++67+r0/CRhpPvDAA3XjfZcuXXIWd8GJAgRtXJM2J4v8wL0ZVLzjd5ylRIWTFKZ/O8eCoPxgWyEekZiNv18QBKHQKbbPsoIgCDkVABklZRGQ6YfjuECc81sgxRWuzwdybiPsQ7n7Z5QF2Fy39/f9xD/nbwnLCoTTTjtNb36QFYSDhDfCXAsZucJGnAVG3fP5sUKgROAgr4oFPhla5IXhpDHNofSCGOLkVuXz354piII0Ets+NgghZHXlAhyNRx99tBZKKHYIglHNyy+/XO+/jnBo4waygVFJ937CqGgSZSlRQMRxu6p4rVCixBgrY+BRykKAkyy81goJ/maOC7YCIPAY8hzHMRYbBBmV5Amz//BvWqK9+zj3gfcw73s7xyqO7XG85+OCY6T2ggsuyDjjkddg0DE06DjLSUtTlyXlPkHlZFHKwrgu9zi/IHiPA5xUQdR23lsEIV8pL59lheJBjrGCl6gnLxI55XH22WfrnRTnR744ABlD8240TMaB80H6t99+C7yM8zPOntsIL07DL/lTQRZ19+1KA3BmbL311taXR5xFPEX4xv3Kc4DI9vHHH+esuZJxbjK9uE8PP/ywdsCynyDy8P0tt9wylhD7YubQQw+N9HssfHJ1NvnNN9/ULqFPPvlEFzu4G8IBYZDRZn7mXqCR15oUXjfd+eefr/IFv9cn46aMs7qzCvfZZx+r66XBlkKQQoIGY3Le2rZta/27jkCarjAnEzjRRRsw7928Nv0EbhZ0CFRkD5OFiADGvo4wiXPQRJQIugzfR3gjj9D5nNOsWbPIfw85kfvtt5/17yF88j6TDkphwj7jkF0bNA3gByUgIv4JgiAIgiAUNomsUnFOsICaMmWKzpgqdmhidNpAg0Z1J02apL/usMMOka4b95bfGDMQ8u04lhj3EaJz1FFHpXVRutlpp520CEhxCG47xkYRaylaYcQcITDd+HYSsPC7//77A3+OaIlbzNkvhdKiEC4i2kedEVkbVq1apcV6k0V63CCOIOQgyODymzlzps4EnDx5sh5LZUTz8MMPL/N7CCo2zmTbvDQ3ZJ7tscceKt/3AZxWTmttjx49jH+3SZMmuqgiXWNwPsKxixxJG8cjIvO2226r/510IRLvgYzfOuVYfnAMxtlJNivN3LwOeF/EGUsJVpCIhVDNiZxvv/1WnyThRA6t1Xy98MIL1dSpU0t9nuFEHlmPQQ67INj/uU+4YKO4pHh+KHkJO77wWuZkQNh9437YRKA4wqcgCIIgCIJQuCRmU+GDNjk9fKAmU+n1119XixYtUsUI+Ud8mEakI6fIC2OEiKHQsWNHq+tm4eK40l566aUyP+c2ncZHXCoydpEZjImZOkNbtWqlBgwYEJq/9dxzz6nu3burbIIQfd9996W9HPuOaeNxeYAyEFoxGe9jcY+oYTsS7objHQJxtnELv4gazZs31ycewtw+XC4podoRz8gcoxiqZcuWumwn3+HxGDJkiP53ixYt9LhmOhh9SyoDL1uMHj1au+Zsnl/H5YmTNCkh2cFkvH7hwoW6jdkLn0lwAzIVQLs0Ahkn2RgtJrKEkV7G4e+9917tmOZEAF9pyXZETjfsy5yA47jhdgNyEon9hQZsxD6ci5xQoEUXkZXHNxOXcLt27fQJJ67b/bpGFOzbt6/+vGEisnMf2bfTwcksHjtBEARBEAShsKmQSmBG0T3yxdXbilJcPkqTYSbg2CHHz4FFAmNEcPfdd6uGDRuW/AxXgPfDO+NiL774onYMMdrjBMnjJrjrrru0GNCmTRudH+QFt5gzLo2DxwsLDIQmYAHNB3GC9Bl3YqHCKBSODfKroua6uTMAuS6TxW6xwhjbGWecoZ+XIBBVyAxhzNeECRMmqPbt26tsgFvFRAB0mDZtmu/itthyU3DmMRrLa5HXyZ577qlfy4C7h2wxFudxwyheHCUNpvA38Tq24ZVXXimVeRcXnPB47733tOOUx3v69OmqkEAccoqB2OevuOIKfTwvdngv4NhG82sYiGhECbiLXRDXnPfOXEIGI+Pc2TopxmcdXue8fyCCRmlUjnKc5fYQPIHPKba3i8DJ5wrnJKWXgw46SA0fPlzKP4S0SD6VUEgU6mdZofwix1ghLu0mkRIQr6aYqxw0G/gAHTQOc+mll5b6/6OPPqpztvycBQg9iC+4D3CDOKNKLEaijkPjIjrzzDPVk08+qZ2UjPa4A835Nw6GTMQ/4f9hAYWgu+++++pgfMQhBxZ2Xbt2VSeffLLORDKFca8nnngiKw/zuHHjrC7PQt9GACw0eA2S3YVAzhisAwfLs846SwumSdx7Tj8AAQAASURBVIl/kE3xDziRgdiJK9kUHpu4wYGEa5kP1zir4hT/EOaCBIs4cbvW+Tt4oyX7jdfzCy+8ULSudtywuJcZ+ww6biEMceLK2+p85ZVX6tFzxm9zyezZs/WHomy9LyI0Ju1+DHq/ymTxygg3reF8rsDx+sMPP+jrJD8Wd6dMFgiCIAiCIBQPiQiA5fEDIx+YcT0Q/M7GWXVcjHy4ZiF83HHHZRSgTaYi40Y4BMlBQvxj9IcP6WQiydmreGGxT4g8ojAOS84U4qxCjEVwHTZsmNX1ZXPkcfny5YlevpBgzJmsQ7/CE8QBHLSPP/54bI3gYftTUIlP3HCcsc0uRLCJCwQhTnhUq1ZNjzxy7Iu7EArnGa/LpE8uMbbMY8nfhKubAhOKGxjBDMvYLHQoq+L5I0uPEx4UaDgCLu9DiKBBjmb2dWIUENQ5IYaYKOQ3nKwkI5FNEARBEARBKF4SEQA/+OADVWjg6PMbv7UB0ZOWTTYbcA+a5Otst912ehOyB88pbiOnjMXBNi8tSr4a4gbCFY5TxnS5Lzz/CJPkTgaJ7ORGUvxgSqEWx/D4IKqFjbxdfPHFaduOkxb/IFviHxxxxBHWJ2DivH88nohFbGSgkY8Wt1CXLTetE0VBoQduRrZTTjlFF60UMwiAOPlw8TkuR0bZEQN5TQWVS+AmPv3009Uvv/yicg0n32zKTARBEARBEASh2EmsBEQQihkWlzbQJGkDi27y0zp16qSzCMmBpLEX5yFZarjaglpGWYCbQlg9DbCFAkISo2o02W6wwQbauYJ4z5i+V/Rk3NfWqVkM4Ai2gccpyVHWQoiAsIHRWIqdihlybBmbd+8XjLKTh0uWLa83xqAR/Jznd+TIkdr9n6T4t9deexlflvKl8jaJIAiCIAiCIAhhiAAoCBFgHHCTTTYxvjwZjjYOKjLpwrL8aJvG6cWYHQ6rAw44QLsCaeFkBK9JkyZGt8VIYyaj6dnO8kPc4u9+6623SvI1GdO85557dHsnOZkOjJ2aNIYWG4jFNs4/xv6WLl2a6H0SCosw0ZbjE6+3Cy64QLfDIggyDk3LbaZib1gzLm21jF6bkos8PkEQBEEQBEHIZ0QAFIQIkAtGzpUJiHGMDZqCswa3Xzpw3zRr1kwXwNC0+vnnn6tXX31VF1vQDOkN5/eCi/Daa69VhQK5Y4xgho1r8rfjEIQknEg87/kuLNiMx7777rtq/Pjxqjxi6+IV/CGeoFevXiXj0plA6URQaQcOX4RHU/r27Vtu921BEARBEARBiD0DsFu3bioJGNvJdYOgIKSDum3cVowEBkFuFtmS6cQ4tyOLBmlTEPr8wBXHiCwOHfeYHjRs2FA7/yitsS2LiApiHO2SvLbbtm1r5Z6EyZMn61HodPB3kl2GuGnTgmvKSSedpEaPHq3yGZ57il0oq0kH+ZLlFbJaKfah4AIHJPtOeXSM5gscEziBEZcblQIgmtwp5bIZHS4keKyIOXDae3FQ7rDDDnqEG0dmobi7BUEQBEEQhAIQAIcOHZpYxo4IgEK+w2Lr6aefVrvuuqt2pvz6668lP6OYgnHcgQMHqm222cb4OmmPjquRlQUwr0+u76OPPtL/p50V4YOGz2xAIRCPAYtw9+PGGG///v0Dm0S9PPzww8a3+e233+rWZUai4wRBEUEBwSjfIRvR1L1VXuG1G6WcxxZea9m4nUIvHeFYNXv27Fivl8cd0f7nn3/O2jEvW3CcI7+VGAg3OMHZ7rzzTjVq1Cjr/FlBEARBEASheKmcjwHvEtwtFAqIWYwCX3jhhdppx2IM59Vuu+1m7XJLopGWHMFly5ZZFYPExeOPP67OOeecMg2z/B9XJDmGw4cP1xl06bBtXeXyjCUieMYhKiD+4UB85513VL6z8847Gzs7y/OxNluinIh/wWy00UbaxUahUVCpUabMnTu3pL25WOBv4kTOvHnzAi/z3XffqYMOOkgfC3G6CoIgCIIgCEJGAiBn1QVB+M/xhzssU2i0jRvcd4zdZhOyt/zEPzerVq3SY2pTpkzRAf9h2OaLcXlccLhgMln487ziILriiivUTjvtVKpkJF/p2bOn8WW33357NXXq1ETvT7HSu3dvNWjQIBkbzuDECa3C2WiJ5kRDMQmAHNfCxD+H77//Xk9TXHzxxVm5X4IgCIIgCEIRC4BbbLFFfPdEEATtiMG1QTlDXOAAzDb/+9//QsU/B5p87733XjV48ODQy2299dbq66+/Nr59Lg8IjDiLaCwNyksMonbt2npEFhehg2mWY67A0Wcz8nfuuefqtmTB/nFGAOzevbu677771FNPPVXiYNt222218CIEw7HhrrvuytpDtHDhwqJ5Ojhm2hT9PPjgg+qiiy4q125fQRAEQRAE4T+kBVgQ8gzTdmFTGjVqZFUgMWLECB0sz4hulPHFP//8U7388svGl+e20jn8unbtavX3UgLiQCA+Afm4+DhpYToei7DjFv+Asbt8BjcVI9VkIJrQsWNH1alTp8TvV7HB44wblHxPBGz2+b///lu7WhGOhfwiqFm4EJkxY4be30zh2BdXsYogCIIgCIJQ2IgAKAh5BsHu/fr1i+W6yK479thj016OApMuXbqoTTfdVJ144onqrLPO0vcDN9mAAQO0sGHKrFmzrEZ2WZz+8ccfoZfhvjCuasJll11WJvAfRyBuN8SZdE2vPGaPPPKIOuOMM8r87OSTT1b169dX+QyibY8ePYxGK3EFjRw5UnXo0EEVG16HOvvPmWeeGdv1v/XWW6UeR3LWcNt++eWXsd2G4A9N5jbgqh47dqweOb7jjjtUnz591I477qivh9gFhHBT0TzXRGmq3mWXXXRpWzbGrQVBEARBEIT8RQRAQchDaM6l+dZvnHPLLbfUrZkmIOqlWyzjEEEAeu6558osLhmdu+GGG9Thhx9u7AY0ddjZtNaSxffqq6+qZs2ahV4O4RKnn58ouc8+++jmzHSi0YQJE3R+oR8bbLCBuv/++5XJ34Nwmqvm0W+++UaX0piAoPnQQw+pYoPMt+nTp+sShJ9++kl/5fUQF3PmzPF1s4rIkiwcX2yOMQj6vGb3228/fXIA8Q8RkEiBRYsWadfzhx9+qPbcc0+1ww476BHbfIb3BDIUbWD/x0V91VVXJXa/BEEQBEEQhPxHBEBByENwFOFYo2gHpxGh7+TqkQ3ICNibb76pxagwcDzheAmDXDxGRufPn5+2SMR08bjVVlupevXqKVMQNE1cdYh/iHOMSHsF0O22204NGTJENw/7LY6vvPJK3Zxp4oRs166dzs3CEYQTk1KN/v37q4kTJ5YIS4x/Bj3+G264oW45vu666/Rzxe/mooVz9OjRxpflcYsCwmy+grDdt29fdcQRR+jnlHFdRFHvWHdUeG0uWbKk1PdeeOGFWK5b8Kd69er6WOEnvgaBe5nXoQkUErVu3doovzSXObFHHXVUpN+99dZbdSNyeYLXKe3tvHfa7DeCIAiCIAjFSIWU2BWE9SAwkWPFmOTll18uj0uegyB14YUXqs8++6zU93HHIFLRUJpOiEOoQgA0ARFr9uzZ6t9//9ULZIS2xo0b+152jz32KHO/gjjuuOP0GKoN3IevvvpK/fPPP6pJkya65Tgo5B6HD6PNUUbnvOy22256lA4xiRwuhMA33nhDF0A0aNBAHX/88fqx95aFHHPMMdrBmE1wdZKFuOuuu+rswjCxbuedd9aPpw2IsAjDtIziVi2UtxIeB9tCmCDuueeeUg2rm2yyiZHQLNiBqI4rl33s9ttvN/odXLg8z1H2y2uvvVZdf/31OX2aaPkNOs5+8sknau+99470t+F0NHUHFzLvv/++uvnmm9V7771X8j0eyyOPPFJdc801eixaiBf2R+I/eO1J6YyQ74QdYwUhH5FjrBCXdpNRC7AgCLmDBQwuNYQbhBjEMPKsENT4agIClinkm1HucfDBB4dejgXAzJkzrZxatuC+YyFrAuN9cYh/8Pnnn5csoGl7RfxxC0D5VEIwfvx4vTkuy1NPPVW1bNlSP3Z77bVXqX0kytgjDkdEaBbacYh/zmgn4m6SxCX+AWKw+/nPl0VvixYttFuOEVfG0BF4EaptsjzzhVatWunRfR5b9mNTuHzU/fKBBx7IuQAYBscgxvZNsz694iHHZ5zaxcqjjz6qy5+8jw2LfU7EUHD14osvajFQEARBEAShPCEjwIIQcnYQwevZZ5/VIlKcwkGc7LTTTjr3DkGGcVVT8Q9+++03q9siS88kbyrdSLGb7777rswoZZxwZiROFi9ebF0mQYlJrsfgbrrpJl1scsIJJ2hHZOfOnUuE2s0339zq+rgOnjcECHL24oBRXUa8KVrxZkKS32gq+JqCS9P27/bLWuR6OPOGI8s0mzNpyP0k4w6hg5ZixkbjEP9MsudwnXJ7ccCx7JVXXtG3y+uOEX1TMhH9EU65vXyGiAjGWvfdd1/r3/39999VscJJsXTCKHm2J510kvFouCAIgiAIQrEgDkBB8PDjjz/q3DayktxtthREkD930UUXWYew5yu4hGwwKbWI4iYz+R0EWMRFHGKM/ZoKnY0aNVJxg1BFqUT79u2NLu+4Mm2E0SRhvyavDgFh3LhxWhgkJ8sEBC9GvClUiAsEP8aIEa6ef/55PbaNuMb9pMG5efPmepwP91Jc4Ji13f/99knHsZhPY5WIILTckmkXF1wfx0TEToo1EI9xWk2dOlX/vE2bNnpMlyINMkoZe7dpA/cThBEvneKfTK4rCgiAjPXbglOak0Y8VrSbIwrzt3DSwCYb1YQDDjhAderUKW2JkpdM9/tsPPbDhw/Xgi/vObvvvrtucjZ53yUv1yTDkfec++67T4/xC4IgCIIglBckA1AoQTIAlZo0aZJeVJHvFgQZb08//XRRiIAUe9xyyy1WwgJjeGG5KTQHI3aZjqbVqFFDOwARFfxYunSpGjx4sBaI3M6V/fffX1166aW6oTiM5cuX6+KHsOc0ChRMEKrvBeGKRmXEPsQy9ifu46hRo3R4f75l5fHYIOIgdpiILIwzk8n2yy+/xHL7jGoyjkd+Yhhk6+HYy7YQlG0QixhNxMHHKGouoFTHETgZJ+7evbt2sZqUvvB6JXcyymh/2GuL5x1nIXmb2XKA27ipgcImRu39HM2M3iOYmjZR2+RT4T41FaARJCnDSFcilQs4Vvfu3VuXEnlPCjGyzGcUhOUw4ZDnzNStjyCL2zOfy4wKCcmnEgoJyQAUCg05xgpxaTeFr2AIQkzg5EGgSScUIe7gMigGGCMzzS3D2UMJRjpwcdmMvCKoBol/fEDDbUZou3dsjXB3xBJEzDBRDYGRvzNucCO64f4hStK+jKjKIhYHEyUriKaPPPJIXorGFLsg+JgKawg8cYl/iEsIo+nEP8D12atXL1XMnH766VoMZX+9//77c5bThpMP9yBj3ozg8jozFUkQLTMR/wCntRdcbjhVTclkDBnBzVb8I4eV94+gOAPeXxAHk2iKZuTVlLPOOisvxT/GcjlRwv7j5wjHcYqTetiwYWV+xr761FNP6d+1ierguUoyfkIQBEEQBCHfyL/VqCDkCBZmiCEmMDYUV7FELmG8DsdFOlh833XXXcZioel4KIIYI9V+4H7B7YEIEQZiG020YQwYMEAXX8SJWwTDUUNGHYUYQdmJr7/+et7mSNpmQcbB1VdfrYWidKUybu644w4tkhUjCNUIxu7xTFyv2YbXuokgy6grIjdnHNn4N+Iw5RSZ4pwQwE1822236dcuTd+U8FAUY/I3mJTzBGFzFtU5VnXt2tXo9X322Wdrp1uckJtJTmY6yP688sorVT6C43Ps2LGhl+FED+K0c7witoCTUpycQhymvdkW2/FpQRAEQRCEQkYEQEFYj5+zIGwcEcdHMcDCy89x44BbZMSIEWq//fYzvk6ccOlGixETccWxePNj9OjRJS226Rg4cGDo4htxhcWibXlHGI6bD+cKjZO5ENEKGZyitq25LNZ5nb722ms6E8z5fdxpm2yyico3bNqfEYVuvPHGUt9jfBwnYDY58cQTQx9LxC7uJ5dBzOLEABv/RmCyKeoIel3Vr19fPfHEE3rkG8GK7EdOBJC7me7EC/sI7eb8HsehKFmHYcdDPzi2mBZrkD1p815jAn8zrwn2lzC3La7pdOPEuYCCmgcffNDosjz/vG8gOOM0N32P8INW9Fw0tAuCIAiCIOQKEQAFYT22Ak6mC918gQX33Xffrb766is9esjYIcUZjLKy0CdbirILW/caC3BclZQDeCEjjLwsRIMgyMuyceOxuA0DITNIbIy6aEVgQFx84403VFKYFK8UIrVq1Yr0e4h+uC0Rc3FqMZ7KuCcuzHwDR5wNCGmUH7g5//zz9WvT73UUN2SIUIwQ5sCiaRynlV+7dhyN2wiMZKx269YtbTmQeyyZ4xjj9h999JGOFUAUY3yZsVxTEJVxGdq6wsgotQHxKm7I9kOI5MQJDk7c3Ztttpk+cfPMM8/obFIEr3yE58ymIAmBl/eqTPNU2ZdtT0II/x0HPvjgA92kzIkAMmF5byUaJd/bswVBEAShvCOzD4IQUWgpNmEG54szcki+3aBBg/TIJfl7QCYWZQCMm5m2Y7JAwFGES+P777/Xiy2ExZ122int79rmiHH9LODjvM4wJk+erJLmggsu0KN9nTt3Dl3sMhZZaCPpbncWos/EiRP1yCciVLt27bSw6oV8zj59+ui8L5yX2QSxifuZZIkL182IM3+/O/+P1+a3336rHXDkyNFU7oVFOK2zmYA7LUx0e/XVV7X7KkkYgTZ14HFMQtxC/MPhRk6kV2RGBORxYzSZ1yyPMZdDrGR/4nd33nlnHRNAVmcQPOaIgwj/iGsdO3bUjzdiY7qTD36RAEnA34ILMMwJmI/wureBbNhM4xS22Wab0BNQgj8cHzhGMRXgd2ymrX3kyJFWEwOCIAiCIGQPEQAFYT2UTSAi2Vy+GMFBcuyxx2oxwA0ODUZtcebh0HGaQtOB6EdOk0mBiPf3krx8vkOzp+PGYmHPmLGfwIMYgShDQcb06dNVIYBYw/2meITcO7aff/65lLiOyIy7hOw3cr/4HUQXGotzAYIDApH7fiY5Don47gUnLs8x7uMhQ4bosVMepxNOOEG7IHmMMgGBE5GLsgU/eJ6SBmGGBmQTcH2OGzdOC+Re8c99XMBxzBYFxMN+/fqVEflw17FPRHGeFtuxKlMQ/W3ItAm8devWunzI9nbLO4jnZC16xT83lKrQYs7kgMmJPkEQBEEQsouMAAuCaxzIxr3EQrXYmDZtmi7e8Ip/bhYsWKBOO+20xEd9cAraEOd4bz7AAorHGhB4cA1RdoKjkuIMnGC4m3AmHXjggXoka/fdd1eFAPf5yy+/1EIThTFeUQ13H8IKlxk6dKge+WXRnivxzyFp8c8Bh2MYuG0QvNjnec5xCDZv3jyWMeGgggrE56CSmzgxdRc74NzjWIxr8qWXXgq83KJFi7SoyokIHqtddtlFjzKHZfe9++672oHr5/Dj9Rh17DxTobbYoOTFppnY1oXLSDfFMojAHEM5rpAvKdhBFict5emg8fqqq66Sh1cQBEEQ8hBxAArCelhAMtqSbvHNiBrFGcXI7bffrj+8pwNhihwmGjqTAscb430mbLvtttoxV0ywyEVgII8RWCCTi8bmB4IQCzTytC699FI1adIklc8wfjdlyhTjyyPglBdw2+Jy8mbR8fzS2o1LzyuaMS6eqTMKKPLwIxvZXojbUUc7GSEn+47Xh7cVHNHirLPOKnNs4zVCWRHZZd7WYI5xCO/pcgijHtuE0vmFvPcm1XrN+HwxnrDLNqZFLfD222+rmTNnlooyEARBEAQh94gDUBBcMN7apUuX0IXK66+/rsXCYoPCgueff9748owBJ5mHhiskXaafA2UlJmN1meZGZRu/HLwweAxwLLGf5js24l95A+EPNy6illOOQGkOuVpe8c8R52644YaMMy632GIL/brzI+m2VAQ6jimZtjlTsME4vAMFPYwIB53YQDQlc5CMQDeIiHGUmviBY1MoDfsvsQDp4OSGjdOVEyNbb721PNwx8Nlnn1ld3u9YJQiCIAhCbhEBUBBckD3GIhQXFUJg06ZNdbg+46iMj1GOUWgB66bwt9m4XXCn2bac2opZNKIy/hl2mXvuuUc7dUzg+SwUoixcETkYgyyULEAhWKjmmMOJBvYDIgfYx8kHTBKEMHezrrdwg7HZqDCmTrYfY7UIcuQZMr580UUXqe+++0498cQTekwz7ASMKffff7/O7uNxvPDCC3W2YTquuOKKUsczHM5JjvcLpcHp/OGHHwaeXEMUv/rqq7Vb0yaug/xQ21bn8gSvkddee007ssn+5StlP35uYtvipWwXNQmCIAiCkB75VCQIPqISLpggJ0yxkqSbLyo42cgdYyz7gQceKBlrRahlXBDxACHBFBo7r7/+elUI2CxcEW6vu+46PUJHCLtQPK9F/p2N7D2EN15PYTBmHDSCbuIeYhwQYRMx0Ctc49SjDZbmXsoDvvrqK5UJZJAhaP7yyy9Gl1+2bJk++XP++efr/4dlA2ZKWMZqeYZcvgkTJuhiF7I/KbvhWI9QTAO94w51xrzT7SOcQDFtlC6PIEQzeu19jeCixQ3M+647WoPv2eRecnlBEARBEPILEQAFQShZLOHAMXUZNW7cOPGxQEofyB1CHPjrr7+0gHDYYYfpEb8omU78Dm2p+Z4nR0mA6cIV8e/QQw/VJSCCEAVcf3fddZdumw4DseCaa65Rs2fPtr4NBDacqTvvvHMp4Q9BnugFik0cOA4x/h5USGLC2LFjdTaoDbyGHAGQrFfucxLgphSCT8Dtu+++eguCfYOMuaOPPjpwzJQx4TfffFPVr19fHmofyBNlmiHIpYf4ilA/ZsyYkpOhNACbjgEj5oY9h4IgCIIg5AYZARYEocRtd9JJJxk/GrTQmuTumYa0M3aE0Ie4gOuJTCgWcffdd592KCAQECrO/9u2bVsms8sLQqY384+MtHwX/3BI0TpqunDF6ZRt8Q9xRCgeeJ14izP8wJH63HPPRb4d91ghLjgEBoqH3OKf89pF/LPNwPT+TU5+oiluwZEszaTE1iOOOELlApqLOa6efPLJegx74MCBkZuM82FkGAcb46uHH3642myzzXSBDaLWCy+8oN3i4kDzh5F4MjfTjejy865du5aM0J922mn6xJ8JtLsHxQlkAxy8tHy3bNlSf7bBPXrmmWeq8ePH5+w+CYIgCEJekBKE9dx5552pAQMG6K9C+WTKlCmp6tWrM38Yum244Yb6spkycuTIVPv27Utdd8WKFVNt2rRJex/YnnnmmVLX9/vvv6f69eun75/7vp5zzjmpv/76K/XQQw8ZXW+mW/369a1/p127dqkRI0akVq1aZfTYTZ06NTVw4MBUlSpVsvI3yRb9MeA5qlevXl4/hs2aNTN+3Z5xxhnW18/rev78+SXXcdpppxn/XtS/6fTTT7e6/Lnnnlty/0aPHp3YY/3111+nfYznzp2bmj17tv6aKStWrNB/m99jWalSpVSvXr2MjztC4TNq1Cir/fWtt94q+d0JEyak6tatG3r5s846K7V27dqc/X3PPfdcqlq1aoH3r2fPnqk1a9bk7P4J+UGcx1hByAbr1q3T79V8FYRMtBtxAAqCUMJ2222nXnzxxVCHF840soEaNmyY0SOH++T444/XYf1ucBtQCmCak+e0yY4ePVqPzt5yyy3qjz/+KLkM/2bEsEGDBrrcJQ4YlWQcCteJGwLseWxq165tfZ3ffPONvv9VqlQp8zPcUpQknHfeeTofjRHJ1q1b61D81atXR/47JBw/O+CWpak6G7D/RMnpw2X7888/G12W1xP7vw1HHXWUdm05hUPPPPOM0e+ZFHgEQWO7DTicHCheYUsCHr9sgROSvNRHHnnE97Hk57iq2UczeayFwgGnfdTXEZm7uOgoJfK+fxAjMmjQIO0mThcnkBSjRo3S+3KYu5FYEUp/BEEQBKE8IgKgIAilYDyN8SlC190jeAh/jPUgtO24444ZL0D69++f8SNPhtgOO+ygmjdvru93WGYY44emokMYlBTQTjxs2DAtmDC+TA4VogZiJiJClGxEFiyMHdLiy9/BYpxRaNqnaS9G1GERP3ny5IxEP2BxhiDToUOHjK5HMOPZZ5/V7Zo00iYNC3MW4FFeo7yOevTokTYHFAGa/Z/SGdP9zb3g5rHIRukQhTg1a9Y0uizivbv4ify4pNp6yTbNFrQZmwihnPhhE4of26Io8ne9WbrsK7/99pt+vyIWgJNrRGzQ0BxXNIgtHFMuv/xyIyH7nnvuMT7hIQiCIAjFhJSACIJQhlatWmmXCmfzydJhAU+oNwv/efPmZewUIfcrThDfknJTUVrAAggHIY5FspOcfD4yjsgp9HLIIYdoYdAWbofbANwVOAzjXKRsueWW2olGsyPPJU6JYgFnCo95JsURSYGgNnLkSP162nPPPfXi011ewH6WqagLFNzgrAUyMnfbbTer3+d1jag3d+5cvbAPy/BisY0r1QScrXvssYf+999//60+/fRTlS1wz/I6Iv8uCAR2RH1HuPj++++1ay5dRlo+grjI8ZDjBydHcPeZwmXJBxSKG97LbNhwww19v9+kSRN17LHHljom5NJFSnv0tGnTjC7LfeWEGhMDgiAIglCeEAegIAiBbLDBBjpEG2cQglEcsDiNaxQ3aRAEEGpYVOAGuvTSS43KOXBRZeqCwLEYt0OBkhfEvz59+mhR5P3331fFQr9+/axbX7PJyy+/rPcJBBaaNGfMmKFfBxMnTlRPP/10LLeBeIfIC7g7o5ZNOMUKjNhTMvPVV1+VuQxu16AGVi84g3CuAgU3cYidNjA2z9/iLRVBJOM1wd/hPG5w991363btpKDEKIn9i+ecExK4e2lL56QNbm5TOMZ5C1mE4uO4446zurxzUirfMW0odsjmiQhBEARByBdEABQEIauQNVYoRG0xJAvp+uuvV/kE4tPBBx+sXWG0ZLobWQsdXG84UfI5w8wrrLCPMHKKw5QFeRzj2N5MLpy2jKxH4Z133lFDhgzRDhnuI2N/d955p140456xbQN2Lr948WLr+5KpmL5w4ULt9qFhnBiAwYMH6xFmRhh5LdAe64DwF5cgG8S5554b+/7PPjRhwoRS3/e2oEcZ9xSKD6ImyPs1Fav33XdfVQikiy7I9PKCIAiCUAzICLAgCLHDB2vGhv1KJuJyEmYD3I9hOUrkayGUMNZIwQHurmOOOUaPdJousLJF37591SWXXKLHO4uFLbbYQo8tOk63XAXPm+B2jiKgIdYwrvnqq69qYYrvMWrnLrCxxVsgwyg/bj72yaVLl2Z0/6dPn16S44fTsm7dula/P3/+fP3V9vecv2PmzJmRXXk4mZ3noEuXLqGX5bkgWzQpyCRETI0Lnt848lQdTBzOQmGDoE5ZFUJg2HGBLFsul6tMvyjvB0leXhAEQRCKAREABUGIhUWLFmmXDa4hZ3QV9wDNtaeffrpevLOQ4HuM4uVjVpuXoObWW2+9VV1zzTVlXHTkvDFaS0A6LqN8gZHfTp066ftdLCCwMvLlLnlwhJ58hLFMwF2Gqy6sCCLK6wOxHacesF9StDNixAjtuMPBg6jF+G0ckJFnC2P0jKkygs59tXGg0nhNkUrU8qGOHTsm7vq1ySTkuUGUjYM481RpPY4i0AqFB/mQRBB07drVd0ycsXkyPrlcoYALtlevXmrZsmVGlyfPVxAEQRDKGyIACoKQMeSBkRnGqJ0bShloPr3oootKWj9ZYOKs+/rrr/NeYPLLUDvzzDO18y8IygYQ2/JF4MQhd8EFF+j7XSwg+s2ZM0ftsssu6uijj9Yi81ZbbZU3j7lfOQdZc1dffbW6+eab016ev2PjjTdWAwYMUOeff77x4pffQRQ95ZRT1K+//qryCRyP3MfGjRvrkwBOJqAJ/B5CBM5DW/ERsZFGc1MYB+b54oRGUjAObSIAEpdAZirOUB4zr2OJHMlPPvkktvuFeCKUH7bffnv15Zdf6gzMV155RccU4ADlmLr77rsXjPPPoXbt2jp/l6gCk/f3gw46KCv3SxAEQRDyCREABUHICIQGWm/DRhcd8c/JmEL8Y3Hh/r4fCBrO6GBc4NAjgwsHX9jIIUKKdwH0+OOPh4p/DvkkRDlNsLQ5Fwu4qNhwt+GA+t///pd4cUNUcJQNHTpUjRo1ykj8c2C/Z7wcx1y60hwWvoiFCPG4uPJp//NCizibqQsQwRABkGNFlPxAsji5DlO4X2effba67bbbVFLw94dBOc+1115bRtwjw5PjFk3SEGdJULdu3bTwI5QveI9D7GMrBsjDxF391ltvhX4GQPDM58gIQRAEQUgKefcTBCEj7rjjjki5ZenEPxYkw4cPV3FSvXp1HfpPZtZ3332nXTjuTMIWLVposeabb74pNVoKiBWXX365KiRoBHXGQqtVq6aKFcoOcJkm6doKI6h9uEmTJtqBiXuN14ktjIqSwYUIGASOnTfffFOL1uzP+Sz+eV9PfhmhbnhtUtrBvkvOptdhnA6cobRD23LxxRfrTM+kCCtmeeyxx9QBBxzg6+xDEGac2TkuxpGnyrg5ztRHH3204BxfguCF1wTiHjEL7nIfZ1/HDTx+/HjtGBcEQRCE8og4AAVBiAy5YiaOuDDatWunS0MYdUMQ4P89e/bUbpTLLrss1meH5lVKMBAfyRUjk4x/I5ogMoTlf+EooPijkECwZFFPO26h3fco2ApEcYFYhKDFfswik9cFDj72NfZltqjC5scff6yFH0QaMrmc55F9lRE+hBtGoXmuGYsuJMgZ43H76quvyvysYcOGurCD1yWv0XQnDPzA6RtF1EK45TE/9NBD07r1ooBLM2hMmvsc9rfyeJGpykgwzz+Pz8qVK41ul6ZpHlMnf5IxyFNPPVXVq1cv4l8iCPkHZUhXXnml6t27txbSORYjuu+xxx6yrwuCIAjlHhEABUGIzI8//qidOZlATiDjnH7jOPwsTnD9HX/88boN96677tLiAJtJeQQ5SYUE2XFOyDljUYw0FztRRKI4GDduXGLX/cMPP2jByPv8IQ4inCGYI5bjAiw0GFkmd4wYAVxtH3zwgZoyZYoO8UfMHTRokN5wsrIPI8yZtlhzMiETlw+FIziBH374YV1u9Ntvv5WIvYiwiL1RQCAOKh9glB2xPh3cNo8L961z585q2LBhRrdNHiuCnyCUBzgGUIAkCIIgCML/IyPAgiBEBhEiU8htmz17dlafhXvuuUePGJMNxoKckP199tlHj1wGiUhRF/xx0KBBAyuX40MPPaRHTxE3yVxMMs9MSBZGYNOJt6+++qpVq24+QTYlTralS5eqTz/91LfB0xnX57VqCvmhmTrbKAOhJZVMQMZyOUbgCmSLCiIfxxsvvE5feukl4+uhTZpjEnEGJn/nrrvuqk488UTr+ysIgiAIgiAUDyIACoIQGVopw8ZmTWHx68fmm2+ukoIcIEaDECBxIVG0cOSRR2oBza+hmKy1bINASRkAYf+4kBhtChM8nn/+eTV9+nSdfeaMPj777LPaYZlN18U555yj256FzJk5c2ZRP4yMS5PLiWAd52PB6G4moihOPAo3OMZRsDJmzBjt9MRth+AaJZuMvzFoHJyTIDb3l8cNl2Tz5s31uDIj02FFQDhE48gMFARBEARBEAoXEQAFQcjImYYzJ1OChL7DDjtMZRvENtyBkyZNKvX9GTNmZHzdNnlkuI8QPGgxZUSSseXVq1cHXh4xE7HQWwLBSGW2oI2WtlvEShxHgpAOxnpx5CbhTka0i0rfvn3VTTfdlJGIiGDPsYT251mzZqkLLrgg9LK2OIIerzVGxXEXMi5N2RGZZ506ddLiKsIlxxNBEARBEAShfCMZgIIgZESfPn10617UceDNNttM1alTp5RzB4cNgtZzzz2Xk2cHEe2UU05R06ZNK8km5N/ZzKij0ZbcsW222UYLCDh+0oH777TTTlMnn3yydjPSZJxELh4uSURbRlMZQ8QlRa4Zzj8EHejRo4caPXp07LctFBe4U3HjJsGCBQsi/d7kyZPVnXfembETduzYsWrPPfc0unyzZs10vqDpfd5yyy1LiXo4lClNirs4KW4WL16s3nvvPZ2jyAkkRquD3MK4MBkJR+hE1BQEQRAEQRAyQxyAgiBkBE2Sxx13XEZOG2dhiHiFIIh4xNjd999/n7NnBzHN7SDKRcEEQiRC4IgRI4x/BzEW8bJp06aqX79+ekQwbhhXfP/997V4QzsyIgeLekTAG2+8URc1HHXUUbp10UQoEcovURuSTYXqKDzwwAMZ3zbOQRqaTcEB2L17d6vHLUrDca5A2OzWrZvadNNN9QkKYgpOOOEEfZyisMjdUk651MUXX6wFTsRBsh933nln/XgS2SAIgiAIgiBEQwRAQUgI3AvkLh1xxBE6n43gdxo777//fh14b7OQxBHH4unYY4/VgfSvvfaaDsw//fTTtYuCxSPOq169esXiVLPJ7mPM7MUXX4x8Hdx3sqwQkSg8yKcyA7fwtsMOO2R0XVGyElkc83yGjf6GPTe33nprIgUg3J+ffvpJ7bTTTuqQQw7RhQSMGb777rt6DBl3IOOTiJFho8C0L9sUH5Q3Mi2xKARo/k0C3K8mArQfZOrFAZmcnNgwhTF/ToCko0WLFurcc89VhcKcOXP0KPQTTzxRRsDjJMKDDz6o9t57b/1YjRw5Up9UGjx4sM5mdaDxmr95r732iuzsFARBEARBKO+IACgICYD4cuCBB2rxDxGQBQuLmYkTJ2qRbtttty2TMecHogoOLnL2WDwhqDz++OPq6KOP1oIZwssff/yhRTNGZxEX27Ztm0imlh8IkJmO7z388MPazUKGVb7hXrwjbGWCbaFJy5YtdbD/ypUrM7pdHIRxg/No3333DcwXZH8ku/Cuu+7S5SoUJ1BE4DiWEMSvvPJKLW4yqpyES7HQ4bGycYQJZY9NUR1yf//9dywPJ6/dzz//3PjyvN4Zm2e8NwjeO7hMIZXsdOnSJW2By7fffqtPcHXu3Dn0mMd7KO7ifDpRJAiCIAiCUCiIACgIMUMWHoIdI5JBMCKJQIiLKoiPP/5YHXTQQboAwtZ5eOmll6qhQ4eqJJk6dap6/fXXM74ehNB8dYG5F9mMrnXs2NH6Ogjjf/LJJ9WOO+5o9XtOuQo5gPkGi2/GgNOBA5FxPsb3Tj31VJ1liIDNePUtt9yi8wPZVxGv8wEn7zEfGDhwoB7hzkV5A2PZuMzyEZx96dhqq62MWoWDCGvUtcW2gZvMz2+++UY7d7fffns9/srfjIDOa4fjJZmbuYa/i5FcTgQwas2JJ0Z5ue9uvvzyS/Xhhx8aXScnC0yEPU46xfHeIwiCIAiCUN6Q8CVBiBlceiZjbTj3GJPE2ecnIp555pkZub8QDxBdorRLmvDss8/Gdl25yNczwdtCzOg1o8A0BYeJJ4zGEujPeOwZZ5yhS04QAl9++WWj2yX0/uqrr9b/thWA8w2EbgRvNxdeeKEe+SM3MMp4c1IgnucLZGMiSO63335q+PDhWb1tRBiOPTiQea6+/vprlS8gzvG6ZDzf77ixzz77aIdclJF7h5NOOkkfm+MAAc8WBD+OG2Sisg80bty45GccDzgO8f5B8cfhhx8eOeswKpT/cILCO4r73Xff6XFehMBBgwbpYyEu9SR46KGHtGNQEARBEARBMCd/7A6CUCSwALLJiHLnHLkzqNKNTKXDadNNikzvXz66rtxssskmetTaTe3atbXDhbbbatWqlfk7GPn+5Zdf1IQJE9Qbb7yhx72dhmObUVf370VtV84XvOKf4x56++2380r8yzd4bBgfzbb454DzFIEnTOzOBby+cJ0Rs0BRBNlyHTp00Bmp7Gu4zRDQM4GsuUyvw4GiC9yumZ7kwHGL6MZ48EUXXaSuu+46/ffj1EQE5HHJBhz/cKaH5fBRokKeIfz++++J3A8yAQVBEARBEAQ78nPlLQgxwYhhtt1llHOYQiC630ImrvGmTPP5wsjEYeMmFyOO6SA7jBFqP/ck7pxHHnlE5wPi9iTrjsUujhQW+hR3+IEbBkEWZ2AYiBs33HBDKdFRKH+wv8TRRpupyzeuPLw4ufvuu/XrkKxTjrcIpY899lgpp1wmUMQxZMiQWFp2eQ+66qqr9HEiEzGWEWCOH973M/5PEzc/nzFjhkqaPn36qGXLlqW9HHm0iIXVq1cvereuIAiCIAhCoSACoFDU4F6hXAK3Gk4EXAs4R5YvX57IAoLFmO3Yrt/llyxZEsv9sXFY4TTDuTZq1Ci9qGbhGgaZT3GQaclFs2bNVJzg5MOZyehqGJ988om6/fbb1YABA7QQgWuI9kqaR3kM/WjdurUWCcPGsnEw0ezM+B8CroTdlz8Q148//vicuf8cOF7mo0BPdipjqEmXiCDw+43X8vq1FQcR9aMWHTEOnM5JN3/+fHXKKackesKLxx3nro0bnpHsJKAkSRAEQRAEQbBDBECh6HFEOZwsuLbmzJmjx6VYjFFQQKYS47JkKuFsyGQskUWhbUC73+URgOIgrE3SgceGwHmC8xmlI1+LhmFaa6+55ppAtwfNjnE4ZBBkbRtyAQdQ//79rX83LJOLTC1C68kACwO3Efl+fm5PhAlG8mg39kI2GUJhun2M5+SZZ57Rrh5apIXyBWI8bq9MxfFM4TXmHYOPE0bio2TkwaxZs/TriNcHQjyu3LhiCRxom6WwBtGLFnByGXFlMmo8duxYq2If3oeC4iEQ+RFbly5d6tuOa1qiwbHLpnXYFoqpbOB+8z7hxBmYuF5NkYZsQRAEQRAEe0QAFMo1LLz+/fdfncOHg4JFJWNU33//vXYPkru0cOFCvTBjXNfENUh5hynt27fXrjAvcYSbk2GFIyQMnJAIfldeeWWZtlkeD4LwGUn1yylkTK5nz54qDhBlTdh///117hXjtvzOjTfeqMs1bKDUgPws96guLkIaahGEKfAIY+LEiVrEC3Pa8DMeG/cINqLOeeedZ53pl7TTSRCCwM26wQYbJPIANWnSRPXo0SPy7yP48dondxNhjteW00ZrKpiZOoIPPvhgPcJLqzWva07QcFykaMkGsl3dTJkyRQtZtI1vvPHG+iuiIsc33m/ANsf1ueeeU0nBe6UNvL/wHCHQmkC2oemJrc6dO1vdF0EQBEEQBEFagAUhUMBhAeYswrzjX4hrbBRBOF8d9wIL0f/9739G2Vm9e/f2/T7Nn23atNGtilHp2rVr2rw5xLT3338/9DKTJk3SI2h+uYSMviIOZrLoZIFtMubKom/MmDFlvt+xY0edgWUKZRx77bWXdvTgbsTFiNPJ1M1I/piJEMw+xOPjPDa4iPKtUEEQwqDNfNq0aYk8SLjogo5/JuDA84NjZqdOndSTTz6px+ht4G999NFHdXYdr19OziDQbb/99r6Xt81HdDv8aH+nTMh7QoDGZURG2sZp0F20aJHVbXDiJimC8k3TXZ73RN5LL7/8ct8TILyHIno671mckAq7To73SQnTgiAIgiAIxYw4AAXBEsbOaDFF+GJ0GOcczjFGihF4EIcIz6dFlkVKkLDEIido1JTfYfEXtQACpxziUxjcdxahJtBo6ydGIoYyqvraa69pl4zT6GvT7Guaxchjy4ibFxaN3kbeIMjoY7zZeYx5fHGoOM8R9+Xdd9/VDkHcPYzsMTbudsC8+OKLhn+ZUiNHjiwRCZJsZPZiOnInFA+mrwFbAZDjRKGBeMdJC8Q0U6faqaeeqgU/BH5ONLz33nvq3nvv1UIcjmw/sa9hw4ZW98u5PE7As88+O9QNzH3nMrYj0pzMSAraf20yId0CLCebyBDkuIpLc9NNN9XCKsdaju0cxwE3J48Pt+WmXr166rLLLtPvAdtuu22Mf5UgCIIgCEL5QQRAQYgJxCNcDmTaMYr2+OOPq7POOku7zdq1a6cdfbjY9t57b+1OYXw1DEbBxo0bF5gzxciYV+hhLJdRVhwS6doXERhtCiaCxELEM1x1ONz4+ykwYfFqsnDF+WGDW0RDiGVRvuGGG+oMQ5PbopkySJDF4bjNNtuUGvc7//zzteMERw4iATld6cpR3HAfEVBwFiGUZgue18GDByfWwCnkFwcccIAWSOIm2w3qcd/3O++80+i1ctxxx+mTNkFQBkKupzeTkcedsV1TnBM+uI9NHltKmWyf13TlRZnA8YRjoqnYiajqzbvl/QmHJXEbvE9QosTJMjeIf4iARHCQafjVV1/pyAec9XE1PQuCIAiCIJRHzBOXBUGwgnKKXr166XIRikZwe7Ao4vuIULgGaft0xondI8VsXAbxjxFcyiZw2eE6pKjimGOO0QURCG4sEhktI5dq1113NQ5SJ+vQBpOAfRyBLIjZENBwfQSBSxDHzeTJk43vA268F154QQfxf/TRR3oRjYOPPCjGywYNGuQravKYMYqL+OoH4hytn36Lchb9jKch4qUrB/EDwZCcRdv8rEzgtlq1aqXLbihaCCpyEQofBBEKZ4L27WzCsSfJ1moEKL9YhiA4VpAVGHYyguOCSbMtxxvGgzmmO+DwZozXRGjkPjBOzPGOY7YpOK95z/BmtPrB+Czt0UlC8RI5qGHlRLgQX375Zet8Vi8Ig15xMEnYt8iPZOya9zAajMVNLQiCIAhCMSECoFDU1H7zTVVh6VK1umlTtXqTTfSWMnRF4d5CfHMENsQ5RBUcfTauDxxqbH4gCuIsY3OD+OdkDXK7uAcpp+D/boGPRSVh9FGgXdIG7o8puDvSORxxTCKC2oArxNukibg1ZMgQLShSWoJgx+VwB7IgRrTDieI3Tk3DJ25MxMp0jhwWhrblAggEjBOaLN6TEAFxibKItclIjBP2VxvHpGAPDtNDDz1Ut3iblukkxcknn6yPR3369NFO4LhwjoVEL9jAMZxMPEp+grjvvvuMr48TDxdccEEpFzFuYdpxw9p3OTYNGzZMH49GjRpl8RcoNXXqVC08UnYSNjLMfeLYaOuqjvJcIO4NHDhQP3buiATHvXfHHXcE5ibmIxwreb/icXb/PQiZjJLfcMMNVqPPgiAIgiAI+YoIgEJRU/+pp1QNj8NsTYMGJWJgiTDoEgjX1ayp3W64vhjndYNgRR4emVCMWpkWR9iCGIVwwuZ1b7ldg27HoOMaNF0Ys7C0gcZiUxjVMgmvt13Qh7kQERSvuuoqnbtHrlQYOOMIpifvL0kQI72CZbZwnDO2wf1xIuJfdkDIJl4g19Cw3aFDBy24P//887pg6JNPPtGvt0zgeMUWBe5Dt27dfH+GSGnjxsMFzEkhHmtcxRxvEflHjx6t3c5PPfVUmfvZokULnceKCzjKWDXHtUMOOUQf12iY974nAU47ToIwyhzlGEWuKS5S3ImIjEQhkD+I+OXngEME5BhLjq0zqsvJKE6O8fcWEpwoQrT0E3B5f+L4zfNLHAfN1YIgCIIgCIVMhVQhh/wIseI01+KUYpyyGFjTqJGqvHCh1e+sql1bsVydV7Wqmlu9uppfrZqaV726msfXatXUMhx4FSroUStvUHkucVyDXlGQ/yMaumFBY3PfuW7y73BB4DhiUYqrxS+PiTEqnC6mDZnctzBniy0ExCNuBomhiIgUgRRiuYEpLOARK3gMEEAohckV7JNRxRvBHIQaXu+2rbFxgcDljIVyDLjiiiu0KGUzspsEvAY4aeMIcEAkA/lzuAPPPffcSNdLzisnEdgckYxjJGPHv//+uz7u4r6l0d1divTZZ5+pPfbYw/h2uA7HecwxlbgCHHjEQZAPeNRRR+n4AhtXugOOUR6XoLIUijpwD1OeVKwgciLcpoMRe0RAIRiWE0QAMKWQ1MlRQYiLdJ9lBSHfkGOsEJd2IwKgkPFOlLew8LRsUDRhWaVK/4mCNWqorTt1UhWaNSvlJFxbv74WCPMJxzXoiIOE2pNlhfvD5BwAIg4OQD7c4yhj1I+FqZ8jAidJjx49YhWJbEdJaS8NGo3GpYIrqZjBteI8Bzy/NJkSvC8UNyeccIJ2iuXivB77F+2uHFMozKBFN19AyKJpFvcezjUy/+J6jHC84SQOGzN2w+0iqPm1qvtBhiE5g0mMveLWTBcFQYwAmX+5dBInBc5FiklMT0DhFrVxwpc3ZHEqFBIiAAqFhhxjhbi0GxkBFoqXWbMSudpaa9eqWv/+q7am1GHEiDI/X1ejhlrdpEngmPEasoRcjpBs4M0a5Aw9CxmnuZjFoPNz59/uMH/EOYpIHHCgkEmIs8Yd0o4IcNFFF1nfv+HDh6vLLrtML9K9kCXF7eNoM4XWSD8BEAGg2MU/HEFuVxNODMRenEpCcTPC53iUDTixQEM3IhG5cPkk/gGOvH79+ulR3LhLSoiFIIMRkYxx4HTweqRI45RTTjFy8jL+mwRDhw41yoHFJUnJyd13362yvdD58ssvtejGc0bGJY+FTRZtOmh+tnGfk+MoAqAgCIIgCIWMCIBC8VK3rlrQr5+q/PvvqsqcOarK7Nn6a6WlSxO92YrLl6tqM2fqzY91VaqoNY5AuF4UXOXKIGRsWRk2+UaF8TV9XytW1ItWv4UropufMIhgyOIMka1Tp056pM0pOaFMI0ruGyOqLKRx5jBGSM4V48Y4mnDsITbaELSoI+uq2CGTq2vXrrqsgFZoFtBRRFlBMAXXH6LW448/rguT8hGTpt6ofP/997pNmNw8E2gtJ4rg6quvDrwMjkIKiuIUvNzYZJM+8cQT6uabbw5tU44TIirIF+SEjRsc55zhvvTSS0uNVUfFtpyJ0XFBEARBEIRCRgRAoXhp1Ej9eeaZ2uXmpuKyZf8Jgi5RUH+dO1elZs5UG1gWU9hScfVqVfW33/TmR6pSJbW6ceP/FwgRC90uwo03ZiY2o/vQoEEDPYYWNhbKwpNcKW+2lOMadETBu+66S5dvEJgeVWCj6AT7MqODbF5atmwZmFPlR1AQPW6W8iDGIBywUUyAy4fvCfkNRQ7ewp9CI6ykp9gh+sBUAASOme3atdPOOk58uOMaKBhhnJoR1c0226zU7zE6jHON/D5O3HTs2FEdc8wxVkIhx22bFnhOyPzwww9qxx13VEmDkHraaaeVed+GuXPnqt69e+uMV/IlM82Zw7ma5OUFQRAEQRDyDREAhXLHulq11MqWLfXm5eOPP1bDhw5VjVeuVBuvWKG/Nl6xQm28cqVqsv5rwwgONxsqrF2rqs6erTf1xRdlfp6qUEGt2Xjj/wRBrzi4/nup6tXT3g5NxrSH2opDbtcgQiKjbzNmzFCzZs1Su+yySxnHoLOFZW4hMnJ5AvQdByDXjQPw6KOP1iH3puIi94uRPD8Izs8WtrmFSTBo0KCc3r5gBiIPZQtkNfoJH0L+M2XKlDIOao5jQQ5roIjJGfPFRei4lylyIV6BDXc0kQucYKEF2Ntc/sADD+gAe0avKaYyIcpxKRtFPkRAnHXWWWlfAzhNKVI58sgjtWCI8IwASqYh7xcce03gOsjPMYXyKEEQhDjgM/EXX3yhPz8Ty7Pzzjur5s2by4MrCELiiAAoCC5YgD9VqZL6dYMN9OZHlXXrVKP1wuDhbduqHevVU5XnzNGCHW7CyvPnqwoJLuIrpFKqyrx5egtiTYMGpcaL1/DVySTcZBOVqllT53XhEGMBmYnziIUpGVt8mGERxua0YjrwM8c16BYH+coCl7FV3DNegQ5BkAB/mhpNIS+K6/ZzxPz0008qGyBe8mGOUTYheXAC4ZyKO98tWzCijeOLNlLcT7ko8RBKN4lvueWWatSoUcYPi/OcjR8/XgvvlLE4QhtCEyP5lCe5G9kR+mgJDnNOkqdIUy+B9SwU/eBnnCx5+umn1amnnpr2vnJ8xmVoekKE19fmm2+ukoaxZFNxsk+fPqpnz55lhElKS2655RYdg5AOBEQybHFTpqN69epagBUEQcgU2tw5TnnLoA444AB1ww03qN13310eZEEQEkMEQEFwsWDBgrSPx+qKFdXsGjX0Vr9VK9X0xBM9F1itqixYUHbE2Bk7njtXVUhYqKi8eLHeanhcKQ5r6tXTQiAiYPuGDdWUihXV5CVL1G8VKqg/69ZVv1nmeOEi5LpYKPqJF3yf/Ci/DKm9995bf+Bp1KiRHoN0uwZxgiAu8kHJFBaQr732mhZSvJgs9DKFvEJcKeRFiQCY3Wa0QgRhgUZtQMQhC9Np9RJyA248ngdb0fC2227T2XVeKFBiYyz/pZdeKnEE3nHHHUZj0zjTTaAtGFdhw4YN07q4EbMoRTEBARJhLRuLYlP++OOPwJiHbt26qSVLluiswDA4ScRrzaSQhfZoJ+tWEAQhKuTlDhw40PdnY8aMUePGjdMTLxS6CYIgJIEIgIKQgUPMd/FWpcp/7rumTZVq377sz9euVZUXLiybQ+jaKiac2VZ5yRK91Zg6VeHVO3D95vBPpUpqXrVqal716r5f/8Jd58pfwlFChh8ZUZSDmMJZzrFjx+rfZfPidg26nYPpxpaDhD6uLykQL3EMMSaG4EkOIWdz+UAnCEGwTzK6yBgwogaOWuG/LDyE3VyNRNu0wzpt5X7inxuczoy40nrOMeyxxx5TccKxkfHYvn37pr0szeDkFjrN8GGQu5c0PNdk/MUFZSEHH3ywat26ddpCFsT2888/P/AkAk5BTnD98ssvupxFEAQhCsQ5BIl/7pPYHJc4EZUN57UgCOUPEQAFwYWti8h2kahhVLFxY70t33nnsj9PpVSlxYtLCYNrZsxQcz77TDVYtkyPHm+Q8KK45tq1aut//9WbH8srVlTz1wuCf2+4oWr75ptqTdOmqnOzZur3L75Qi1i8pwloZ/SNVkdahMPcUWyMq3kfd4QTb84g/+dnNWvW9L0+sqGSElgY+6Wx2O2yGTFihM6k+vDDDxO5TaF4IEMzn+A1RDZnNlyzXsjEwyWBI8ymrTZXIN5+8MEHRpfF2UGhEcepxYsXx35fXnnlFSMBkCZ4IhZwnYaN3Q4ePFgXjSQNJ0041psIkqaCIvEWZCOaOicRRDlmM5oNiLS8p7z++ut64z7ihsSRTomWIAhCEm30HAc5ft16663yAAuCEDsiAAqCR8SxIZGRoAoV1NqNNtLbih120KLk9ddfrxZss81/P0+lVJ01a3wLSvg/36+d8DhkjXXrVLPly/WmyJG6+279/aZKqZGcwaxQQc13uQYRC+eu/7q4dm110iWXqG3btLEa7fW6gxAo/IQ+MqFYnCFc0NqI6OdsuEE++eQTlQStWrUq8z0ElKFDh2pnJIUAglAokLHWr18/nWmHIIJQZHPCg/FK2+II3FWUXDgt3o6j+PPPP1e5JCjaADiJweOEg8yURx55xGjsNApBo7FBzjbGi2+88UZdOOL+G4lmoKkYMTZbdOrUSZfhxAViqyMAMhLMySZOAFGagvvcnce4xRZbqJtvvlk/Fl26dNEuTS88PpRUcUIHNyfZjsXC0qVL9d/F+9RGG22k9t13X9/IDkEQokGGK1EQpgwbNkwEQEEQEkEEQKGoYSGJgOZsLGD9/s3Gh3sWnLgQTEdFs7EAYAFcKpuwQgW1tEoVvU2vVcv3d2quWVMiDDqiIK3GfG+TVatU3YTbaaumUmqz5cv15kdq/Hi1unFj1Xv5cvV75cr/uQldI8YLqlVTaytWjHTbiHxkYPkJbrjxWAi6XYNhI8UshBw3SDq4DjK9yNYiz9Dh9ttvF/FPKCg4scE4KyIerlbHsWYD4t+jjz6qBXdGJ3md0ZQb5PCiQZzsTgQ1BwT+J554QgtsjNfbNpbHBeIex2DGtxyXOCeLyJojZ477aAPNj0mN1darV8/q8u3bt9ePOw7Ub775Rj/PLVu21O3EuXic4xQAFy5cqE8EDRgwQLtJ3fseo3WMQfP80cDpQCagn/jnhtKsY445RkeG+EVXFBK8v11zzTW6gMjtjucYcO655+qfBbVYC4Jgzm+//Wb1cFHuxPuoX6GdIAhCJogAKBQ1jGE67q90kDXF4o4FEaNA/I7Tautch/NvnAO4CGjuTJoojrV/KldWM9kCRmGrr12rBUEtDPo4CDdKWCCkBKXq77+r7cnO8vk5UsPiqlVLXIOOMIircC4CYfXqapWPQMhzc9JJJwXeLgsZP9cmi16vKMjGGOIll1xi9DeRZch29dVX64UsWV+McAwZMsTo9wUhX+DEBq8lXhcIMjfddFOk65k4cWIpcQx3Gv8n+w7xBOEF5ywZopMmTdI5a7h2cZ1RpkMD7kcffVTq9cv3ucz777+vsgVNsTjJvv32W3XvvfdqFwdjszjKGP/94YcfrK6PogpahnGhhUUgRCFqcDx/B1suYbwWYY0x5jjg/Zp8TYqk/BbjuFxxQDL26zhWTYtREBdpXaaJuFAhcxGnn1/hDa9Vxg8ZbceVW+hCpyDkGt63bGCd4T45IQiCEBcVUkFzLUK5w2me5IMeAdrlFRYBxx57rB71CYKFKg2vjKwFOQqd75mG2JM1xEIS4YlCCRwYfGBAhGKxkU2qrlunGq13DR7UsqXagkXr+PFqw7///k8gXLlS/f/wVG5YXKVKyXgxXxfVrKl2Pekk1bBdO91wnPIRP3GCcFbVFEbCHBHDmzfIJodPoRghE+3aa69Vxx13nHarRYV247D8S95zslEwEXUk2YFWb0QkXJF+Tkjb6+b9g+tjRDXshIXJCLIb3i9oHzdp7OX6eL9H6MX1ni9wXO3atavOJ8wU0+eFUWeC+RnrtRl53m233WIXcLMFzz/in1tgD+L000/XDdYm18nnHkQL9llByGf4LMjnc4wCnNBPGo63nEzCQWwC7nuT16dQfpBjrBCXdiOnFgTBZ9HAqBcvKlwfs2fPLvkZCyXaucgJ2nTTTY0eO8dZGDR+zJl2xpPI2nKLhdyW0yibbXDX/V6jht422W039Wvt2upZlwhZCYFw1aoSF6HjHHQyCdkqJ3xuocHq1Xpr8/ff///NG28s+eeaevW0ELiMLMXGjVXFZs1Ui6lTVc2qVbWTcJnBmdWpU6fqcHjGxVgc8n/3GzEjid4SEsbHk2wbFoSkYXSXNtlIJUcW+UbZEv8QucKKLsLAMYxYd8UVVwRexlZYJKIAyFVkBPXu9RmqfnD8v+uuu7QzDXEvjPvvvz+t+Pfzzz/r9zUef6eEhAZjnGzEF+Q6943bf/755/Vjg/PU+Zs5BuNQDDsxF/V54XFDBPRzCoZhe/l8AmHfVFx49tlntRsQ8UIQhGiwQD/ttNPUQw89ZHR5m1xZQRAEG0QAFIQAERC3BwtURoQ4U0geFYKcbfGHM4bsB/lEuGwYh3Mu6x45JpOJHDrEJfcIsjOGHAX+DpsmXBZe3pEs8vkYz2Xzo2IqpRqsWlVGGGy6apXadoMNVI0FC1TFhMeMKy9Zojf3cnag699/V6pUqqjEGTF2/v9X5co6u4xsLEoInPwxHneEEae10q+lGCEXEdArDPI1qgtJELJJHOJfmzZtfL/PawDBJRvgpjZ1XPhx3nnn6Ry0ONl22231V44hnGgicw+BxSvwETHB+9Cpp56qjj/+eF1OwfuRF96TBg0apBeXYdBke/LJJ5fJYSSbEQGQxuW33367VA5jtkGUxAHIfXVDduvMmTMTuU3yYnmPs3VC2o705RMIwDbHAk5ShonggiCkh4gYDAbEQKRz/3ESRBAEIQlEABSEsBdI5cqqY8eOiT1GNEE64p8jHCE0ucPug0ZWHWHRm1EYlFnoblqk8dEEhK3mzZuXckGasK5CBbWwWjW9feOz+N2mRQv16xdfqJXTp6sm60eN3U5C/r+B4eh0VGqvXatq//OPah4ghi6vWFHNmzRJjxjv7IwaO63G1aurP6pUUakAdybPDXllfuHpQXmDbE7BgCAUA5QI+IHjjZMf2SAT8Q9BjVKNuB29CHkOiIA9evTQY9fkGpLHxvGaVlrazJ1jN+43HFtffvmldmRxTOb4wvH8xBNPTOvcw/HFgjLMCYkQePjhh+sTHia5uUkIcfvtt5++H5k+l7bCL+Ir78em49bOiHuhwomtJAsMBEEoC5NDY8aM0cfZoNcUa46XXnpJyj8EQUgMEQAFIUewIBs3blzk33dcZs7iNGzh4oiFBxxwgA7458MFwqKfaMhl3a25phmGpnz//fd609Spo6b5XSiVUnXWrCnlIHQ7Cfl37YTFshrr1qkt//1Xb36srFBBl5G4HYSlMgmrVtVCqBcW9CxO2bxi85FHHqnLEHhuEAM5S8xCDXEwyXFMQYgbThzQqg4cQzg+sSFe4WrLZ3AuXnzxxerss8+OXKoR9rhQduF3XDjwwAP15s6n8tKuXTu92XLDDTcYjUHTOj9y5EgthmWb66+/PlD8swHXOmPW5LeawnsfxSyHHnqocRNxIReA2Aq8hex2FIR8Amf3tGnTdLYshVgzZszQn/84rnMyiBxS9+dwQRCEuBEBUBByxFNPPWV1ecbEpk+fHvjhfOjQoTqQnOZZr5MMYZCweRoRCf4OE/VYiDrC4KJFi3TRCWNZjO05IiEbH1gS+5BSoYJaWqWK3qYHtA/WXLPm/xuMV6wo4ySsl7BAWC2VUpstX643P9YgELpdg9WqlWo1XkDL6vrHj8ccBxCCyS677KKdQIz6Mf7NBizeEQKdUWL3iHHcIq0gZMree++tR2cZNUTE5pjBwmfy5MlZK8+xcXMBrbAUHiAAOtmrvNbiglFdTr5EjW+ICo+/TXYeGVXZFgCJpSB30pQWLVrokWD3iREeVyI1yEskN9FGAKTQAxjF5sRcOvcgLe/t27dXhQonAhF6bS4vCEI84N7mBBObIAhCthEBUBByhO1IDaNet99+u85polkTAYhQbsbUcCIg1FFQ0rdvX91ai5MCYYiR227dumnXHWMH6RbE7hFVrqt169Z61MkvuBgR0Dtu7P238/+4+adyZTWTzaftF2qsXasarRcG3aPFjmhIgUiSUIKyCc8RDs2//irzc5ati6pVU0vr11c1WrVSld57T3342GNqwvz5WjRU5FG5BFbnsaxbt26Z63LEQWfLJ3HQVoQRigOcfu4oA/ZR3K3ZXmTZ5J0i/CFSurEtPkBIQuR0jw3zGsBZxugzJ3KSglIKClxee+019eeff2rBERc3zjab1yAuwGyD6MYIsCmc5OI9FLcefytxFTgrneeL8XPyFU1g1Jp8X+ffFD4dc8wxaqGr+Mor/j388MOqkOFvII/MZLydxzRuJ6wgCIIgCLlBBEBByBG2geNkPLGYYwOEHT8HHh/W+WDvBQdgFCGmV69eupWRUQVvgYXTZJzOJcMC2C0W+omEzve4XBwsr1RJ/Vqzpt78qEqTccCIsRYIV61SSfp0uG7dmEzGI9vYsaqzUnpzWFylSinXoLewZMV6J1E+i4PscyzE+/fvX6Z8QChe3OJfrsCh9cEHHxhfvlWrVmW+RwEHBQgmcOzCVcWxnZzVBQsW6OZHxnq32morlSQIUhdeeGGpYzS5doh5tsfUv//+Wwti3bt31yeVstEMjIhne3ne67iPfiC0XnDBBbrhNwzeQ++4444Sx6fjdiOb9+mnn1ZPPvmkdlDynHIijJNthez8c0AcZuSak3zp4Pgd1/uyIAiCIAi5Rd7RBSFH0PL1wgsvWF3ejc34LYtAwuOjwCKS5kjch7QiR8miQwRiYcqWzpHjbUL2Ew2dr5mMIK+qWFHNr1tX/e5aMOP+wTE5YsQIVQmBcH2TccmosUssbLRypXb5JQkuRba2f//t+/MllSuXEgTnOl/Xi4a4JE3EQbco6Pw7zsxB3CaEX7PgpORAmpCFpKFEA7HGVADcYYcdfLP1Dj74YH1MKMktDYGTLI4D7YwzzlDZgjFrsqOCiFIu9Omnn+pt4MCB2mWXpHPREaRs8Dav+8EoMMczTl4FRWfw2PEce0G4Zf8p5Jy/dNDqy/sx+ZB+IPoRKYIILAiCIAhCcSACoCDkCLKmCMM3GVHLdATn66+/VpnAqBUOExaC1113nc4a9C6eyWPCOZIpfk3IQQSNIPuNJPuBKIXA6S4poPUTyOdDSGPzo2IqpTZataokd7CMQLhihc4JTBJyDustW6a2Dcir+huB0F1O4nESkrEYJA4i0jmCoFcgtBXwGF+PI9xfEGzGeRnjRNT/9ttv014eh6rbBebASQbEPH4e5pjlGJjObZYEvCYvu+yyxK4fJ9z++++v8/QaNWqU2O3gruM4ZDoGzHNr8v4wZMgQ1bVrVy1kvffeezrbr3HjxjrjkDFh2pXLK+zvnJThBB+PD+/vPP4NGjTQjdHnnXeeFtIFQRAEQSgeRAAUhBzBYgd3xSWXXJL2sgSaZ5KjF0cGGw4Ycr0YiZozZ45uMatTp47aZptt1E477aRLK8i5ssncsoXrHzVqlO8IMm4OFut+Y6YsdPzEwblz55b6P0LpN998o0XAJUuWhN6XdetLPti+8fl5hVRK1V+92ne82BEKaRpOEpqS2VoEPCf/VqxYqrnYKxD+Wbu2fo6DciIdYdAtEvoJtyL+CdmGEVZe04zi0n5O02IQuJsRPPygyOSmm24Kva2OHTuqV155xVdIT5rhw4erP/74I9HbIFuQMdDbbrst8VB83uvSwXE+zPHoty84GX9CWcj5ve++++ShEQRBEIRygAiAgpBDLrroIi1ekdnnJ9IhTHFmnjP0mS6u4oBxqddff12PVJFFiJPC3fqJCEiT5ujRo1USeMeYEfZoyWXhyIJw0KBBOmjfC49tFFdh0Aiy04IcRqpCBfVH1ap6m+p7gZSqu2ZNGYHQ/f9aMY7h+rHBunVqq3//1ZsfKxEIGSv2ZA86o8aLa9bUQqifg9NPHORrrktJhMKD1x0NsbimTSG7D3AwTZgwQR8bKMjg5IVz7DjiiCPUpZdeqh2qfiAephP/4KOPPtIiWS4EQMozsgHHfEZFOdGSFAMGDNAN6JSohIEQmcRIMievnnvuOf28kzGIEw6nIaPdtpm9giAIgiAI+UiFlNQzCuvhDD8jnGTfXH755fK4ZBFy0WjZZeHhjOAcd9xxGY8oIbaQ82PiqrAVFGmaZDQsyFFjEi4eFyz2yXEirJ2RJrLtkgYXSpBQGFcDcq01a/SIMU3Gzqixu9GYEeBcsnq9C7LUmLHLQbiwalU9Sp1utNj5dzaeN6H425txreKKq7S+JMcBtzBRBQjUxCpwnA1jv/32U2PHjjW6TcYl/ZrSozJv3rySoif3iRYvXbp00aKVKRSScPLi7bfftn5+cUd7W5LjBuGN1noclX65f7feeqt+X4wb3s/IKvUrI2nYsKEuguGxE4Jhf+I1xv7lN04vCPmE6TFWEPIFOcYKcWk34gAUhDygRYsW+kXMFieUdvg54jIF1+KNN94YKAAGha4nBYsz06bOuOCDoyNcheEdPw4TCr2LpmWVK6tltWqpn2rV8r3uGmvXlhEG3U5CCkSSpEoqpZquWKE35ZPdhX9xkU/2oBYKa9dW8zfaSK12CYSOe9ARBd3/ZouzmMQBRxNOMNpbhf+g5RSx4+abby7Ih2Tp0qX6gxAlEG4QJkydY7NnzzYW/+CRRx5RTZo0Ueeff74WjLJF06ZNrZ9boie+++47azEvG83OiHwvv/yyPilG3AT5s7xGd999d+2Ej8vN7oYTb8cee2ygO3nhwoXq8MMPV++8806gW1QQBEEQBKEQEAegUII4AIsLFqS4UpKEXEAyAN3gwtt8880Tvd1iBPHPGTFmwRsmFppSde1a3VbcJGDEmBKT6D3K8bCoatXAohLGjFe4XFy4Sxwx0LshTkQZL6aJm4w4hKHFixfH/NcVJogsv/zyi9puu+3U/PnzVSFSq1YtLQRGdSKNHz9e7bbbbta/R1EGOaU777yzyoY7hdzSHXfc0fh6p06dqlq1aqXFdMQ20+ImHkfuU5JFILkA1zFj4vxt6dh6663V9OnTI7fPc4z65JNP9HGGnFlyCZMQNHOFuFOEQkIcgEKhIcdYwYs4AAUhoYMt+U6UX1AYUbNmTT0WRoMg/87X+0ym4C233JL4beHKIEOLLEMn/yosbF8If95YjLLRVJlOKPSKhN7/c5lVlSqp3zfYQG9+VF63TjVEDPRzENJkvHKlqpzwGCgiJFvbACFiSeXKuom5TA5h/fr6e/+4shh57Bwx0CsO8tU78kj4PflejKuL+Pf/8FjhYmNM9JBDDrEWAfNhfJjXEG3le+yxR6Tfr1GjRqTfW7BggX7MvvrqK2t3XhRoH8aJTcNtOrhfiH/AeDSZimTMmhYw2Yp/ZOohMCJ25WuGHqPGJuKf04iMC5DHwtYxj+uSDErchA48Low7X3vttTnJjxQEQRAEofwhI8CCEABCFuIACzk35C2Rq0eo/BlnnJF3j9/DDz+cFfEPyEti8cL47ZgxY9Smm27q28IrJCMUphNhgkRC9/fn1qihNz8qplJanPNrMHZyCKsmLPSQc1hv2TLVKkAU/bty5VIOwhKxsH59/f2lCITrXWBegZD9d5999tHjkLh6pKDkPxzxDnfvxRdfrM8w2gik7dq108dIyhomTpyocgVuragC4LbbbqtFULdgYwq/M3jw4ERbc9089dRTuoQJgSoIHK5Dhw4t9b0LL7xQi1LkcqbDNFsGZ+GLL76ohUVOnjmj10cddZQ+UbTvvvuqfAKR2wZbARAB9KCDDlKff/55mZ/RNE8+77vvvqvHzSm0EgRBEARBSBIRAAXBB8bfWFAFOQP44H7mmWdqQaF79+558xiykCObLwqZCCA//PCDzkiipXfjjTeOdB1C/CKOSUahu/XYLQzyb7YVVauqBQHulAqplNpw9er/BMGANuPqCbf+1l6zRm8t/vnH9+f/VqpUpslYf61bV3/9M5VSbdq0KXn9OOKg31dGkMsDPO+LFi3SQoe3edsEihpwSp944onaIezN4vODJm9aZhm7JUYgDjbccMPIv8troGvXrrrQKAoIOxRL4PLicTznnHN0RmAScL24HSlD4kSM132JW533Ka+DD5ET8ZDfC8vXvPPOO/XzmQ5eJ5w0oyneDa+bl156SW9XXXWVblbOl5II0xHoqJfv2bOnr/jn5ttvv9VuTEbHBUEQBEEQkkQEQEHw4ZJLLjEaC+rVq5c6+uijsxr6ns7NMGfOnEi/yyIP5wYLyShMmTJFL3i32mqrSL8v5AYW52yMqaUrMnE7CJ1//1WtmpqNaFirVtlsrFRKNUilVMN//gksK6mVQLGHmw3WrlVb/fuv3vxYWbFiGYFQjxjXqqVLShZXrarWrRcrEEkQAt2ioPvfnBDI9ehrHJBLttdee2lh3xZGSyk1cgthfC+s4AgnGo7qOEeHuU2cV2FwjMcB9/zzz+sxZ4Qy8iAp8thll120gBlVAOQ1RUYqIAAhevFY8J6RBIhHfuKfM4rbp08f9fvvv2sx1i2+UayBgEh7+vvvv1+mMATB7phjjjG6Dz169Cgj/nmhWIbbS+pxsMV2rNnmvZ4CE9OGZt67aVkmd1MQBEEQBCEppAREKEFKQP7j119/1SKWqRsOtwsZYvkA96Vfv36RnDK0XiJw8LeTYxWFgw8+WC8Y823MS8gOTjahWyD0/t8rEtZas6aMKOgeNa6bY9fd6goV1AKfcpK5678urFZNrV0vqDjj2Y4w6N4QCfmZybhlocMxyNsg/Omnn6r7779fvfrqq1qQQmxDWEIIcpdtdOjQQU2YMCHj+0AuHoJYELQ+47oKiizgfuHaI2MvTh588EEtlMUZUI/QiHBk4lBFkOrcubPvz2jepVSE22X82+ZvZ9zaWwgVJro57b5ueI2wb9SpU0cfS7LBhx9+qDp27Gh8eUbaTQteeA2Qx2sKY9aciCtUJKBeKCSkBEQoNOQYK3iREhBBiAnOxNuMwr7xxht5IwBGHatiQeqEtLNAxzljO+oE06ZNMw5UF4oPxC22sBITr0jI9rMjFjZooP/v3o9rIBCSN+gRBp1/M4KcJFVSKdV0xQq9qb/+KvNzJJdFQQJhrVpaPFztEj05tvgJhM6GSFjoo8Zk33Ey4YILLihpBCeLz8njYx8JEnhwqp1wwgkZ3T7HsieffDLw5wiDON/Cxl7vu+8+/WE77mzI3r176xKpOEsfEFZN9xkcgEECIM5Nt3vTBpyUpnCCifcZxoV5bF9++WX9N5CDBxwLjj32WJ0ZGDXD0RQyQLfffnvtYE8Hrb027c6cTLSNHhEEQRAEQUgSGQEWBA9/+SzyM7k8DpMXXnhBffzxx9rhwIIY54nTxhgnbdu2tf6dAw88UA0YMKDk/7hxcOsgajJWZjOSh3CTrpwin2FsMEwUELIjErrdg4g5P63/f/U6dfT33OJR1bVrS1qL3U5Cp6SEEhPPYHLsb6L6NleuVGrp0jI/RzpijLhEHHRnEdaureZttJFua3bDPugUljiOQu//81kkRNRhdBa3G+IObjygdIXCIFxmHFfIoKNIyT2Gedxxx+kyBDIIo4B7jOPXJpts4vtzbveyyy4zep1TZMFI8OjRo1Vc4HAjdy+uEVj+Hh5TU8aPH68Lrpo3b67ihOfU9vLEZyCGso+4YR/nPZPtuuuuK/X+FDe8Z+GKJPP3jz/+CLwcLswwUdkPjllJXl4QBEEQBMEWEQAFwUODBg1iC5p//PHHdRumd2FBSy+lGbQypmv+w1XHeBXiFCNZm222WegILj83DdE/7LDD9O+w0EWY5P8ILgiJb775ps5zor3RFFwtpm2R2YJF5hdffGGUjRiX+McIdJcuXbSzMu5MOMQvHDyICMWK44YLcqHiytKCYPXqWhCcsf5rtRo1VLV69fS/nVHjyuvWqUYugdBdUMLXhitXJvpGyL1ouGqV3oLSvf6oUqVUg7F7xBiR8F+ajD04IqHbOegVC3M9bszzx/EDgYr2VI533lIaIgPOO+88PcbAc4oggxOMJmH+liC4LMcsXte8xigfIruV0oUwIcXJWjOB600i35W/zysAIpoiNFK6wnPL+9AhhxyiR6XDcNqsbSDuIW4B0PY4x99L1qJX/POCAMhzazI2HRVOxpHPyHu1X+szjviHH35YNWvWzOp6d999d+0ktbl81MeeE4zs27zm2Gdx0SZxklEQBEEQhMJGBEBB8IAwh8hiungOGle799579QhTEAhsCEV8cK9fv36ZnyO+IRS6SzlYHHP/cESwQC7zgq5cWV177bU6u8pErHvrrbf05sCik/vMopzrOuKII3QYPrlHJpiMUWUbnB0jRoxQw4cPVxdffHFkZ5EpiE9kMeKkxOHESCOum7jA+cXCmaIGFqXlEcSDdA3HvIYdgbDU19q19b/Zv6ESRSWMF693DHqzCBEPqyZc7MEYM1urAFfk0sqVS0aMy5SV1Kyp/mac1Gf8351JGPY1zhFXL5TLMM4ZBMdZRBIKKnidcqKDExCIdBxb/Y4pu+66q26Ubdq0qfH9wImNwGP7muFkCuIQrsE4XYBuODaRmzhz5swyx2jaexmp5nHxw8nVtHkOOXbEDce6sMxFL7Qjc5w0ARGwW7duiTjkeD84/vjj1bhx43x/ThHKs88+W3JiEIGQE3vvvfeefh5xBuJi5ESTd6zdxs3Kc8JkgC28t/B+7xW1+RyAcDlkyJDQk4aCIAiCIJQvRAAUBA98oCebyGSsqnbt2r4f2n/++Wd16aWXpv39qVOnqmuuuaaMSwA3DFlRfgt6MgdxirBYRqDzwoKRResNN9wQeLsIiX6jy4sXL9biIotuxq9YdNIO6Xc7hQKLRsQe8pWSFv9q1aqlF/OIf7g2cTY5TaBxwT7AWCILVhb+jFkKwaPGQS5C9oky4iBfN9yw1JhxhVRKi3NaFCR70CMU8rV6ggIa1FmzRm8tPcKRw7+VKpXKIHQLhHz9s3ZtX4HQLSq7BcGgfyfJK6+8ooYNG6aFHiCLjjFRxlV5TZEbx1gv7lcnV9AUhGLczR988IH1/eJv51iO+4tj6uTJk1WmuMeTcV+TlegHx2jeC3A5Pv3002VbttfHFnCSgzILU8c6G+9RtPE62a+ZcvbZZxu73RA2bbJiaWimYT7TbEg/URiXZdgJLtzjXIbj7SOPPKKjMbzOVMRo9g+KZdwZgTy2iLc8NiYiJ6KoDR999JEW+YJOhLz77rs6t5CR+E033dTqugVBEARBKE6kBVgoQVqA/x/O8hM+zuIzCBZeiHA0WXq58sor9Qd/U9GIBR5iIuCiIJcvHTVq1NACYtBY0vvvv68GDx6snYSOO4SRoJ9++sloMU8boTPOy8KH0boglwm5W0t98s/yARpFWZTRbkzzZJzg3EQ8wYl02mmnafGVcTVuhzbTJAtR2EdY4OH8QLTlec7nXLhCg9e3Iwy6RUJncxyEKpVSdVevLhEGm/iMGtfMca7kiooVS5yD7lFjRygkozCVpkAI4RlB1SsKuoXCTFuOd9xxRzVp0qTIZUZB9O/fXw0cODDS7yI6vfjiiyWPAfeP4y73cYstttDH4blz52oHmOkYLMd4chG/++47XUBh4t7DuXjuuef6/gyBlFIT0/cbJ3+T/Rj3GgInLcKZwrg3x6F0cFIJ57tNtiKu9KjPYVghismJOuB9HpHaJH+yTZs2pb5/99136xN6Qc8zJwF5TGz2e15rW265pVG0xaGHHlrK6Z8U0lApFBLSAiwUGnKMFeLSbkQAFDLeiYoVXAecuWdU1wsfvHFu4AzwA6HNxvlFDpIjJJLJh7BjAiNthO2HwXOK840sKYQ8Fhsm4LJhJM0ZPWPhO2jQIO0MdBwQjH2deeaZenEWd9ZdHDC+jIMDt8vWW28d63U/9NBD2uHnx6mnnqrHxpIGlyHuD8TqsFINIX7cDkL35nyvZGQzlVK11jcZe0tKHKGwbo6F21UVKui24lIFJa6vtByvNRQnEDncgqDfFlZiQnOqrcMvDG4L91NU9y+ClokD+sQTT9QnhNLBeDMOa8QeTqpwHDEBUQmx308kIjMQkSdqWQluVwougtqBTcGxiNMSESwIHJ40BuNcY4zWFEakb775ZhUXTgkNx9A4Qdj1G4X+4YcftFsbtyCZwLj92K+Ic0AEtoX3YZvn68cff4w999GLLE6FQkIEQKHQkGOs4EUEQCFjRAAM/uBMSyAuD0S0/fbbT4t0QZlMzhgxAqIpZAp17dpVh7PbjOqQL8RonKlzYJtttrFa8DAyR06hG0ZpGRVG5GjdurW+PhZS+QbPD0IqzxdOmygNyUGiIm4Nshj94HkncykbBQwstpcsWRK64BZyg5NB6N5wi+mykmrVSr1ma6xZ45tB6PybEeRcglSHCOgdL3aKShAPV/uMp0YRChE2cKMhsLLxOs7EEUgxAuJYFHgdc/Ig7FjvwDFxn3320e7AIGg7ZpSU4zAgAtm0ziMABh3HOAFA8ZCJA88PHmuO94yMZgInJBC6OEHmdtBzkuLCCy/UTkWeT8aeuYwpFMhwsikubN9rbaC4K+n3RGJKHGeqCUwkkEebJLI4FQoJEQCFQkOOsUJc2o1kAAq+5KObK1dw1tzPNRf2GDEaaiMAshDk+hDXbMDVwsKPsS4TbK8fpwqLVRauziIcEZTAcuf/SQTKZwpiCy25nTp1KmkI5f5mul9zvbg1yM4Kui6yuLLVvpqNsS4h/gxC9kXHKYgoyNdZjlBYt+7/jxevp9ratVoQ9DYYO18brFql24aTgnujbwvnr8+oP4ONjBG7XYOlRo2rVVOrPCIaeXaOMOoGZ6B7VJ/HCgHOEQSdjdIQRl8R951xSEbwEejd2ByH/UQ9FonuzL4gyNUjk40PYJwwcufE8bfi9mIUlPvJySRO+NiIf8B98Y6XOnBcZkSV0ijGhcm1wxlIBqpJ6zGPOyO2fo53G9ivaWOmTArxlP2fE1VusY1jJ05AUwGQ0VqKOuL8XEI5TVJw4skReZPCr6043eWT/lznXL98fhQKAd5XODbH8dlQELKBHGOFuBABUPBFssQyA3eY6Qgw4h3OER5zE6eJFz7AmDxfCIW2whSLODbGZ2kaZHMHlXO7iGuIpGF5ielABGEEjUXTY489psfivEHrbnBXkN3EwpJRW0Q3GhlZqOMwQQhgwek8LoTOIwaSi5ipu+WJJ57Q20033eTrqAgqnRAE94c4p8UYB6cXBC5HGHS2BTVqqB832EBV82kMr7xunW4rdkRBp8HYEQwbrlyZ6Js94mPDVav0FpQk90eVKr75g87X5ZUr69cvxxdvVhpClpNbymsagc3djg4473CY4Uqm7Zvrcca0OU64XYamjbmIRByLaFQ1gTOwxCzQ3o6QhoCIeEVpD3mBQGYbrmqyWG1hn0h3rKchmc2BQiIbtySxD3GNYDt/M3jvNydScGaOGjUq7fXwHsTzyOsFhyMjxF9++aV+PyMDF2cgGyfeTEGwtW1PNoU83KQ/QzmZwTaXz9bnOl6vgpDveD/LCkKhIMdYIVMkA1DwtZFedtll8shkAM6Hli1bGh2kyQBy2hMdEctURNppp51CGwzd0B5MSHsmILw9//zz2gHHWVMW1oCzJZPcSAQORsLIzqMIgLwkcgVfffXVUgs0xEYuR8mK1yXlzRFjlJDFNg7Fjh076vvL6HacsNhHbPS68gq5NVnIb9iP3SPFzldnvNi3KTaVUhu5RordQqEzblwlxw6IpZUrq5VNmqhqLVuq1Zts8t/WtKn+umqTTdS6OnUU95Ac0nQnVxCeOB7hfuPEB8cL9wLPERS95SV+30NgQhSLC8qCouSDcqyl3Z3n2Ab2i7CTKV44fgVl25rAsZf3P47PjCuHNdsifnNbFDUFccYZZ+iIDNyS5OTisvSjYcOGuimY8iVTjj32WP0eEzcIlCbNv5m+9/To0cP48gim7obipE5s8NrKdGxfEJKGkwlktuLG5hjJcSjpjExByBQ5xgpe7rrrLikBETJDMgDjhXEq2ifDwK1CG6LbuYCLxREETRYBuPJMwGEXR4YS9xl3C8IDWYewfPly7WJkkZEpuGOefvpp7eBjzI8FH04cmnbJ82NRHwTh6iyKRo4cWcbZwYc7PuwhssYFi1uyrXAf8cbMeJ7jRuEDpiBkGwQit3vQEQdLFZN4qJBK6TFiLQquWKG2qlRJHdG2rZr96aeq9uLF+vvVEnBK2bC2Zk21sGZN9dOaNWUyCPn6V5UqqKOlxB1HyEJAGj9+fOS8nWeeeabMCLJ38xNe/UZ4yRWM4jbp27evuvXWWyPtDyat7w448kwFQI63FFhxogVxcvLkybp0yYF9jlxCTuYElTBxbOf9DqclwqEDLkbeCzkphKiEg5v3ynTHY55nTr6ZQOYh1xsnPN68bzknx5ICYZv3SJMxclygXsdsEkg+lZDvcFKHz+b3339/mWIoThBTqhellEcQsoEcYwUvUgIiZIwIgPFB7hRh6mFjXizG33nnHd0a6IaFVLt27XS5Rxg45fhQ783QCgJ3xNFHH63igOwmFtiOAAiMu+FI5P5nCiNo/G0m2VsOf/75p9p77711JliukUwZIdcFJH7j/nzf6xp0/u921CIskHuK4EKWJk3G9Vav9i0qabL+/xvkeOxvRcWKpUaM/6pfX3Xq2lWtpQG4Zk1146OPqj8tM/eAx4XFoslrPkwg5HjPiQ2aw23zpnBeU/RjM+LqgOvrq6++Mr48ObHu0V0/OInSu3dvXcxhcqIDYY7x4jB3HiIfhVu433Hz4bx0IOuRaAdTh6XeZ2M8UTdgwABdbJLuPRnINiTGIhtQAsLjErY/MdHB6zgbooYsToV8hvfE4447Tk/DhEXycKzKtAxJEJJAjrGCFykBEYQ8gkVeuownFjy492jRdS++cYiMHj1aN7zSVOgHQfd8iDEV/4AxWD7c4BzIFBZYCIBuGjRooMVMFoWZQgkAQfIs/LywQMSRM3bsWL0QZRwZlwnfywfxDyRQWsgVuJ+GDRumYxy8rh+nmISMsqDcQTYEGEol+H3cavxsSdWqepvmlz2WSqnaa9aUKSdxl5bUSThjqfq6dWqL5cv1ppk3T6n1GZ1ISS+vzyCcXbmyb5vx4mrV1NqAsUWyPjm+4fbFmeY3hstr3nl8g+DYu9dee5UaNw76NxuPPSeDOHkTRfwD3mOImTABB4yJ+Eem4eeff258Hxj1JRaB0W0eRz8QSIOac3EHmsJ7xj333BN4O16uvvpq/Z57ww03lHnPxjWO+IeoiFMQZ2SY4InIxofxbHHiiSeWfN7gBJgXXJc8HuJoCofXLgI7Dd1MMzBtQOlM0i5OIbvcfPPNoeKfc4zmsy2xD6bleoIgCIWGZAAKJYgDMB4YY+KDt6kIRHOjnzMPoYux3SFDhmhnBAskHHaMuPLhFDePLb169TJys5i4XVg0IfixuGSRChRzsPiKA/5ehEC3C5DyDQL+g5pVRXgThP9EwPfee087kTm+cGxnYWsDbbXOSKZbHPQ6CMOyON1ssF4gxEHodRLytX6WmrODQJ5c6CkncZeVLKhWTa2pWFG72TiOcvyzhbIim/w/Mk8RHxEi/JqQHWeh89WBqAOafznJhJjhLGjD4Pc5qYKLOgyOv4MHD1ZRuO2223yLk9JBjqvN/ssJNERKG4iM4O93TiKRX8hJM/doN+PFPPfeqAveizt37qwfl7DMw6RgjJrMW5xLjoPypJNO0oKlTbEY75/8jXzmmDZtmn5P3WGHHbSIzMSBye87JwwKJQOQ1yQlM1OmTCn1fUR+ojzIV+JkiFDYkIOKs9079hsEJx0Q1gUhnyjEY6yQLDICLORsJxJKc8cdd1gtck455ZRIofBRwCXAaAMf7uPk3HPP1cIiH6ZtF16mGYfsn4ydCcUHQhLOGhFw4wOXMHlGuMfuvffeRNpO/cTBoLFiEwffLg0bquaVK6sd6tVTW6RSquq8earK7Nlq3c8/q1oRxnfjhEdvUdWqWhBcXLOm2nr//VWV5s1LikpWN2miUmkc2cQk4Dgz3c9pycV5Rot5OlgMkD1HsD0jnyx4HUchua2428gg9GtB5nni5ApOtzBwjiIoRnWRI0xT8GQL98+m9ZCMWhz0SUHOIY3yPA440BkrdMdhFCJ8NmCcGPHUD0464iwOE8MKbXHKfoI4Huba3X333dWYMWO0CC0ULrSH25Tg4dQOKhwShFxRaMdYIXlkBFgQ8gSTnCA3uHT8wInAWUjG8FjMMZrFGWmaEKO4/4AxMoLPTz/9dPXuu++qOIU63pAIcye7iRypOHDyBHE2iPhXvLB4dhcACJlDO7g3XzQJ+DDKiSM/V66TOegnDnqdSWT4fbJ4sfqE/8yfr11M5/TqpY97ZKW+PmKEauQzYtxk/deGK1cqc6+TPfjAGq1apTfFCPXTT5d9LBo0KNVe7G4x5itjqYxjfv3112lvj+Np+/btje8fDibeL3g+Ntxww1I/Q/TDsYigyDGV8g6+x2KCsWZGSVu1aqVFIK+70O2AoyE4kwgJREhu03bhwntKukgNr3s1SXhebJ6bfAd3JePf7gIXLxRrUThCSYyNsJ+vsK9z8jVM/AM+f5GHms3RbiF+guJ0guBkiiAIQrFS+O/igpBn2OaG4Lh0wwdSxowQ1dx8++23+ow148WczWTBFoVGjRrpBTWNkv369VNxQTHIBRdcoEdmcETEAe2dLE69eYPlBRby7B+//vqrKmYQJITiIyxzkDbvIHEQ0WnhwoXqzjvv1MIEi/XVFSuq2TVq6M2PSuvWqYarVgWOGCMeVrEs37Cl8uLFeqvxzTe+P19Tt666ZeON1ZS//lKzKlcuNWLMtgxhZb04xjHPdPQQZyHvF+nahXkPIRuSkWIcdTgLnTxDHm8/eC4cQZDLbLXVVmVyC53/p3M2RnUtnHXWWVqEMYGMxqjvjeUV3rvDxD8HnHBk7XIistAhq9jvpIUfjERff/31kglXwPDekuTlBUEQCgkRAAUhZg466CB13XXXGV/+wAMPLPk3CyjGacOKNHBCMBY2YcIE3ZYbFfL6cOzZnhkNg6bEOMfHuW/du3c3aposNnBPvfTSS1oEKCa3iRf2ZbK3hPKFIyDhKvLizhjETez8G7EqSEBaW7Hif2Ja9erKz19XMZVSZxx4oNpv6631WHGVOXNUhVmz1JxPP1X1/vpLi4TVEhqTdqj81196lHmPgJ8vq1RJLSBXsXlzVXXcOLVi+nS1qkkTVaVFC+0gXEsRiM/fz+uHx9IERBxO1JjCuLDzXPG8MAIchCMGBhWbkCPH/22FQGIgEIP99hUvV1xxhfH1Cv89v7xv24iFxSAAkploCicwOGnKGLRQmDDSa8O+++6b2H0RBEHINSIACkLM7LbbbnqhM3nyZCO3IOO47nETkxZdxoZxRJDJExUW0y+//LIeEzQ9E56OTz75RJ199tkqTkycCdmELCBC15Pm1FNP1YuzYlhsBUHhAJlljHsmlVEnFB4I/mzeZlNEIz/XIBuOwjDWVaigltWrp5bvvLPeHBHgfcf5lkrpIhL3iLG3zXiDhPfRWmvXqlqM2PLe4fP+sa5GDZ01WDJivH68+I8331R03v5RpYpKpRHWGBVG0KhTp471/UtXfMJJi7B4Ct7rZsyYof/NeLG72MRbcuL+P2UolNnQJEwLcRC8J55wwgnWf1d5BoHdZryaE49R959ijGoR8h/czhz3iGDALW1Cz549E79fgiAIuUIEQEGIGRapZDHRIJjOuUY4v/uDNGfXTWHxyhgvge+IhmSosQhGgKQp2KS1D2cZoh1uQFpDM4W/l5zBOMm3Ygjy6tI1asYBmUu0QBebMMbrgyIa2qMZ73ZKJMIW9oLgHAsQ3/0EeAQjRwxEpHeLg07eoLtRnFzVTz/91L1jqj+rVtWbb0VSKqXqrG8yducPbqGU2q52bVVl7lxVyWfUOU4qLl+uqs2cqTc3d6//uqpCBTXf02I812kzrlZNLapWTQuhjNzbCji0Zz788MOR7zsNnE5bvLMoZzNxLvL8IT6SQfjUU0/psineaxxnISO/F154oS6xEOyIkunI7xS6AJhpVItQGCxZskTnZnPMMAXxj6xWQRCEYkUEQEFIgA4dOuiSjZNOOkk3L3phgcr4LdlGbmgWNIUFLE2fc+fOLfV9AuZZqOG2ePTRR0synoLYbrvt9FjY999/r0fJ+HCPyLXPPvuoV199VV188cXG94lFGm6ubLnkckE2xD+Iy5WZTyBQkzvJ4otsMRbvCIIi/gmZgpjEsctP0MCVts022+hxc3Ly2O/Iw+MY5S65CKVCBbW0ShW9TXeJB+zLTkFAxb//1qPFels/ZuzeKiecdVk1lVKbLV+uNz/WVKigFlatqqpdeaWqSJbfehdhSWHJxhvzIi37e2vW6JNVpu4ZP1hQRy2PcMRC3lvIMOzWrZsuM+F75BkylsxxhPcwd2ZhmKvQW3BSXiET2AYeO2/JTKFGtXwTkNXphX2FY4dQWHB8OProo9W4ceOMf4cTk4MGDUr0fgmCIOQaEQAFIcHxRsZrcHINHz5cB6hz1pxQe4S/evXqlfkdW9HMK/65wSnBQve5554zyltigYxDBpcN95PfIXuJ8GvTkgbGVe+55568Ef/44M6HQCE/YH9kf3LgNXDeeefl9D4JxQ+5c7icGQFzwBGCA5ATJF7XIP9ON1Ls4D7Bsq52bbVym2305keFf//VTkE/cVB/L6CIIy4qp1K6IEVNmfLf5oHx4TUbb/yfIOgaNf7un39UlZkzVdVq1dQqT3uzKZxcooXY9HENg+OG3/unN7MwHY5Y6BUK3d9zvharWMjJPvLOTB1SuKnIgix0mJKgsMxkwgARCQerUFi89tprxuJf8+bNdeYyJ8QFQRCKHREABSFBWBx26dJFbyY0adLEKOjcZkyYUpH99tsv8DIIk4ws4xbEVQF82EX8YxSCwPgbb7wx7W1RSMIH5W233VbFCa6PoIbKdGy55ZYlmVNCfo7n3Hbbbbm+G0KRQykTrjE3RBWw+A/KG0Tw8RMG3SPFjhOb3zcRRVIbbKBWbb213vyosGqVqrxeEFzz00+q2ty5qtq8earmwoX/OQjnz1cVEowEqJBKqSrz5unNTROl1AHr/724SpVSY8bur3x/eYBAuHz5cjVx4kS1++67q3zBEQtNYH8wEQoLUSzE5W8qAF500UWqGEDwufbaa0udkAr6/HHHHXdk7X4J8WFTbvPrr7/qrNGk4L1mzpw5+vM9rmVb560gCEKciAAoCHmyEGEcZdddd9VjTHFCrmCQAEhRySGHHFIm4Pr3339XAwYM0GPKt9xyix7tdcRBPxgJ4mwr953fjRNaHRkbtXXy1a1bVxeS8LuCUCzgzM23XMx8ZYcddtDjuRQdecH1hNOZQoOgYzKj6X7j6YwUIwY6giANoZRP4DTMhFTVqmp1s2Z6+6tNG/0883xzLNOsXq2qLFig3YLfvvmmmj9+fEkWIV/ZcPklSYPVq/XWOiCiYEnlymVyCB2BcDFlE3kkANrA/sBm8hzznKUTCZ3/u8XkXIGrjwxFxrzDQCxjsqFY4DMOzwN/F2PuXlq2bKmL0rbaaquc3D8hMz7//HPjy/K6njRpkv48HCdc7xNPPKHuv/9+XUTiwOuI1xzvGzaN6IIgCHEgAqAg5BBELc5S8sF7+vTpidwGo1dB48OMI4e14eG86969e+DPWbwcd9xx6uabb9Zn1MkSjJPLL79cC4CcLUXMsxEBTznlFPXMM8/Een8EIdeI+GcOJUeMOPpBdl/Xrl0j5T2xqMPJ4bi1OX5zrEJMcMZP2XAHOv+OJYqgSpX/xnKbNlXvTpqkvtqCCpL/p2IqpRqsWlWmwRiBsPGqVWqT1atVpQxFynTUW7NG1Vu2TG3jVy7x1Vdq7eDBpVqMS/IH139dy2hvgS+IeY2yj9iIhUGNyN5/JwH3gddBs2bNdLGY13HPRABiWdhngUKEv7t///76s8WQIUO0CxKnKn8vGcqMrOeDQCtEw/aEjKkb2BSicBDXR48eXeZnH330kd54D2LfKzTXsCAIhU2FlKwmhPXglKB4gLYzFjNC8h9OKAl55ZVXEr0dRtP4UAuMuQ0bNkyXe0ydOjVU/DOBUQbGuhj/Bc6gUkwSB4yK0XDsfDAir4tx0ddffz2tCELbJB/cx48fr/IFXEOMmMTtkBQEIRiOA0Qc+IkXCHg4MUzLAMLg2LfTTjsF/txpvCVPlWMvx2Sc0xxD/Y5n3LcyDkAXFD1xm6bQvH1aly5q1e+/67HiOn/88V8e4Zw5qurs2Xr0mK80DeeSdTVqlMofdL6uatpUrdlkE7WGHMdyulhmXwhzE3q/RnEWIVrzHoubn9+nvAUhzKTAhf0VJx2XFVeTkGtat26tpk3z7XT3BYdenBmAp512mtFJaMR1YioEIR1yjBXi0m7EASgIOeLqq6+2Fv9YMB577LHqscceM/4dij2AMhBy/eJsXF20aJH+8MKIgzNyx2I1jhzDzz77TB155JG6jZi/+/DDD9fCJc5F/n5cN14BE7Hw5JNP1u6/o446SuWb4Hv33XfrkWTJJSweKDVgv2OcNFNBXYgfhDeOe7iIvccEjlU4pHFhIHpkgl/7sBuOWwMHDtTlTO5jMI3xNNsedthhpZyDXJ/fWKL7uG4jACI89u7Tp+S2KdHg2LrvySdrN6QmlVKV/vqrdEnJ7Nnqn2nT1Irvv9euwtoh9ykOECCrzZypNz/WMSaNQOh2Dro2SkxUkbq2nMVf2H7hJshN6CceOoIducWMJQpCoUPZXt++fY0uy4nrtm3bxnbbP/74o/EECgt4Fu4s4AVBELKBOACFEsQBmD0QyJo2bWosxhG8jVMFEYwP6DT2mopIBF1zFj+pD/U4DAk3JlQfyFAhEytuWKQcf/zxumWYshTcfddcc4366quv9IIIdx1Nn4T9n3HGGer5559X+cYll1yi3n///VJZMPkA+9Wbb76Z67tR0LD/ebM0yysIohyvOCtpI1IlCc6Or7/+OtCZ9MMPP2hx7rffftOi7tNPP62FOFNwmgQVIH333XfqgAMOUPM85RpuWKiSt+rcPy7LcQ0BE7HOO1K8ePFiddVVV2U8Eo4ISgkE70dBcBu8B3G7NTnWrh8v9hs1ZgQ4l6QqV1araTIOGjNmJLxKFVUMnyF4D+QkHO+NFF7tvPPORk49P/wchEEOw6BxRXGnCHHAfsT4LFMTmbSGc4wkx5GTH+ng8yInj+OC4/ntt99ufHlK+IptxF6IHznGCl7EASgIBcSLL75o5cSjZdIt4LFgI0A4HQTUn3nmmYk2L3LfvvjiC3XQQQfp//fu3TsRAZCF8PDhw3WwM6N2uAG9jbI9evRQd911V+RFkN/jh3PP1HGRDrJe0jmFclEUwai1kBki/v0/lCXgVOYYtfXWW6tffvkl57sXY764ivfYYw/fn3NS5aabbir1NzjO5nTgfOb3/WDUF3dfmPgHxBu0atVKH68dEFo4lvmNAP/888+qZs2ausjJ3VRs0kbsFZLIf+NEUYkT0Od4gntyxIgR6p/KldVMtpo1fS9bfe1atfF6YdARBberXVs1r1r1P0dhxEZ3UyqsWaNHmdn8SFWsqNY0ahSYQYi7MFWtWtrb4fiK6MvjzzGd54ATbbiIkszzQoTFzc/7IPuomxdeeEFn8jLuHeX91TSn0tkvvSKh83dzkhLxphAbkYXcQRMvxXNDhw7VwjbsuOOOqmfPnvqkru2xrUGDBvpzIsdfTkYFwefpOMU/IOYhycsLgiBkgowAC0IO+Ik2xAwuf/755+vF7LPPPhv4O3z4xsWCSyDp0UQnYxBo3CTXyvkAFzc4dNiCoEyFxUccsMCO8+/IhviHWIATySb/MI6R7aSQ1tvC5N1339ULK/LDKDrKB3ALBwmAXnr16mUsACJ0+jkLcRWyeA07XrmhgIGFblh+Gu8FjIsxsuwVgADBxREDHWHQ+RpUaMDrf9y4cXqhHETHjh216JQuw3RFpUrq15o19cZtdurUSe101FHq1/V/U4WVK0uyB72jxnytvGCBquDzd8UF111l3jy9qQB36pqNNirJHfQbM/5l4UIdQ+EV/Qn1R3RgpLxFixax33dORg0ePFiPFwa9vzz55JPaPXXggQeqpGC/8ytMQBTlZ+yDzj7sbkROV3QihRvlFyYQyMRm33WDwH7eeeepBx54QL399tuBpU5B7LXXXvq4RdPzSy+9VOpkLmI9n6U5WRU3koEpCEI+IwKgIOQA2w+6XkcbH7BZVCO8jRo1Srvw3Oy6667aUcKiLRtjBe7xMT74cNs06xVK+1sQSYmYScLCjDHsfCpAyQQWlQgTfPj3EzyE/MQRu3GO5YsAaNPEyzjlHXfcoVvIw+jSpYsWfLzgljv11FOtmiUpXghzKeIS4ZjubWl1w2sEdzmZlIh17tcM43Rut6Dzb5w1iFeItUELV06qEGFw//33a/ehCbw/vfXWW/q+IAQC7rpVzZrpzZfVq1WV+fP/Xxx0viIa8u9587TLL0kqL1qktxoBUQ2Nq1RRzapVU/OqVVPzq1dXc52v1aur+WvW6JgKHqu4RUBE9SDxz7vvIW4QlVFojchJl5wI+ceXX36p413CIheIbyCqhOOj7VgwZSC4YxHsiaTgmMzIfMOGDTOOUAiLnLDJlY2zfEQQBCEdIgAKQg6wfbOn1dbbANmnTx+1dOnSMpdF/Hvttdd0JhnEWfrhB6Nv3uZfcvjIKCTTqlDhQ6bN4j1fYNE9YcIEVUwgpDzyyCNaGDF1Uwm5xTn+sPjKF2wFGeIMWCT279+/jPMNUQuHIyVI3jFHFqkUEUWJDiDHdKutttL39cQTT9S374iXjHeGiX/e0hEvTn4gcQl+rkHG7xADnaxBvroXyITUI4gyTo1jkJE9E1cz+VqUlgSNSZeiShW1etNN9ebL2rXaJVjKOeiIg+u/VzHh43a91av1tm3A3/535cpq0cSJqsEuu6g1njZjvq5lpNtSvOL5//DDD40v/8EHH+h9sJhLTkwLTqSVOL+54YYbjPJWEe9GjhwZeb/mPYmTHA7EMiQlAHICnM+/JtfP1AbuR0EQhGwhAqAgZBlGHMhcMoXFGS2WDjTJ0hoZBOIP7Y6ffvqpHkeyHZmIsmD1OxN/8803a7cK2VJuN1qhjHQiuvIYFmJBBK7QYoLFL4KL5OwVDk6mUr40I2+22WbGY5E4f4cNG6adKYgRLDibNWum9z8EaGIGENjIqqLUh9w+nIBEBjgL2qi5oRy/HQEfJzXjbzjKeE0zUpwEjmsQRyCN625wbrnbifnavn17nc1FJut7771ndBu0tnfu3FmP5GVEpUpqTZMmelvuOfG0/o9RlRYv/n+BcM4cnQfodhPSNJwkNCXX5uTc2LG+P19HtqxLFNSjxq4R47UbbVRGIMR1aRPVwLh7oQmAUXMLTcQjJ7fQpBlZcguzBydW3njjDePLP/TQQwWxX3MSB2f4448/nvaynMx33jsEQRCygQiAgpBlrrzySu0QMeWCCy5QW2yxhf73zJkztSslHSxQr7766pIPSywgk4APOOeee27gzykGYcO1QlMwLhNHXAsLZY4LQtmjNO4ec8wx+gNcpgIgCwlcPJx1PuusszK6rvIM7iH2NZtWViG3YtvRRx+t/23SwJgNaGVMVw7EiQnEO5wbfvsaUQezPeUSs2bNUp988ol2AjLyxUkXxtXjALEN4Yz7knROJycpaBv2G/1l8y5QETgpNSJ+wiRrECGRlmWaOZ19IxEqVlRrGzbU24oddij781RKVVqypOyIsctRWCnhrFYEyGo//aQ3P9ZVq6bLSNzFJH+uWaO2++svNa96dbW4alW1Lo2DMBt5s4WEk1to4uqX3MLswWivzQlhhO1CgdxCPvuGjQKTNduvX7+s3i9BEAQRAAUhi7CIMzkj6IDwx4YQRZMvgp5pDhqLLRwkuDU6dOgQayYcCz0yVBC4XnnlFXXkkUeGLq4ZY3NG2ZxRDv6epDP2Hn30Ud3UyGgbbh5TEFAJh6ZROBPGjh2r3Zgsxi666CLfkW0hnE033VSHdGdDMBbi4fTTTy85HviJStmG1x6v53TgrA47WeIV/9zgCMRhiPM5bhh/T3qUmpE1G+cTx7SgQhBaYP2KSPg+mYDNmzdXbdq0UTmhQgW1tn59va1o29b3IhWXLi1TTsLXhYz1/v23qpdwBmHFlStVtV9+0ZtDI6WUkwy5pkIFNZ/cwWrV/ssdJI+wenWdScjXhVWrqhoBjc6ILYjyCLK4qnlehPhzC4O+J7mF0XNZo1w+l3C8e/nll3UEAtmp7hP/5DRTHhWWuyoIgpAUIgAKQhZh1MEmk4+MJcfxR27gn3/+aTVqzHha/fr1tUslU1iAcvssdLnu7777Tm+0ISLS0Jh5wAEHGF0XC0DcjAgF5BUmMRLM/UX8ZCM43UYAJGx/p5120m26BPNHxXE81qpVS5exZCoolkcQXQphZFwoXVYwcODAkjINREBv7ly2nKNEJuDCTbfI4iRLpk5pjo80rycBJzKSgvcInOY2hDWt41hkC8oaJJAfd4wzUsyWT6/xdXXqqJVs225b8r3nnntOfbDeFVpj7VrVaMUK1WTlSrWx6+vGK1eqJitWqAYxlVAFUTmVUk1XrNCb8nGGIpH8Xbu2qnr66SUuwn8bNlRfLFyo3psxQ/2wfLlavb6pl88VvG8b5TMKseUWmpSdlIdR5JYtW1pdPol27STheSTDmI33B04CE7NAnqogCEKuEAFQELIIocNRIXjdFs4wcpuZnjXF7YfbI8jBxs84k/nmm2/qkV8T+ACEe5BsoyeffFJ/RahEtIwDWhgRK3GPRSnF4L4gbu6///5lWpZNGTNmjBYggdHCjz/+uOgKOpKEscOkS2yE+HEfq3K5iCWjbs899yzzffYpxnTJ9OP+sQi1yWUN4/PPP1dJkJRAhjjLiSnEUhN++eUX7UTn2M3i1ua9xckaJMifZmhOHDngtnILgs6/o2YpxgnvBZRqOCyvVEn9WrOm3vyoum6dFgjPO+QQ1bJq1TKjxpXnz1cVEhQ8GcCuh2N64sT/tvVsrpQ6fv2/F1Wt+p9jcNo0Nf/VV9XsDh1UywMPLMklTK0/eSUkk1togpNbaOIs9Bu7LwQ4yUq5l2ncCidSCxVOtLAJgiDkGhEABSGLZHvcJmxkzfQDKOH2uE8Q6MJgoUYYPq5FGnRtxEXys9yjyz169NAuQz9BiEIUcrHCPkSfccYZWmAkqN60NdPL5ZdfrsXId955R+23336RRFRGPl599VW177776oU2giCiLC6hQhplyRUi/hUmTs4WzlsE+Fy4/4AcTzccUyglIhogqXF8XteZOoezAe4vTm4wXswx2ASiFDixkumxCzET8XUjyi48WYN+oqG7ldgRCLPlGuQ2eE+yYVXFimrlFluohl26qCV+ztNVq1SV+fMDMwirzJunKiT8/rDRqlV6a+tEKzDOPXJkyc/X1K///83Fzub6/zpxMGUtt9AEJ7fQZBw530aRycAjRiYdnKTgs50gCIKQGSIACkIWQUgqJPiwxWiY42JLB27Dl156Sbc92oIzDmGPkWAnWL5u3bp6fJYPfhRzUKSBkMaHRcpUvvjii1LXQeMx2YI0U+IqzDS/b/LkydpBFHXBS/gzG2Nvp512mrrpppt0c+jmm2+ubrzxxozunyDkK4gmjPjT+JqrFmCOH+4GdMQ/3MkUdiTNTwHlDvn2HHFC4tlnn9WFUekg4oGTF9k+GeaMDTtxCt6cNrcw6HyN8+QK7wOc1LIBgaVbt27BIkvVqmr1ZpvpzZc1a1TlBQtKC4PrxcHKv/+uKiESGmYBR6Xyn3/qrca33/r+fG2dOv8VlTiiYNOmalWTJmpl48Zq7WabqXVkf+aRyFTs2OQWgp9AGPTvpMXCI444Qv3vf//TJ12DaNSokc4PJbdSEARByAwRAAUhDTgVcAD88MMP+gMRrjJccVE+iJCzg+sCgapQHFgIcjZweRsBkA+uhPTjLnHDgt1xAZJRxOIdQdARUhEMJ06cqL/yoRe3D4u1OHP2EBHvvPNOvQg1LV/xY/ny5dp1xPOOAwkhUBCKmZ49e+ZM/AOOHTNmzCjJjCJLNRviH5gswmkUxvHGSG0u6d+/v9ptt930+5Ib8qpwQOPexE1t0j5vCo5Dp9k+KogSOM3ZOEnkBgHQEQMpmho1apTeF/gdXIeMHDZp0iTtbXAiilFnW3iv8rpPrahcWa3ZZBO9Lff7+bp1asE336gZY8aoirNmqY2WLVM8mpunUqoGzsK5c3XTcJJUWrpUb9V/+MH35+tq1FCrmjbVf8Mqr5Nwk03UWtyfIhDmfBTZr+3cizNibDKOHDXygQKm7bffXn/eYurCgWMPkyV9+vTR7fKCIAhC5ogAKAgBsHi49NJLtXDjXdBdccUV2oF21VVXWZ8dJZQeV1khtJoietmO77kvj7jH/xkPJvjYL6eGhaVX/PNCXhQbo3U4EhkR5sPmLrvsojdHeIy7ZOO3337TH2gpBEFszBRcUbgYBaGQsM16c4pAcg3Hb8obRowYoR5++OGc3AcEKo5/zgmEBg0a6Bwr7hsZhZz8iAIL4tGjR+v3EZzXtPJGhfITRwAkMoH3tWeeeUafuEgCjt9JZkOyv+IYJNcRp7Xzd/BeXb16de0+PPjgg/XJGJo6EUH8TvBwcslEIPEruUqUihVVox120Jubuc4/UilV6c8/tWtw5P/+p2osWKAar1ihGlNWsnKl/nethEeMESCrz5ihFJsP66pVK+0g9IwZr2nYkCcy0fso2ImFJuPIziiy6TiyG070shFd40TJtGrVSke/CIIgCPEhAqAg+MCC7fjjj9fh6H6w2MI5gcPFNjye1j0Wbscdd5yaM2dOpMefRQyuB9wNSdKsWbMy7op0EHL8119/6WwpFt3OOByju4wUs+Ddeuut9fd4/GxEO3K1GEMjwJ8geRZvbmE1bpwsQxasZA8KQnkE5+0ff/yhCg1KiSiaSCrvzwQWzThYEPw4nnDscx9XOJYx2mb7fNx22216Y2Ee1shr+jjx/CJ27bPPPtotlxQ46G0bh6PAWPMtt9xS6nuckEIMZGP0mbb3cePGaZcR7/necWIyLPkdm5N8XBcnqnJKhQpq7YYb6m38Zpup+T6ZvLXWrCkRBfnqCIOtN9hA1f/7b1U54dzOiitXqmq//KI3P1KVK/8nEPplEPK1USOCIxO9j0Kyo8i8rtzuQkcY5PNt69atS/7PazPfcgsFQRAKGREABcGHIUOGBIp/bgYPHqyOPvpo62y/Dh06aGEMZwpOC854fvfdd8ZjprgXXnjhBS2C4dawzSgyhYUrC8zrr7/e+HcYr2rXrl2ZRSROQB4vHJUvvviiOvzww1Xfvn0jL1jJi3Gcg7T9ulsa48JZqJ966qla6P02IA9JEIqZQhT/HHIp/jkMGzZMbbzxxurWW28ttYhFuCMzlZMinDAxxR2Yj1CVaRkGv88xtFevXomKf2RC8vcm7eiZNGlSGfHPDzJeudzNN99cIkC4swk5QcfYOG5Cvu98df7t52jv2LFjGWdTLiE/lxgTL8sqV1YzatXSm3e6AQdjhX/+0Q7Cqk5zMf92CkvIIly8ONH7XWHNGlV11iy9+ZGqWFGtadSotCjIuPF6sZDR45RFGZmQfTjuIO6xZTKK7OcszGX7vCAIQr6TP59SBCGPPpRQRmEKIlSUcg/OclIMwQa4Ih544AHjfC3cb2QRInwhqsXNIYccot2KwMiySX4WuUqMk4UtInFfnHDCCbohFyEwKvzNjHARDu23wIkDMvvYH8jDosmXNmRp7xUEwZbbb79dH6u8Qfccx3FKI4qZupjPP/98/ZWMPlp544BjdtwnUfjbyL1ljO/cc89VnTp1yoqLZ+DAgVbvI7TQu93kDuQUcvx359F6TxC5hUHcnYiz2WgnNgVH51dffWV0WZ4bR4hJ1aypVrVooTffy65YobMGS7UXIwyuFw0pMamQ4ONQYd063ZbMpgLiOVY3bFh2xNglFqY8xTJCcY4iB40jOy5FEQsFQShvVEjl0ycVIafQwkWeECMsYW1cxQ5jPy1btjS+PB8kWBxkOoaFiIUz0MTNh1iISMmHHBZtLKzipG3btrpQg8B0oAAFEXBxyFl/FlAsTE0XsYiAOBgzOQSxzxIePX36dL3QTIKzzz5bvfrqq4Hj1jwHbdq0EXegICQEizaKhXBLFzKc9OE44ueAI1aCkwy418JA8OMYS+YpMRW4ZzIFoYuWdds4i3RQhJHtRmRKO4499lir3/nwww+1UOYXOYF4aQqX530IJ7+3mdjZsv2Rm9ujWMHU2YkYQjzJrFmzdB4k/6e0Ze+999Yu1nS3xd/O71RYvfo/gc4RB72NxvPmqQoJ5xCmY82GGwaKg3xdZxl/IhQWRNWwz7K/klHtl1fo5zSUUWQh167ZbLRzC8Wt3YgDUBA8hIlcfnAwZvFG9l0m8OGaxQvjs+lcZvfff78upkCcYtFIrhLjTJlCTh/Xec0115Q07gKLmo8//lidfvrp6ssvvyzze4wMPfHEEzqfz5SXX34548UQYi3gvNh88811aUfcPPbYY6E/52+g3CPfyLS5WBAydRCTbxcHuKoYZSx0aJXFvU27uBeyVseMGaNjF15//XXfEyz9+vXTrmfeo4gliEP8g/POO0+f5IgbJ+s1W/DedPLJJ1v/Hg5vP8jyY9/zez78Tmg5J6E49uIKZPPLR/NmDfI1KWc5i0T2OZz5iHrp4D2DaBI3iIfkFiMCnnLKKb6jz2WoWlWt3nxzvfnCInbBghJB0BkvdkaNK9NkbJAjlwmV//hDbzUCoj3W1qnjnz+4ftR4HZ+RZBFeVKPIJsgosiAIhY4IgILgwVbI48OAbVFGELjuTBcCnNXv1q2b/oDPKC0fzmmDjAKjxLTT4vJzZyB5F0O0Io4aNUoviFg0NW7cWB166KHqwAMP1PdjypQpxrcZx4LHWYjwlUUswe+5AAcorp5//vlH5YvTCJcQCz9ByAUcF4gNiKPtnBMjxQKtxIgxOE783ntw9pE1yrGMExyISTjDGWvleAuPP/54Rq2/bnAvU0ZCW27ccMIom/AYmYwH+r3vkuXrx9ChQ7XDPuy9beeddzaK4eA9krFhNu9nBqeExNnczsFM4bY4Ufj0009ndD0fffSRvl/O546MqFxZ5/Sx+XZNr1unKi9aVNZB6Pp3xRUrVJJUWrpUb9W//97352tr1iwtEHpajdc2aCACYRES9yiy+3uCIAjZQARAQfDQokULPQLMWKnpQjfT8V93WLzNuBEjcWQI4sD7/PPPddMkTg5b5xcf7LntdOHlfJhhsYPjkIWpsyAFbtPW0cftZeJi2WWXXUr+TZA+xSg2ImSc5JPbDqcRj4Ug5IqLL75YHnwfON4hKhFd4AclGYh/HN8dKIh65513tAOQmIW4Xtvt27fX7xfESJDNWshQYoJ4GgXeR2lU9ssBRKjl/fGGG27QbnDKrNw/6969u3bMZ3oS0K+EBHhP9QqCzr9t3nNMP8+kg5OAu+++u25pTZT1JR9sy3fcsezPUylV6c8/S4uCfCWXcH0eYaWET8hx/ZV+/FFVXz+J4GVd9er/Lwo6jcYuJ+Gahg313ykUL1FakdMJhTKKLAhCpogAKAgeELbI2DNdwHLZuLBt88VhgeBFuyQ5TiweGfN59913dZtf0GiTF34HAZGWxkweN0ag3AtXkzOjUQVARpRPOumkkv+zAGNMiSwrCkayDQto2iQJlDf5sJc0SbQiC0Ix06BBA+sIiKjlQn4CICVQQe8nNMU7Lb0LFiywuj3ey/j9b775Ri9InVIOxrQ5bn/66acqCXr37q369++vxSpy5HCZM7qcRAvw1KlTI5+EIZcRl2nQ+HCdOnW04x4RkCgMREDcmrxfesd844b3SYRJP3HSaU/1CoR+7z+cFIrzvSVxATAdFSqotRtuqLcVbdv6XqTi0qVl8wfdTcZ//ZXoXcShWO3nn/XmR4oiCkcY9BkzXk3mYh41SgvJIqPIgiBkC3lnEQQfGInCTcBCLQzy8g4++ODYHkNGg2y544479OLAGeHabLPN9P1isWgDgd+ZghuCRZ8JLD4JX48KrgvvQpKWTcYOWWj65WwlDW3QODIJYs2k4TiORaP0OwmCGQ8++KAuPmDkNpOTIKb4je+S4WpyzGZ8eNNNN7W6PUaIyW4Lwml+jRu3UEk8BSdmENHeeOMN7SKPk0yPd19//XXa/EDceQcddJDKFxw3kPd9ECHUmzPIZZyCjkyZNm2aKgTW1amjVrIFFLlU/OefktZivzHjygmfDKiwZo2qOmuW3vxIVaqkHZA6cxDH4PqvjqtwTZMmKhXhM6NQvkeR040hp5sEEgSh8JFXuSAECHEIgAiB5OZ4Fxf8nHFbMofibGLaY489IuVd3XLLLfq+Nm3atOR7NALZnPXn8plCNhCNRIxjhcEihHE23BRRuPLKK0s5aHC2PPTQQ3pUi7+ZxwGXS7YXKjgwGSUjgy+X8LfjiBEEIT0PP/ywdoHhTttuu+308SRJ3NEJDrS6m4pYNk43FnMdO3YMvQwFStkCJ+IBBxygR0lpCY4L3OeZnPjIpwiHTOH9lfcg9/sQwuXtt9+uv+cUlCBosvFvm5OPTptxobdQrqtZU61q0UJvflRYseL/R4p92owpMamQYKszLcn69ufOVRtMnFjm56kKFf6PvfOAv2r+//hpSAMVhYgiGSkjIqvIppC9ioxsIVsklFFkj7LJirJHdpTsPbIVUqlIQ/P8H8/Pz+l/v/d77r2fz73n3Pl6Ph5X6Xvuved79uf1eb1fb48y4tAMwv/+34/ZoSrKtxQ5nUCY+PdSvw4IUYlIABQiBTwY4yLDsUCH24kTJ5obHs4FHGZNyW+JGES8bARAZgEJIb/00kurOOweeOABq/fjIMQlkiuURdEkhMFGqjI1tiFZSjQtYeDh0iSALsW4R2hWEpRA0XkY8S+sOzCuh6BMKh+Qo3jFFVcYMaGQ7LPPPhIARdYwGYAoRDlsto2FSgncd7zosMt1Ke4O2sluPK7fjzzyiPX7f//9d+tlcTY2a9YsYxMoJlXi6kSbDMcV96ooXdo437nncf/JhqCDb7mCO52GL+RJMkmWHA/CQD4QBRPFQZ4Nkl2DxG1UwqDfr1vXW7jOOuYVRo2FC0234iolxokuwqlTjYgXF4iPy9FJmWetTz4JXWbxyiuHi4P/lR0vjaiBnSjPUmSbZ+dUXZHD/i0KB7IQInckAAqRgZYtW3oDBgzIy3aim+5ee+3lPf/8887vTXbTERZvKwByk6ezZBTB/Ztuuqn30UcfGScgwmkQms7Nv3v37qY8NhAbXZ1yONsC8Q/Iyxo2bFjK5enKS37ThRdeaH5HMgLff/99Ly6mTp1qxMdCukloSMM2pjQ8XwN6UV4gyiMUVOLAZ+zYseaaTy5qHOcPWXhdu3attr3pJO4Ck1A0E0kHkQg4kjOxxhprmOgCmyZUiMNRdHZ+7LHHTKdychejgus8+be67lUHwY5tjsA9c+bMaj9nsM9+Td63vC/RMcif+RDJSwHKbxe1aGFeoSxe7NWeOvV/Lj5KjZOchIiHNWPOC649c6Z51Uvhal6y0kpVRMFlpcaBQNiwoToZi7SoFFmI0qOGr6Ao8R8INjz88YCPgCAKA/lQhx56qPfcc885vY/sKkpgEznhhBPSCmSJsN8pz8pUCowjKMgSCitlSwSnwQ8//GAGFziKcAgmwuAvbDCSjr333ttkduEw3HLLLa3eQ2OQ0aNHO22PXNw9TzzxhFUuS1yQ58igvhiakbiAWDt79uxCr4YQ3iabbBJLR3EcVVwjcC7TUT24Tro2kyCzjmsa2a9hgteGG25ofs6f/PzFF180EzP8nS73XBMTO85y38G5na6BEt3maTjF/SmX7u0BdDaOOlOPSa9evXo5i4DcS+KcHCoW6AbMxNkrr7yS1ftx83zxxRfmuEpuQsKLZlg8H1SCQzBnli71av/5Z/VOxglOQhqJFJIlDRpUcw0m/j9NWGjIUor8/fffy0rZaSonio8wJ2Gio7DSSpEDd2al/L4iPu1GDkAhigzKa5555hmTMXjDDTdYvy8sGL5Dhw7WghcXkIceesiIZFGBw4+yo1Rk05kQYZSsRF62kOf466+/5qXM6+GHH/YKDQ1ISk38Q1AOa44gRCGg224cIJLg3MNtR0OP008/3VwnuZ7ZduNl4gU3NCLl8ccf7915553GuYj4Qrkv2Xo4gbmeM8HC9Q9HYyIMeHlYvOiii8y5x30HUYgIA+4Zid2Q+Rkd54nDaNKkiffoo4+avMRcO8tG2Zk2gPWkQ+11111nfn9bPvjgA5MZy3YtZxB/ccJ/88035l6KCMJEXLdu3UwuLy7BdNxyyy1G/AtrQhIMTjmeuP+EdSiW5yCBmjVNkw9e88Oa4vi+V2vmzOodjBP+v9bcuV6c8Pm1vvvOq/tfrEoyS+vWDRUGg78vbtLE/J5CZINLKTLXHZsy5KBkWYhKRg5AsQw5AIsLBm40s7AdJJF9RAZSIsHg0KWsjLLdqByAmeBmnG25FoNmlwEkwhw5SGRFFdKdlw+OOuooq3I+IURqEL5sRWnEM0S2fv36GSe1LYhpBx98sDdixAhThmsDWYXJsRQIK4heNIRKFO8y0alTJ++1116rMiDiukqHdrJMEQpZBnduIpMmTTKNS7hfcK9CcOSe4HJNxpG4+eabe3HAPcp1kBeHI7GU4F7McXXjjTcaYTDM/XnAAQdk7U4JGhEkdyjmT5VtZ4HvezVnz64mDAalxnQ4rp20H/PN0uWWM92Kk8uMzf83a+YtXm01HgQLsm5yAFYuQVdkm+xC/iwWt50cgCIZOQCFKDNWXnll79hjjzUz7plo27Zt6MDF1QUWtzDGoIzutASQ8/sxYMz2wd/VPULGFplYOFcyiZylTrkLnELkA/JYMzmigqY7Tz31lIkmcC2NRTA88MADvUMOOcRcl1599dW0y3PNTBbNGBS4OsYDcA5us8023rhx44yIF0yu7L777mmvL/yuTC4FGa+u1xzuWTTUigsGbJRbuzSAKnT39kLDQBeX53nnnWfKx3/88UczAKaSYOedd845wJ99QrdhXojriXDeBC7BRHGw1JzseaVGDZPRt4BXmzahi9ScOzdtiXFth8mCbCDjsM6kSeYVhl+rlrdotdWqlxgHgiGTzA4dqoWIuisy2HZE5k81OhGlgEqAhShiaORA3g5ujFRQfkNoPaW7NBEh24kHbODfXaC7JLMJW221lckUjGrWiwd53CK33nqr99NPPy3793zOqgVuyvfee88rZ9jnwaBcCJE9XCsQPtKJcmSb0rQp20w8mga98cYbxp0cZPal6/LLJAoZggh3CDNAKWc24l8A2XcIiDfffHPGZRFmKBel2UYuUH4c5/Wfz+YelklQTbyPZitIsu/ffffdZY5Jmly5ZjoWE2wLWzdqVAQD6cRcyuB4D4TBZHFQ5cSZWdqggbegdWvzCqPG/PnLmpQYcZBXwv/Xnj7ddBuOC7ok18G1mOKa59eoYUqkQ8XB//5Ot2Yh8tHoRKXIolyQAChEEcMggvB2cpluv/32KqVdDHB4AKbT7bPPPmv+DUcGGVAsiyslyG2yfVBmIMoLyO675pprjAsmF1g/GneEiZj5eoBfbbXVzAD7wQcfLPvuppTrkfEkRCWCgJDcUTe4Vrry888/mxfXQB78E8UkSiLJTkP4yZWPP/7YXJ+Y7Ekn/gUwkUFeW9DIgZLNXOGeQRddmgelgxLRXMW/U0891cQUxM1JJ51kLQDiDE8uc84ExwQTZkxsJZZ9B+598hXVXCA3cNPgzAxzZybmDCaKg1E0qKkU/Hr1vIXrrmteYdRYuNB0K07OHgxKjelyXCPGbtCIj8vRSXnqVC6UocssXmWV6sJggkCICCpEvggmLWzg2SRT+XHiz4SICmUAimUoA7A44SH3ySefNN0N6eDHwy2DjXQlsNxUaARBXs9BBx3kPf7441l9N59z//33V3EDuGYAMrByCWOPg+7du3ujRo0yzoxcHIAMjnEEsS+KFYSJuBoYCGELD6yFGojTyIHuuDihOR9ofMBECs2V7rjjjqw+E1HHtWO5LTi3WUcmSRABbZk4caJpyoEQGQVMNCFapYImI3xfssBqC/vi7LPP9nr37p0X9zeODXJxM3W85T7GfYF8WFvYFkxsvf7662nLnPk526wSKJZ8KvZ7cvORoJxYrsGIWbTIW27atOqNSoI/p0zxahRYkF3csKG3ODF7kD+bNfNmNWzo/bvaat7SlVbyGjZqVNB1FMIGxl1BlAKRHenEQ5UiVwbXqguwEOUHzpD999/fuFBc4CH3mGOOMbmAuAJ5P10OXQk+h1Iq13JiIEOoGLri/vLLL+Z3IXQ+Wzp37uzdfffd3o477ugVMxL/RDFQSBcO3VzpchqIWZz3XIeYFMmWuMQ/wLGbjWt3woQJXseOHSNbj88//zztzxFRXcS/ddZZxxs4cKARXvj7dtttl/OghH2Lqw9nOc5unO6Is2EwEGLih3xFmmSFwX2NEmoX8Q/o3pxO/APE3MMPPzxnx6Rwg/1O9URyGTbPAMluweDvTGqKLFhuuf8JamuuGf7zJUu82n/+WTV7MCmHsKZDTmc20AiFV92vv67y78EZv7h+fW9x8+YpS4yXcH0pkiYQorJhcoNrFc9XmSZZuNe6ZBeKykIlwEIUKTTL2Gmnnap147Nl9uzZpuSVMigGKoMGDTKlSq6fx+CN8jA6ALpy7733FsWMOwJALg/5LVq0MJlVhMrT6VMIUdxwzaKZAd11Kccsxy6jXNNWXHHFvH1fuizaMHCLk1cYlTjZp0+faqIbpaE9e/b0hgwZErot+DcEPt5H4xImwhg8rbvuumZyiw7Mrnl9/F62XdYRdpnIi6vbsXBvDMMr+VjhmEjuTMxLTUhypFYt0+mX1/z27av/3Pe9WjNmVBUHKTlOcBLWytJxbEvtefO82t9+69X99tvQny+tWzdcHPzvz8U4fHOc2BAiahjv8LK5hgWlyLaCYbF0RRbZIwFQiCKFUPZsxb+Ap59+2giAdNyj22S25W+U8FLKS6dLBDCykiitylQCTMlyscBNkBK0bNYJB+G+++5rmrLkAtsNYVYIES+//vqrmQBB/CtXdw8TE1yDETP++eefnD+vTYpOogGuzYWicoHSpITohbDfkSiMYcOGeR9++KER+cJEQAYrZCzyigLcpC7CEBNh+RQAcUmSCzxr1izjjuTe1TpFEwjxP4IBLg1QwvK8wsTBYpjcLHlq1PCWNGliXv9uskn1n/u+V/Pvv/+XOZjsHvzv77Vifqaq+e+/3vI//mheYSxdbjlvcbNmVUTBZeXGCISrrsoBFus6ChFFfEMwEZKJRLEwk2ioUuTiRFckIYoQOkNGUTbEACB4iGUQkm0ZG6LfJkkPZzguKA0ePny46VwZRrHYyhs3bmwe7OmQTGOTbG+Q559/vsnesA34TSZfQkTTpk296dOn5+W7hChWbrnllrIV/5o3b24ELa5L2WbyJV+rccSlI9V1PhXJYko2MBghBiOTwIkAeNZZZ5n7UdwQbeFCYuf7uJ8bTjzxRO+1116r8u/nnHOOmbDDFYtoLHJvQsJ5hwgcJg6Wo9u4YNSo4S1t1MhbwCvFBEXNOXOqlxYnOAlrxxjfYL5/0SKvzqRJ5hWGX6uWt2j11avkDyaWGPMzr06dWNdRiDi6ItuMhZiAy9TkJPFPuQvzgwRAIYqQTKHlLpB/RBORbEWrdLz99tsm1+mtt94KdY+0b98+5wYgDCJxL+DCCwRNV7bYYgvjwPjss89yWhdmx1zLxRKZM2eOlw8Ip0fwFaKSySb3tJQc4jwwI/5FITjglERUTAeZsnQftiWKfEIy/HBz2kBzJqIqomqKkgomgVwgrD1uyLzcYYcdvD///DNlfuM222zjjRs3zuQxJoJwRXYsghZZiHFvv3IgCOLnRYVF8nNCctZg0IRERM/SFVbwFqy/vnmF7qt58/4nBiY1J6n5yy/e8n/84dVJcc5ERY0lS0zHZF7e++9X+7lfo4ZxCVYTB4M/mzXz/JAu2EKUAsFkie31zyW3UO7C7JEAKEQRQsB5FLz77rvmFSe4CnEXHHXUUV79+vXNIARRkAdk/o0gfhtLOUIfpVyUcVH6zCDkwAMPNC4XPouw9mwEQG4QUQqqdH8sds444wwz+Kb8W2VKohLZYIMNTJfcYoEJEpxYXI9xYuUCuXqc48CEBNfdXFyA3bp182688caMyzGhs/HGG3tffvml1eeSwZgrLk2kuM+MHj3aO+6447w42WqrrZyWp/t8nHCNp9lIKvEvYMqUKSYvkQm74P/pIEhzq+Deyv2Sxiocq9tuu22s612uBANVzsuwcuIwcVD36fjw69f3FrZqZV6J8JzJdsfBtwoi4X/uQYS62ol/nzrVqxGjk7yG73vLTZ1qXqlYvMoq1ZqTJP59aQRuayGKyV1oM27kfpWpDFmNTsKRAChEkYHTbWqaB4FihBLhK664Ytn/U2Z05JFHervuuqspy7ryyiszfgYZhQxieIWRrfOuXEsA05U7b7rppiZvkL/H2b201OHBoEOHDiZHDQG6U6dO3owZM7wLL7yw0KsmcmTNNdcsKgGQLrRrr7229/vvv+f8WYnddJkcoUSWvMNsnNGnnnqq16NHD+u4huuuu87bc889M15XcQvSOT1XEKniXD4bunfv7q266qretGnTMi6LQ6xXr16xrg9OfBqNuCzLenF/Tt5e7FcqBsj7pWnKCSecENNaVx6pyokBd0xyZ2L+LGQ39UrBr1PHW9S0qbcoVXn8okXectOmVXUQJpYbT5ni1Yh5P9WeMcO86qXo1L64YcPqzsEEoXDpSivFun5CFIJgUsWGoNEJouBKK61U8U53CYBCFAl0WKRTbxTZf8UgYg4cONC8GPRSevTOO++kXJ4Ou5ncIjvuuKMpcxLpwcmBQMCNUeJfephlnDBhgikPxyVKYD4gCJL3aDPAF8XJDz/84BUTNGbgWrjXXnsZV3Qu0Nn4lFNOWfb/p512mrUAyD2GLNRGjRp5zZo1c/5uhD3iBcgLTCVOIPyNHDkyNMtn0qRJ5rxCcF9//fUzCo+uOYJR5A5mAvGMUuNMmYnAdYRM1jh59NFHnZa///77vSeeeCKtWIozCgc53ZIRCkW8UCYeVioe5Gwli4MIhnIN5onllvufqLbmmp7XoUP1ny9Z4tWePr1ac5LEV00LN1Mu1P77b/Oq99VXoT9fssIK1YXBBLFwSePGJm9RiEpodLL88st7lY4EQCGKgPvuu88MJqJwq+H6yjYrLw4Y8PFaY401zEUXcZDfk0EUA1EGsjivMnHyySfnXDpXKYwfP77Qq1BS4IihrPKll14yZXScQzSLQcR47rnnCr16Igu4zlDCWCznQpDTt9lmm+W8Xr+RJZVUknrppZeaVzqC0k5mwBNBkKMMlNJQuuqSA0ep6E477RQq4uEYxDlLkxVy94Ju9Uw8IBqRO5v4HTx4cy5df/31VSaC+B6aVpx++unVctQCiIBgcswWugXnA1x9dEVm8iqVEENOY6Z9EgWuExVMeuDazwS/F+59CYCFA4Gc6ofkCgj2TVgpMX9WWtVDwalVy1u8+urmNb99++o/932v1owZocLgsk7GETRySruKc+Z4tSZO9OqmcMUvrVcvPH/wv79Tguz95zoXQpQ+NXxNIYn/IAuGTnsrrriieagV+QuqJ68tmyB3RDTKkRDWGEDxoP7yyy97t956q1fMsL4M/AYPHuwUkE65GoNOIeIAdxZOwDga5oj8w4QBEwzF0JUTkeuGG24wf//iiy9MB/VAOHOFbrw4ChN5//33TfOfsO7fiHgHHHCAcQ4mNrAIBJ4BAwaEHvM4Y3GKJTeNSITPILOWssZkYTH4eabJG0RR7ltNmjSp9jNcajgnbUohcZrnW/D96quvTKns448/biYPGjZsaPYDx51rVmA2kP1IbAYlu7awnTPlBSZ3F15vvfWsHRYcB+rkWDiSuxMHf1c5sReaAcixynlbMBAI//47vJPxf3+vNXt24dYPgRAXZEj24DKBcNVVjRAq4oXjFYGfOAFdY7OnYcOGxpRSydqNBECR80EkcgPn0SOPPOL8PhwYBLcnd1pksMWApBTAAcjAyTZ/ioE87hOXYHgRLTx4yGFQ3tCAh8FRqQ8YKQPGcXb00UcX/HfhgRPnXlCi+sknnxin3Lfffuv8WUyeJF7jP/zwQ1N2m655FMIfDleiFAL69+/vXXbZZWm/i87AOMbIVMwGJnnOPffcjMuxXq+99lrooObqq682pbTpwCE1duxYb8stt/QqAVz1uJQp5+W5zQWOBZdJjmeffdaImpmQAFjccN9OdgsGr0r0ghSNAGhBzTlzUmcQ/v67V7vAWc9+7dreotVXT1lizM8opRY5bmcJgJHQUAKgSoCFKCSzZ882DguXB3fcGrvsskvKgQ65Si4Qhjpnzpxqog55aDwY0RQhLggbp/Ts+OOPN+H4d955pym55MEMlwKuFQbvlGQi/lFSlUr8cx3UCHcox2OQLsqbOM/5fMFEFs41Mszatm1ryk+ZaKHENSg/5Wcu5aW5wDWNaz2ltYHrDRcfbj4cVi4wyZM4IOAamalzPNdGurIjiuLQIk81k/gHv/76q3fBBRcYockVRAZEKhveeOMN496jjDgZBER+TxpFhbk5acjBRFKliH8IvrvvvntW5ynnBE3GXO6VQcMZUdqwH1OVEyc2IUn8U5N9xcHSFVbwFqy/vnmFUYMuxlOmVC8z/u23/3UydnD8ZgNNUOr8+qt5heHXrGlcgqHi4H8vX7lsQuQNOQDFMuQAzB0epMaNG2cGMjw8UbpEiS4iW6ryoY033tjpO3CRpLMuUwKGa8P2AZ9OmawfIfLB4BB34UEHHWTcM3vssYd5OIyLTTbZxAiAdAsO+x5Km8lIJJ+KQXyxw7Yna4v1/TxFx7ZSBIfOHXfc4W2wwQaFXhUhrKB8lIYuAfPnzzfiB7EDNMBA3EIQydcg9+KLL64iuhH/wLXWBWIQbrrppmX/j4CZ6OrLxOjRo43zuk+fPsZBbgOTK2wr12YWiHLcR2xByLznnntS/px1GD58uCnTZ9KKfXvooYeaV7Zd4ksNGju1adPGHMeucG+nG/Ull1yStilXIkwCkqeJYJ4JOQDLD5zTgRiY6BqM85kwX5SSAzBXaixY4NWeMsWrE9aoBIFw2jSvRoGzI8kZDETBhZQV82eiQJiHBk/FjhyA0dBQDkA5AIWICjKMKJ1OFn2OO+4449jDfZL8kBGWmZSJTJl5DNJ69+7t3XzzzRk/i8FZ4Bg8++yzQx1fOPJwrfzxxx9eHHz22Wemi2UqGOixnqUwE12/fn3jatxiiy2M2IBLAyGwHMChQ1MAIUoFGh0kCoCIRC1btlz2/0zQXHjhhd4VV1yRl/W5/PLLjegWZMS99957Tu9fbbXVqk2CPPPMM06fwfIIgC+++KL1exjwIzQeeOCBTt/l2rWdyahMkys44HkVGhyXXOPpppzNfTxbcMlnI/5R1s8kH88iCKm2AiDHqo34J8oTjm1ePNskwvNYWAOSSi0nLnZw1y1q2dK8Qlm0yFuOybHkMmNchfx9yhTj8ouT2jNmmFe9zz4L/fniRo1C8weDvy9NYbQQQlRHXYCFiABKu8hzCitPYgaVwRbCHE42Mv8CcJ+4BHIzeA0LSg9zczJrn25wSAj9XXfdlfGzaCzy888/e6NGjTLiFkIgJWu4a/JFKYh/5Bi++uqrRvwLxIYxY8aYweqwYcOMc6PUoUxbiFLBJhsNRx7XbZph5Mt18tBDD5kXTStcwLWYnJdKJ1oXguVdc+OIq3DFtXS02EPNcT2x32iyFYi3XOe599PkhaYp+RAAXeD+TZMQ1jFwSeKYHDJkiPfll19mdH7iWhUi7Nym8Q+vsHLiMHGwGJoxiRTQ5KN5c/MKZckSr/b06dXFwQQnYc2YI3hq//WXedVLcd1asuKK4eLgf38uadSIm0ys6yhEqSABUIgcQQijMUWmhxseingQh0AExM137LHHmpBz2/B3m0ESD+4IdghPOAETO0YiOp500knGdcfDGw9suLvoIolYSS7WvvvuW6Wkiq69rDMvBEDExa5duzp1Eix3OAaSG7KwfREWKLmibI39cN555xVsHYWoJGycWVxPBw0aZPLx6FTLeYq7C+cgeYEff/xxbOtn68JKdCyGObtcINsVmJBymcRxLf8Ncg5dyIeAli0IoEQ7JGdG4gK89957zeQe99rEfMao4RnDNS+S5ik4+ZPvS5QC77bbbildmtzzydvNRydjUT5wPeX5kxfxLWHlxMklxeVQTlz21KrlLV59dfOa/98kdxWWLvVqzZhRJX+Q7MFER2HN+fPjXcV//vFqTZzo1U3hJF9ar1411+DChL8v4V6qvFNRIUgAFCKCGXkGAbZQnrvXXnstKwemscUDDzyQ0V3VqlUr74QTTnAa/DIYQeyjtIrAcL5zo402WuYieeqpp4wglVx6RdMNMqIIXQ/r0EtJEK5HfpdMZVulDL+77aw12VypQEzt1q1brGKCEKJ6fIAtZFsOHTq0yr+9++67xqVXLCVtiJTJUM5r22gDyKQFYhWIX7CB+8HOO+/suUIEAqIlHWtt4H5SjLD/cdClaxjDMpR149IMtnEc4oprF/ZULkzu4Uz6UQVAR+ngPk4eMMcZE4StW7eObN2FyFROHOYaLJZrr8hAzZrekqZNzevfTTet/nPf92r9/Xd4F+P/3IS1snCZu4AAufwPP5hXGEvr1PEWNWtWvcz4P9GQJiYIoUKUA2oCIpahJiDZQRMPmnm4QA5UYu4d799zzz1TDpTI6WPGHndeVPDgTz5hOnD8kRuUOIjAAcgDG/+GK4T1wgFBBmI2ZWLFDJlbOCEyDWARS8MalARNYZ599llv1qxZ3uuvv+7s4BBCZH9PI5OVcw8RC2czzuVUzkDO12nTppnrGFELvIcS4f79+6f9Hjr5uubdubLeeusZB3HyurPONBKhM2wmmERC6GFig+s4bvCgK3I6zjnnHCeRMRG6B4cJl8kgsJGTW4y8/fbb3g477GD9PMAxx36hzBqXf7LgkQvt27e3nkjiWGFiMZN7k3XlmEdwwSEaNulng5qAiKgJhMFkcTCKcuJKagJSCtTkehmWQfjf/9eeNaug6+fXru0tWn311GXGq61mSqljXQffXzb+KvbIjGKmoZqASAAU/48EwOxgoIi7zjWXh3y4RHgAZ7BEl0MGelzc27VrZ1x/RxxxRKSDiG+//dZ0ErR5iKKsCWdDmACYGLDPZ7Vo0cJ0KbYFZ5yLezLf4JZE4MTRETboYqDE4HjgwIHVnBYs36tXL+/TTz/N4xoLIdLBNQrHdaKgQ2kaJZy33HJLlfN8u+22M5MzCIg2IPbwWVG7VhBwcJ9xPQqDLDcyXdPlAXL/eO2117ytt9562b8huHFvSecoI9aAbNNc7j+Ih+miD+g0j6M8yntc1PEOTITZgruSCbFgf9DpHic+Qmiu3YrpxE4UiA35FlUlAMYLkStMJk6fPt04NXHYJjY1qiR43kx2C/KnSzmxBMDSosa8edWbk/wnDlJuXLvAkUR+zZrGJZgqgxB3Ic1YcvoOCYCR0FACoARA8f9IAMx+QGlb4hSAYyNdB8hgABnXDM8ZZ5zh3XDDDVbL8qDJADgQuFIJgEA3TdvQcN5LV8cPPvjAixpyi3hAtHHF2Dhf2B8Mnu+5555lwembbrqpd9FFF4WWSfG9O+64o1MJohAiP+DqJesP0WzevHlG4E+ekMkFsq+iPPdZ10wluFyXEJjCrnm40rh2cd9Jhi7vOJh/SCqLQsxE+OI+kZzllQ3c72666SZv5MiRZqAObH8mlxDMsnWd5QMm4r744oucP4dMRCaUku+bLnC84gLMFL2B0DhhwgQjPuYLCYDxQAOxvn37mkzG4NwJng9xNFN9EGV1SCmTWE6cLA4mT8xIACwvaixYUE0YTCw1rj11KqJHQddxcZMm/587GFJq7GeYBJMAGA0NJQAqA1CIXMHNZ9NNNyyIPRVxW7t5kLQFZyLh+HQOpKQonbvFJdQeITFsQBoFDDYpb0OQJMcwG9gHZ599tvk7rh6cQZTz0hEZPvnkE+/pp582TVwuvPBCUy4YPIDiqolCACA/i0EynSeFKBcQpDJ1II0TBoO4cxFRjj/++EjFP4ha+F9xxRWttimZbog+NIBCNGjUqJHJHu3cuXPKe8ree+9t4icQGSl1pSSYfLiDDz7YRCBEOSmD8xIhkoE3br9c3XCl1oWeewaCDfdJBNZsYLu9+OKLxv2Fkz+MBg0aGEdlPsU/EQ9Ul3Tq1Ck0ZoZnsWeeecac82PHjjVRBJVOqu7EgDswEAQTxcGozm9RWHDXLWzZ0rxCWbjQW27q1KrZgwlNS5b74w+vxuLFsa4jLkXjVExRGbS4ceMqjsFqnYwjmIwTApQBKJYhB2B2fPTRR94WYV2xMpTxFCrwnIcdV7dFYjMMcqSOPPJI8yKXKhEGjGRo2YLzxNaJmA0MgNOVxaUDhx8DNh4QCdrHuZEKSvPI9+P3R0xgcBYFdIfGhcjxpQYiolzcd08++aRphFTogHfiFhAAi52ffvqpYkv9ioEDDjjAiKpR8eijjxqBNRfIF7z77rvN5FyQP0lH6GOOOca4KqlMyDdyAEbPgQceaMRcmwkAmvqkavoS936nYdJjjz1mnv+YsKDDNJMPNp3YC0VQzQJM4CaLgwiGhb5HiTyyZIlXe9q0cHHwv1fNhQsLukuWrLiit3CNNbzFKcqMlzRqhHuhoOtYCjSUA1AOQCFyhXIcOsCSlWcrSh1++OEFnyG1CX8PSMwKpFRswIABJhOJbKjEgYZrMDPNTeIkW/EPKPli9h0XYTrxD8hspIyNnK4oB4pBFiSdonv27BnZ5wpRCHB8UQL6/fffF8XAisy/Uri/SPwrLDTLivK6zgRgrgIgIgsTaLxwnOJSJ66jEAKQiAeqDWyPOxzVPI9RkZJPuJZT8ZAcaYMwjZOYSZaoJkTjgnOGe1OyI5l7VKruxHINliG1anmLmzUzr/lhpg7MEzNmLBMDyR1MFgvpNBzrKv7zj1eP+IcUERBL69WrIgguKzf+77WkSRMJhMJQvFMzQpQQZLDwAM5DTyYnHWVQZCqxPIHOdND95ZdfvDp16njbbLONCfiOu5SDLCLKRnIBIZDwdjKngvB23IEuDVHy0SADAS0bsQEx89ZbbzWDNRveeustMwvu2hAmHUHZHm5Lyo9t10WIwG2HA2Pu3LkF3SC4Kyi5xZmEmBW38G+Li1u5UBAxkAzXMxzBkydPNpM5W265pXF/iXhAwGAbR5VXG7WbO4qMRlF84KhzeXYhKiSfAuCPP/5oGiWluo5yfSJiAMc3pe+lBs9f3EN5Jccw4A5MFASDv/NcL8qUmjW9JU2bmte/m25a/ee+79X666+q7sGkv9eKORccAXL5H34wrzCWLr981dLipI7Gi+kYX8R5vCI6JAAKkQU0xWAwQAdbGllsvvnm3m233WaEGmZDEfSSIZMOgZDSCLJ79tlnn2pB3syiUhKLCEhgelzlE4S75yoAAqVHPHTikAgGq+mamyRCPtH48eO9uMnFacTv5tKlmHwrrOVR0bZt22UPojhMf//9dyMaF4N7KgrIwaK8GleYiB4GJImh8fmELuNcF7gmIk4FziRE8uSGE4WiUNvGFiZUaFASwHnPNYa4jsRMMAaodHy99NJLzX1GZH9PDzIQiYAIJmA4dp966inTiCUot80F7incK5lk2mCDDUzzljXWWEO7TVRhypQpTluE54N8wnNqpkkUjnGOb8TAYu3yne2zCy/yNhPBGZiqO3G5PLeJFNSo4S1p3Ni8/v3v2T2ZmrNnh5cY//f/tXOoWrKh5oIF3vI//2xeYfi1a/9PIEwSBpf9ueqqHPyxrqPIDxIAhXCAbr8MsmiikVhCy2CXMk0e6inboHz0kUce8aZOnWpm53fZZRfjlsMB+Ouvv5oOseke7hAKeWgg4yeuB7fzzz/f5AjlCq60QABE/KRkloe9TFxwwQVmm+UD9k9YiLbNoNAFBodRNQDgWAnKfnmIRkgh8LsYSMyEzAUeimk8IIoL9i/XLZo1uIIjjY7ZHTt2DG08ke9BajoK7YzMBA2Agm3I4PHkk08OdZlzr7j//vu9559/3jTzQLwSdnC/JtKC+3XiPZ3JFzqvIl6wDxDomDTD7T9s2LAqxzENTmwnvoDvSby3X3zxxebZ4cYbbzRirhCQLC5FvXwu8Kzz8ssvWy1LQyLOL/Ipyx2XcuLg7yonrhyWrrSSt4BXiiqvGnPn/n+JMYJgYqkx/08DkRihCUqdyZPNKwy/Zk1v8aqrVsseNOXG/2UT+nXqxLqOIhokAAphCaIeDoCwGU/EJcLkGQQgiDF4QAgL45JLLrGa2cXpwaCAEos4HlIGDhzonX766Tl/Fo0yeLhhkMQD6HPPPWcEz3Qzw2wDugojQuYDHGYnnHCCs9jkOmNLQ5ioBMBgJhlw/BAcXyww8x2FAJiNy0HEz3XXXWdyTRGb7rzzThMuz/7OJPwSY/D444+bKINUFFPnV5cc1EKAszyAOIJMERN//vmnKbXDWV5Obpu4+Pzzz809ffr06aH3e8rW6ayM+5r7G+7u/v37exdddJFx8c+bN88Ig7wQvHG3ZgPnFKIiE2d0li/mxgkifzBRzHOaLTvttJOXL1wnIykDrgQBMJtyYsqGw1yDKieuPPwGDbyFrVubV+j05L//erV++81bfsoUr86UKdXchLWnTqW7a2zrV2PpUtMtmZf34Yehyyxq2rS6ezDh5evZpChQF2CxDHUBTj9QpNMrboFMMIt/2mmnpZwJXXPNNa0HnjQLGTFiRCxHKQITIlyu5ZeIAji5Et0+DGQGDRpk8g4TXTY4WnBVUPYJBKHHXf65ww47eGPHjjVi3sorr+zUGCRb52BUXHbZZUYkJTetmJxTorzhmpPYqIhzB0EEpxICRZgw3rlzZ+/KK69MK/4FrlqugS6l9ZUIIvuqlNv81+GTiRbbzMK77rqrogfbNnD8UX5r41ZHfD3ppJMyCiLEekTRmAanZymiLsDRP6Px3InYnAkmX3/77bdII0gyVXBcddVV1svz7EdOclTH2euvv+699NJLZsJ1tdVWM8+SrtnZQRdgJsRXX311r9gIKycOXionrkzY78ExG1Zh4S1c6C03dWrqMuM//vBqRDR5ny2LGzeuLgwmOAqX5iHTtqG6AMsBKIQNiFQ24h8MGTLEPMAjjCXzzjvvOLlO6OoWF9xAyLhjEETeYDblfkCgf/KNiAwlMhGvueYa47LAKcEDDGWF5IEFjsGzzz47dgEQwRH4PpyJOJRcfjfKuKNs7OECzisedCX+iXxCR0muDQw8uY7hWKBMMp14jrOPRgk2DUEOO+yw2OINygUmVRjQQ/CnLbjHJQCmh5JEG/EvuKfjIE/XYbdbt25mEjW43+QiACI2hg7uREXB8Yb4THxMJjcYx16+xD9gMtUFrvtRgIjYu3fvalmcOHPJ12byg1zuci8n5v4Q5hpUOXGFU6eOt2ittcwrlMWLvdrTplUVBpM7GS9aFOsq1p41y7zqffFF6M+XrLRSeP7gf2XGS7nO6f6YM6ozEMJyQOWSE0gGVlg3NoSwYsqootTo8ssvNy6z0aNHm3B+/m3UqFGmnNUGSp9TgYCAI5JcqkQRDWGNjqAMdCidiqIhSapS43333bdK4xEXAZAuxYUS/4IHPY4nIfJdAuxaHvviiy+aawFdzTOBmPjCCy+o/Dsmfvrpp7g+uiLv6XQ7xUVOSWY6zjrrLJO/iBjD+ZCNSwfH+ffff++1bt3a+b2VAEIHk3IIpM2aNQudaC0nKFGnfJZ85bBJWpzCXK8RqPMJgve5555rvXxQ9ZELTIjvtdde5hgIY8yYMSYyh+ZyuMzLFY594jZ4JRNWTswLwVAIr3Ztk9PHK7QGY+lSr/aMGf8vCCb/OWWK6TQcJ7Vmzzavuikabi2pXz+8vPi//1+yyioSCC2QAChEDAOqVMu7lhnwgJsPKB+hyUTAtttuax48Mw1gWD9ykpJB8OvXr1/KTCSEwT59+pgSDhqq8F0MsqKCDEZKVBLLGIGHaGaKbQdmhR5IU9JCUwUhSiEb77777jMNhhD104FDA2creXWIHSJaKG1jMIwjRoTjer/hXpBJAATuZbzYB0zeMOnnms3m2nyqEmB/3XDDDWaCYfbs2ebfmjZtahqQEbmSr2elQrD33nubY4lIFSomyPpcaaWVvD333NNMuhSifJVnEya5bRqB4BYkbibXexLPc6nEvwC2ExU4dO2uRJjA5xXWnTjZLahyYlENmnw0bWpe8zfbrPrPfd+rNWtWdXEwIY+wVkQ56KmoNW+eV+v77726KZ4dly6/fLXcwUSBkN9NSAAUwgpmWV0Im5kLhLW1117b2tXFbCYZJ5TO5hMGLISSM6ucqqSgSZMmxsXTqFGjaiIA5Wc2pQh0rRw8eLBpnoJbj4YDmR7wUrHuuuuazDycEx06dAgtoWKZAw44wMkFWChY/6CMj78r8+V/JTEqcSluEADJq8sE0QO4nXC3MKhHYOG6SXwAjYR0vGcPTSUQDbi+hjnR44T99t1335nGGpSOk6NajE0tUt2jo3oGQJThxf3MtWt6VOWS5QITit27d6/WYItjjNxRyj5xXCY2zSk3EPyomuBVLNCUiMzXdNmkHPs8E+balOixxx6zzkAlj5PIHrKTxf8/OzGZnDyhHJQTB6JgojAYVaM3UUbUqOEtWXll8/q3bdvQRWrOnp06g5BGJQ457NlQc8ECb/mffjKvMPzatb2FW2zheTFVnpUKagIilqEmIKnp0aOH9+CDDzplaDHwSbWdyb6zhUHUUUcdZToP5numl1IK8o+YTQ2EFx5EDzroIDPL2r59+yrLk/fHQ7jLgwMDMbKYCLzHNbHeeutlVfrMgw0dZZMFyWTIMevSpYv38ccfp1yGLJ1sMxGjAndU0GmPshfE1mKgkNuGcu6vv/7aKhRdFFYEpMkC5zbXLDL/CLO3JZh8ELlBGRzCqqt4lQ3cH8h1JE+W7NJEtyfHwxlnnFHNlVJIcCS5dFYncwzROttyyWeffdZqWc4Tnh9KMQMwjiYgdLTeYostMj4T0AiC4y5onCPyA2I/lRV0y06Gc3/48OEmwzCKez8NqGyhLPrMM88s6SYghYZzOcw1qHLiIm4CUgLUmDvXCIF1kvMHA4EwD7FLC7bayls+RYVapWg3xTctK0QRQladrQDYqVOnlOIfMBAaN26cydyzgRP75ptvNiIcZXOtWrXy8gWORfIAKTnBtchAEjfi8ssvb0oyKMXhohPciCjRcZ015IGCbUt+Eg9hhF4jeLrC+jDTTGlxOhiEtmjRIq0AWAwus0SHCi4HMqjizoS0ARdlum0XJ5wDuFMlABY3OEMSIWd09913N7lrYaV6iIXkO+HoYYIhquOc70VEJ880U4h+OULzEM6ZAw88MNbvYdsiAuDSSebXX381cRDc7ygXLBZ3G/d0WwGQCaNsxT/AtWUrALJsqQ7s4oAKAZvrAbmANB4j4kPkDyouiHqhioPGOlzDeUbkeo/wHZX7l2dQFwqZ3Vxu5cTJ7k2VE4tc8Bs08Ba2bm1eYdT4998qJcVVyox/+800MamRRb5uIkvKpFFQLsgBKJYhB2D6WRcGUYhhmUQbGoBQuptpwES5KsKeS94P7gBmuQtVUsWDOCLf/fffb2bmga6+Rx99tHHsbLbZZs6NToLBGMJfAKXAp556qplxdIGg6UzCKsuUQj4M+3jmzJlGYIW3337brHuhH2zJV/wiRfeufKBy6NIF8RhXMW4d4FrBdRDHX+J1MIp9zGcwaCR/CmEAx3LU4DDBrcU1mfXl+k/H7mIqncKR/eGHH8YqKl144YVmkiITZJZRllwMsL9wFQUu61SwT998882MuZaZvgsXJMd5OshsRCjMh2OzFByAlPzi6GOCwIY11ljDCM4SUMsP1yqIa665xjvnnHPSLiMHYLQklxMn/llM98RSphwcgDmzcKG33B9/pC4zpklUhuPtnz59vBWvv94rB+QAFCJGuNASwMzDbaoyBGbJmAHNJP4BD8gMfGlUgaiIAIbTLxOUPzJgIQ8n3/BgzawuuV2JIEhxAULAs31QTya5kx/B3vvss49xXVCya0sgPnKTZH0RLAkKR6SEq666qiTEP+BYI8emXbt25v+3335706WZ4xABlt+PsucddtjB23jjjb3zzjsvL+tV6KYkyoYr7SB/RLOHHnrInJscu2Fu0ij2MSX0iH+AYzkOEGsoicf1jQPu+uuvN3EGxQTbFyckGatxgAucsl8bGMCzPsWQ1cY9nQZUxFmkEhZwi+MSzEX8C74LEZp7EZEayRNbDOaYRLvllltKVvyL63rh8kyB+M5EQnDei/KBTFMXARDBUBSuO3FybnlQTpycNahyYuFMnTreorXXNq9QmISaNm2ZKFgnKC3+7++1p0yRA1AlwELYg8BHYD2daxG7KMnk4ZScEzICe/fubWagXahXr54ZQNqIfwHkLEUpAJJthKgYPDgjvK2//vrVymtxbySLf4lkK/4BGT9hs/8u4h/gLLrxxhvN/gkcioGzgjB8BNdSInmGj4Fi0AgDsZMHKGaxcbJQZnfFFVfEvk44noTIFrpYDhgwwJyPv/zyS2wbkqiFgFwFnHT5V/DBBx+Elr8WC2zvnj17xhKKz/5Mbs6QDtzdCF3FAAIfIi6uRAS6t956y9zruKezvbK5p6eC6zbXZwRwJnBolMN1nEkuIi9ofiOqoskeEcAzNs9vNs/KnTt3NpOionTKicNcgzr/RZYHm7eYbr9rrOGFjkqXLvUarrCClz4tvvxRBqAQjoIMgcZRhBonznK7gAssCvgcypLosJcIZRN00cUdEeQN4myMq+yTph0HH3xwtX/PJmeOgTgOuWTGjBljXqVG4FyETz/91MyCk+tVyN8tF6FXCJwAcYt/NEwity0AUaeYIAeRhkVhndVds65sYJB1xx13WJXpuuKax4mLnUka8lqDzs8ItNyLmKhBKMsnfB9uUV75uqZnak4g/j8yAMe57flLhnCmJmCiNCEblmvY4YcfnnY5MkYR80V5dSdWObGI8KDzPDntvfw+aQkhquGa5xdF/h+Dtm222aaa+BdARzecCVdffbW5EfPgFRfnn39+tVlByCYzhMFllODQLCQEagNiCaJJsvhXKDTIErkQp/gHL7744rIyS8SvYnP+7rLLLt5zzz3nHX/88SZblj9xYePmxZG25ZZbRv6dcXURT45vyAQNsGjURGMWXOc0byCWAYc5ExwubnhR3pB/S7dmWziP8i0gi/xBN3lK8lOVeJORTV6nS8d5UdzlxJQSM2nCpBkOdqqTaDxDIz/+jWOBZRSdIIQbcgAKUWBw28W5fDIIesyiBuJSKhDgEOcYpMXZ9TU5KySAm3yhwZlC5+VCM2jQoIz7K5/ElakmRBTQ9IKcwV69epny12Jz/9JRnYyqsJwqRDBexCIgkkUFjUrowstEQpS0b9/eaXmcHOmEWzL5KMmVkCOCigREn0zOc9yzcTT6EcUF1SJ0F6Yqhet60CgGoXjnnXfWdaMCUDmxELmjqTIhCgxuD5dBFA1DcuGdd94xA2RbcAG6BvW6uEJuv/320H+no3Ahw+L5HbbddluvkOCOIWQ/rKy5kPz999+FXgWRZ0qt4xw5oJw7NCgqNmxc3DgcooSJH7qIRx3lQGZs0NU5CsjYjcutyEQWghINW3CLjRgxwrnTfBQl8HSqJ8eX+z5O/LPOOsu5lLpSaNOmjffEE0+EVgkE4BBCNKYEWJQ/VGYwuUNMDc7pu+66y0xsaNKgsgnKiSkXp+HSmmuuaWIENtxwQxNnRM4q9yoqWDiGXN3rQpQTEgCFKIKBNdlMNg8vuCNyLQ9jNj1ux5dL+S4D0rBmH2yXQpbuMUj//PPPvULCdiEsvthy94otU03ECw/UDMI33XTTktnU5IEi8NBtuBhLGzNBSWzU0DiITuhRQpkWHe2jJOoML6ITdtppJyO40YUXdyjNSI488kgzKMRNlA8Q+dq2bevtv//+pqEYguSECRO8oUOHmsiN0047zQiEovq5gBv2hBNOMI1bAij/69u3r9mOuVZGCCHKl6CcmGtGYjkxL5UTi0pEJcBCFAGEnz/44IPe0UcfnbJECqcFwem5Mm3aNOf3uAhQPIiTIejCzz//bBx/YYInnRPpcJtvcIY8/fTTXiEhLytfg1MhwmBGnU6vXKNwkOEgplsq1wRm0m+44QZz/hYjcTUuyhWb6ymNpnAxRF36z76kCUeqHK1UIEyRW/j444+bdUIURpg55JBDTLdc7isXX3xxJOs4fvx4LyrIVdx+++1THqP8LmSLManB/TcuJk+ebLqTsj6puPnmm819Z9iwYbGtR6mCQEq1AGIpgi4ThIi3DOyFECIbcAHiLk7XnTi5EYm6E4tyQA5AIYoEBiHffPONd/bZZy8rZWHwzSCLMgfKhqJoSmHjPgnDZsDIQ/m5557rXC644447em+//XbKjp4E4zPgrCRwICKuUAYsRCGgrGrs2LFG/APO6/XWW8+IQUxY4L75/fffi3bnFKP7z1YAJNSc0tCoYRDDfcYFJnRwSiAAs98p00VIPOaYY4wIgzuUSZp3333X69Gjx7KOjgyuEDIvvPBCp++LsiyXY9RGoCZaI5vJMVsQR9OJfwHDhw8321GEwzMQ1yBK+iT+CSHiLicmX5Ry4nXWWceUE3P9SSwnRjxUObEoNSQAClFEcIMZPHiwN2XKFFNGy0CRbJuuXbtGlm+y++67Z/U+Zt5xpKQCcQAHA10tw8LtM2XK8Tv++OOPoT9nEFlqGWS5olIwUQh4kKXrN+WKhKzTUfH+++/3rr/+em/gwIFGCELs+eGHH5bNkhcrPLQXI7ZdtOMqa2S/2UJ5ZZcuXbyffvop9OczZ840Tm1EwK222socKwiv5C8i5JHnd8ABBzitX1T5hwhuCJU24AC8++67vTiYMWOGk5Ob/EohhBDFB5NzieXE3K+Sy4nJJVV3YlHMSAAUwgHKhcgQwq1HNzLcad9//308J2cWgh8dexHqyOpq2LChEezomEbpVjDoo5R4jTXWcPpcPgthDxciOUrJIfaId3TLDbrwZeNcQQRk26bqDllJjScCB02xorDt8oXZbUo6OcdpgsMM+FFHHeWdeeaZRvgrpfMQ4SlVl/FCwjXYdl9E2WAjOHf5XBsodeJYoNNmpuVoqkHGYPAdOM0DVwTNnDbeeGPrdeR4iwLuGy4NrJ566ikvDihpdnE1vvrqq7GshxBCiHjLiZngozM1LkHutcQXYO5gQpIxGc9UPONXmqlBFBcSAIWwAPEMsa958+amiyCz+TgLBg0a5LVu3do79NBDMw6S4oZsLmagEN8+++wz48D4888/TfksAh0uOv6N2SvKjFxuPvx+dF3bYYcdTBh3ojuNmS7EQfKNAnCMZBM2T7fbsLK9qJwZpXDDxXGV786UrmyyySaFXgURE7hwKfHkoZVrSqnm3SBgcpxyvS4mGjdubCaQbOBaTaOKqMVH226plP7STMV28omunKmuu7b7gcHTsccea7WszTrFuXxcpejFWrouhBDCDZUTi2JEAqAQGWAAfMoppxixL1W5G511yeorVHdUMp0Q+BD8UvHyyy8boQ4xkxJdSraSnXxh4BZECHjsscdCxQDKmwhPv+mmm6r8+3nnnecs3CGihpUBU26YC3RexFWBk7EYIFONhi4MirfbbjtT6se+walJd8hiF1169uzp3ERAlAY4phCJXJxTxQiTFLizcS3SPTQdW2yxhRHb8jEQuOeee6oFjqeDdef6FQVc77ku20L8hAuU+6a7ZvTp0yft+9kuuMzJXIoC12sU4mwc2Aqu2S4vhBCi/MuJS8HEIEoDCYBCZOC1114z3ecyQROLZBEsX/Tv39+4+zKBCMigDocBlnSaTKQrMcO+jrCJozATlAgmC3W2pW6Z8qlshMpUHH744d6nn35qXIlHHHGEV8jyAMS9X375xTisGBBfc8015rh57733jKMUYbYUmp0QxK5BavlSzLl+LtCgBNGNbFIaUfAgnUjLli1N3iFNFzgn44ZzxjXXj1LaV155xZRjZyLd4IBrKJMOHTt2tP5um3uK7fKsG/EUd911lwlST4R9xL2CUlkaQkUFk2Iuwi5NTuKALsQueZTcs0T5wcTed999ZyZUv/zyS6csTiFE5ZCunJjnFpUTi1yRAChEBm655RbrbXTbbbeZ5h35hC6xo0aNsl4eNyM5FOQy8ffELrMMEnFB7LTTTqbbIyVgtp/N781gOhE+K13jkGQYrCGAJT8Yb7nllp4rCJwIspQVB5l1OO4KNYPG9hk3bpzJpWKgm8rlhyBLGXAxM3HiRO+rr74q9GqIEiYfAvLkyZNNWecuu+xiHNy4lROhO+yAAQO8zz//3AhPRBzELUji9HV1+HJNYKKAnFUmMbgebr311t6JJ55ohEsEBaIZcIKffvrpVSYRuKYS4TBhwgRnYcnViZdpea69dA7m2sH6UDKME539QP4e2bVRwnYjq9cGMplYtzjgvnraaadZT64cd9xxsayH8Ap27yd2heMbZw9iPq5eBvQ0fStU5UgxQyUI1wQcwV9//XWhV0eIooB76PLLL5+xOzFjLwTEXMwToryp4Rd7rZnIG9dee633zz//GMdB3759teX/c6MxMHAph8Ntls+MNMpGyfiLEgaRdP1kcIkD0JZWrVpVa4py/vnne1dffbXT92N7ZxBEUxGEgk8++cQIljaQ0zhixAjjukhsVoGrCYddsQSsE4p/6aWXGkEgcaDADZ4ukLYDxihg0EnHaRuYfWS7purYXE7Q8AZhRUTL/vvvbzrH2mbhZQuD7nvvvdcI7+ngQZrJDpo8IazF/Vg0duxYIzZyf+G7gmYZyR1s+TnnmqtYyrmMG5vrCWVEtl2Hw4T+ZLdeOpgs6t69u1dMMMG1zTbbpOxiHIA7Eld2nCXpRD8g4qaCwRpRG8W2DW3hWOb35PdQqdr/QOwOqhBSgSBI+XwpuP/jhms1kzJUqyRvI3K4eYaLilyusUKUyjWW5wDGP2SLJ/5ZLpUe2dCwYUPnZpjlpt3IAShEhoGUaxZWvrtkxnERv/HGG407Y+bMmU7vC1v+1FNPdc7emzJlinf55ZcbIZUQ+s0228xKLOCGiAuzU6dO1TrVUu4ctfiXy+waJUCIIAMHDjSlwDgD+Dxew4YNM7b/fIGoR2mBDZSPV4L4BzjDRHQwK40DFtcXwjfHXZx8/PHHGcU/IDsVB2C24p9rdhw5fExoBOc7jaRompTsUMxF0MdhhOMoW/EPuCbsvvvuVsuuvfbapuN8sRG4J4mACIPrLBm+cYp/8Pjjj3tvvfVW2n3GPbdUxT9RFe6RiFVM9KUT/4CKAJqsVTrEoHAdThb/gm209957FyxmR4hShQlG7i+J5cSYNZjcW3fddVVOXKHIASiWIQdgdZgdxEbt0pX1iy++MA99LrOQdOplEMoFmtwil4ExDiVC7KOGMjNmYnnocnHuUeaWDAMfXIqumVKBOwcHIPldiIDk6IXBQPrOO+/0jjrqqNAZMG545O+J6iAU8PBNQxJcUEJEASI85227du2MoxfnH+UrAR9++KEZ8MXVQZ0HXMpi44QmHQhIf/31V86fxcM5jm6uvflyp1B+iEjK5A33H64BXEtxJOGaY98wIZTuusA9kskV8gURUN944w3jBgzuadxDcJKHOR3zCVm2uMO5R7HORF1wTNapUyfW733zzTe9nXfeOWM8CPsdoSMfDWkCOMaY6EB8Zl8x6ZbtxJYcgP/j22+/NQ7fadOmObsFiz3+Iy64TvMcYjOhzfnEJG+uyAEoSo18XWMxviQ6BYO/893lQEM5AD0VhwuRBgZfzMg/8sgj1o6JNm3aWC3LgOqMM84wJT+JF1Uu6gyYGHSR7ZAJnCQMsKN2K+G8wz2BrRh7sQ0Mgnklu054GEaoJO+GbEFcZLYwiGRbUEbMoJIBMiWyNGfhpkTGICU2lAvjogsDATEu8Q+BIyrnTiHL5DjOJf6JqMUFmg6lyvBk4gLBg+YLcbhKGYjHCddGOp1H1TEZwYAJIK69RE/ECddg3MeUSSd2j8cpwD1o3rx5VZanPDFsAgd3Np/BPsbpdOSRR5pJsERoooXTgHLsuHMW04G4lc94jgCiHmyygdnvTz/9tHfAAQfEvk4cs7ipuJcmNu/CHUK2JE29OBaE+wCdiUpX8Q9okDNkyJCK3OQ849lWs2BWiEIAFEKEwyRU2ESUyonLBzkAxTLkAAwHdwR5crYPMTbZbQguDIToCJfODYJzLpWolQiNLuIoYaL7JI47umjaQnZgnz590g48me0lmN/WNYPIRllw4g2JB20EBhtXyZgxY6xL2VxhwISjJN/NXyoV9re2delAaSjnezoxgXOZawbXmVKKJW7QoIHTZIYtTGZcfPHFsTkAEfK4/pJ76HruUbrN+iB+4uojXw/BEHcd97R0Lm+cdlyLO3fu7FUKiNC28QrAfgkrgYza9bnvvvuafZEK9ivl+i65dHIAeqbcPFuRmyqJZ555xqs0mABfeeWVrSeauSbyDO3apCgZOQBFqVGs11jWKzlfMPh7MXY7bygHoDIAhcgEJVHnnntuxuVwbjBzbgPlcOnEP2AGmQ6GNgNiXBdnnXWWFzUM2hObVNiAIybToJkHN5eSORx2yaXF3PzSiX/cfChfY/vlkoNl02lUglT+KMaHCZGaSZMmeZdddlnaTcS5zOQJ18Szzz7bRCggHNLQJ1sYUNIhLy6IO4hD/IP777+/mgMvSo4//nhn8Q+4zjEhxL2GjFaC+dl3XGPJMMsU8cBgoEePHmVTRmQDwqgLmfLiogCxPZ34B3SWPvbYY2Nfl3LDtlokjEKXyBcKOrXbin/BMwDPXUKI4uxOTIMNKtiY/FJ34uJEJcAJNyBC+RmAUA7BK3i4p7yFUsh0D7WUblDiyPuZVaK8ghMB9xYzultttVXWO+nCCy+sVlKTDOU3l1xySdbfIdJDQDsXtSuuuKLaIIeZGB6UaTJhk93DMULmn+1ggLwTcrIyXXwpHSFDhYYSHMuJD5XkHbk8YAHHL5+HC8CFTN0WsxVxbN6DswE3JI1AaAAQuAcZdDLjk+8GLSJ6SskhJv4HTW24P2UqKSSnk5gA7nnkj1KemC2If7icuGZHDVl3PBM89dRTXhwwccEziEuWrMv1mbzPbGFi5Y477jDlwwETJkyw7pbNwJ37H2XflYDrvS7uCQ6eTzNN0iU2LuF5hSY1wg6cadlCnEslkk0GZ2KWrBCifMqJ0U/0nB8/EgD/g8DrbGfumAlPnLVFEOJgJ1SbB2NelAQwa57LDB+ZQKlygVZYYYWsP1dkBoHtnHPO8U466SRznDDY4eLFgzHuO5cSLQLjXXjooYcyCoCsC2URlAEjdhGuz0CPB6sOHTqYrpunn3660/fyWbj1XB/ObERQZoc4Zm3D/yk3y9SynQdvStIC4S/RPUhZci4de0Vxwb6My0VER1dKsRCSRTRwL0TQ49qUSdTC+cz17uuvv87pOwnUp+HD0KFDI3Pq0VQE8Yv7OY7vOInLVUwGa64P12zXRAHQVQhl+UoRADlm4lzeFa5rLtdOxMIrr7wy1nUqJ7J9FmdsUKmOSyabaX5ie81nUhdXkRCi9LsTJ08Ml1o5camiEXGCwEMzARwI3Fg4IHH+2T6oIwDtuuuu3tZbb20ywfg8grVp8ICDiiw3Mt3COpTawgMzzQ5EYR/uKN/NBbLsolieXK1bbrnFCJIcaxyzHIOnnHKK+TMxeP/oo482DsXEsO90UHp30UUXmb+3b9/eiIu2F14btyuzt4gBOPVsxch0M77MGCHaJIt/iVRS2Vk+QfDlGpjPG3Oc+xI3OM6XUsalcU++oIkPL7LFcAOmEtCYUMlV/EucXcbtRqdX3MG5MnHiRDOBw++AUBwXXG9zKX9Ox88//5zzZyTHMXDOuOC6fClD0xEm4WxLrinPzhUm1hBp77zzTnPMMtCiWQsdq10b43z//fc5rQuOT0REmpQxsKNJ2jHHHGPV4KwUoeKHZjfZ5H7Gdc4XO4yXiM9Jlx2dCEJp3J27hRCFLScOG/Mx1gtzDWp8507NLN5TlpC1RgcuSo/4u0vpDQMWhIyDDjrI5BYFwZyUjHJT32mnncz/U/bCwSoqG1x1uS6PC6Vt27YmND/o4Dh//nzTQZBmF0cccUSVjmoIAmT+IHBngodQPjcIWKaUbp999rFeX1ySyeDCC0qUmb3ls3E22v7+mR4MR48ebcrwo4ROfriWEp2HDMxFVdgmNBDi+nbdddeVxYM551Kp0aJFC3OOMzFAqfshhxwS23fl4jgnW2yvvfYyZcFh3bqjbIDAZ+EKZgKO70wOzeY+71JKhoBBWTITEkw4xAXX21wD7lMRxfmZfE8ib9GFOMXTYiSYTMsEFQU8f+bqfOW4RlDhnshEAHm7b7zxhrmnubo1s3XO8/zBs0DLli1NF2SqEEaNGmVK8nkOITMyClG+2CAzGTOBC4whuHdWMoh6NuMunk/jyLsWQpSG4YDnD545MF7x3Mt9k7g17jVkMzPGZMzLs04xNUopNjSa/Y9cSnOZ0Uz3fmYEAfHv119/zfp7RHnQpUuXnJbnQZqH+3QlYg8//LBxAiay7rrrmtJlxJrETB8EHAbBQXk5xyhuU2boKfOifA4hjBzBTFC6t/fee1f5t1dffdW4aimhJhCdckAEQZs8Pr4TcS9xfRk0UMbGA+Ohhx7qnXnmmSY3LEr4PZjFx6mEg4FtgnOG7C9RFa5r7AMmULg5JwrPIn/88ssvJueS0GUeenD/ZNuNMhO2pfvphDTEgWRX1H333edFyQUXXGBKHnFDP/fcc96PP/5orp+4+BBHcCVRIuwKrmuumemygbOF6zHXyrjAvZgryZEUZC26EJT/kqfL5CmOMBzh/fv3t3aplxJsn0wCD5PHHKOZcjIzVQvwvEnjnVRMnz7d6TO32GIL5/XADU61yu233x7qDOf85/7avXv3snNucF3gmLYZeHJdousvTX8qPaKEQT0TWEwSp4JnUiZ14rjuCiFKv5yYho9UWzJRwEQTz8OMfTGyMDHDMzJj3Zoyc5gbsQjhhx9+8Lt162Zef/zxR07b6Oeff172Wd9++63z+y+44ALz3hEjRsS6r4YMGeL379/f/CniY8mSJX6rVq0IYcr4Wmmllfw5c+ZUee+6665r9V5eEydODF2Hd955x+/evbtfu3btjJ+xxRZb+DNnzvRfe+01v2HDhimX69Spkz9r1qwq3/P+++/7devWtV7fxNcee+zhf/3111U+75FHHvGbNGmS1eclvvjd27ZtW+3fmzZtao7/xYsXh263Qw45JOfv1kvbIK5j4Oijj/bvuecef9q0aeZ4nT9/vt+3b9+iPeYOO+wwf+nSpf7bb7/t9+nTx2/evHnk31GvXj3/zz//THtNvvzyy62uhYmvXXbZxX/xxRed35fuVbNmTf+uu+4y6zRlyhT/t99+M39GyT///OM3btw4p/UcM2ZMteelOnXqWL23RYsW/sKFC/3Bgwf7DRo0CF3m4IMP9mfPnp3z78rx/+GHH5rji+ewQsM9tGvXrn6NGjWq3HPOP//8ZedsLpx55pmRnjvLL7+8P336dOvv51xm3/Ksavsdw4cP98sRnlVWWGGF0N+Z56hRo0YVehWLkgULFvgPPfSQ37lzZ79Ro0bmGXirrbYyx0nis3AUxHWNFSIugmssfwqRi3YjATAPAuCzzz5rPgfRIZsbWCAA9u7d2z/mmGPM5zBwOuecc/zHH3/cnzt3rh8FEgDj4ZNPPvHvu+8+/9577/XHjx9vLtwvvfSSX6tWrYwPx7wnEZcHa15nnXVWtfVhgMlA01WMA86F8847z2/ZsqUZ+DKA23nnnc1xuGjRomrfxc+yHXwE3xlw//33RzawadOmjfnM77//3r/99tv9a6+91uynTDz99NORDrD00jaI4xhYbrnl/J49e5rB+w033FC0xxnXkM022yz270n1YIQwxL01UZCxffGe33//3e/QoYPT+7ju77fffmYfJX7Wnnvu6b/55puxDE6ZwEFwW3/99XPelgcddFCVwQeTJe3atbP+3ceOHetfdNFFGZft2LFj1s82U6dONcJ3stC5ww47+E8++aRfaBD7PvroI//LL780gkcUzJs3zwgmUZ437CcXgsHpdtttZ/0dnP/lOpj966+//JtuusnfddddjYjFM82wYcOMCC8KjwRAUWpIABRRaTc1+E+hrZvFCKVCZ5xxhvk7zUCytZyTJUUpJjltlGNlU9pDLuEXX3xh/k6ZACUG8+bNW9bJD1trv379rEKVKZ1Mlb1GSDQ181jxKccRuUHmDqWplN0mgiWZY4vy1lNPPTU0rJ99TPktWX6JpTscQzalswE0pXnyySeX/f/48eNNVmU2DRsoz2jXrl2V9ybbqAlofemll0wXYo75XJsp0F2brqAEl7PN+PwooDyHXEHOhyBDkd9l5513Nv+equyJsuvOnTsXfZkapcp0HxeVDfkoZN/ZNtspVyh7JX8suYy3b9++OTWvcelcmVz2RwwC1zW+n3t3cpfzdNdZ10w47iN//PGHlysHHHCAiZBIzE0k4oEMMxu45/H8YdsB+Oyzzzb7yAWiGshh++2331Iuc/rpp5vy8HKCZ0Saf0UFjcN4BnE99ng+ce1kzDMS2U2VBI103nvvPRNpwvhi++23NxEaIn9EdY0VQohCQcwNUV3kHro8L1V26EQeCJo0IKpl2wGYZg/kumy++eamvh3xAtFo7NixZscjDJHRduONN3orrbRS2s/iIEFQCSMxU06ttnOD7s8EFYfp63TlI//q3HPPNRlYZFKR/UNnRPYfIhTZdgSZJu6HK6+80kn8A/J1Ej/j+uuvz3rfkiuYHNKc+Fn8HgwYpk6d6kWZnRRF18pk2C9si+TfhXwZXojuyRmKwLlHcwX2RTHPndBJUgKgIBfw9ddfr/gNwXUz8VrFwDtX8Y9rQTbdipkcIVeUTBomaALSrUu264nox70kU+4b+TmIetx/EJHIznn77bdNlhyiBM8eTAryLJK4PmRBcq20hYlLrp228HzDJJmtMEL+KOuZTvwDnpUQXXNtuJHN+cikE8cf2akcA4iVbPNcM+CyaTCHGMsk3QsvvGAmq8lG4lkT8S/IinQ99lyfUYL3VEquG12Vr7rqKjOhmvjMze/PdqdxYKXnARYCjXmEEJWE7jIxwsMV3QcZKJx22mkmmDIbCFNOBqWXZgu4yRCSaKyA04vuhOlAiEy1HomNTDQblj104cS5kEkguuaaa8zAigB0Xumgix/NMFyhK1KwLxnMcTxmy08//WQ+K2zWlEDvOBwVcYh/NgwaNMg4Z3DSderUaZm7lsESPyuFQYYQwfWo0qHrbOI9jU6+uQ74cMtnI7pwX2Ayhft23O4UGsHYNH1AiMD5jDMu4IQTTkj7HsQ/3OTpGk6kcnXbwmQSjaM6dOhgtfyLL75ofe1jcpbJnHx0CWT70v32jjvuqPJcQBMa1pmQ8nvuucd0MsyWtdZay/wuthNTTCbjZt9pp53MexBPo+ia6NoRGpjsrIRnTo5lROcwkZRj/eqrrzad0DlvJQLGjxyAQohKpSIEQAbsYYMgyilxysQBYg0lRsGD9LbbbhvL99Bdld8DlwduskwCIKU6qcp1KO3BWciDGO21RXbQOTZdh95EEM5waGSC0l1KRVzBxRbsSx4sc4HyLT4LVwkPTsFxwoCLEvRyA0E9KJ/ebbfdvMsvv7wkysYYOLi4bIQodxB6gusg169XXnkl58/MRvxLLNfMdI9Nvs7agJDz2muvmdgSxCXc5raMGDHCOLhtBSA60SNouOJ6H3P5/XGh20KMA/euuDplJ4K4SkfcdJEziKnvvvuumbTLBrbRHnvsYdx8NuA2Sy47zxWOP8Q8HI046W3g2ZhokXKH4/7YY4/N6JAkQgUB8NJLL83bulUq2VxjhSgkXGOp7OI5Px+TV6L4yXbyrPyn3P6bqcZBlfyiHDYOnn32WTObC7169TIZTHESzBpHkfEjcoMLc6qMxVQPezYls7Nnz3Zel6222srbcccdl/1/rjeL9u3bh/47bhpbwbNUoVwHtwTXkmKHMi4hxP+oV69elYkxhJ9cy/dzLR3FbRU1RI1wjaKE89FHHzUOZpfrMk4+G7cgEFdx3333ZbWeVC+4ujdtIVPRBdfls4GJN0qOM0E0i0s5dRhUHtjeI8IiLqKCsu04li1lOCd//fVXq2VvueWWrCZ8hRBCCBtqVooD8Omnn672Cpp8RAnlHMOGDVtWutu9e/fIv0MULwyMXIXlTHlF0KRJE6fPpJSH0PtE0Y/8pmxFQGYYjjvuuJxdF6VMLg/klNcTfB+Ic+wHHJVxUAoiZbEQtg/IucTBna/yQBEvOPW+++670KgLVxCjrrvuOu+8887LaZ1sGna5QLbe7rvvnlPEQzCBZcNTTz2V1fWQc4vMO1twqCWW/yLeUkpLThpiF5OtiSKn677N5VgAMiBpsEP1BGXdYddelwY8REzkkqHbpUsXb+jQoRmfDVhXqkfiomvXrsYhmgmqUWwqIMoB8ixdxHzGEkIIIUQcVEQJcL6grCh42KNbXr4ebIJZ7EoJUS4395XNe3iwJ7MH56ptyREB44nw/7hRaTjiCk1L6CgaBt0si83xQ6B5McEgNbEbMw4kBu22rL322lZZWwS3v/POO1mvZ6Xx/PPPm/I7ti1NELbbbjvTjRHhD8F2yJAhJrSfpg24N5g4EqUFJV7krdKYKejcyzXXVsCipBEHIXmtiFdcX/hMcts4drKByoAoIVsuudt8Ns68pk2bWi2brUjF+cXEaFAhkQniU2gAgiDCBBTCYyIIb5TM4pji3oZLnazaXF3tmfj4449Nk6833nij2jYkVoZS6uC+7lJuTpd7RFwXkTQZJrYR95j4TrwXcE2jRJiIErJt44TvYp/Q2Xfw4MHVhFEmXnhGIVajUiZZuIfEubwQQghhiwTAiOBBkFBpBvbdunXLuuNvMnxeugckZsSDWX/boGwRHwwANt10U+ugcxqytG7dOuNyPDAzAEKQyAQz/Dxch8HDPzPLLqVhDNiSO+YmQufIqMrpCRCnoU0ulFt4Nuf/XXfdZcSnm266Ke2yUXZgrgQ4TxMbHwQuKByATOYwgKZcE5GhmLs+i/SwPxGRcFI3bNjQTM6Rv2rDgAEDqpVL4oimsdeZZ56ZVTRDlLlzHJc33HBDzp/DM4ttt12aiWUD1RE408mfy7T9mcw455xzzAQT2ytVMxsaRfHMRYklgqGtI53P32STTZx/B7ojI6SF3fPIUMYhSqdn7rOIgK73xigc3DjweH355ZdmghinI79rtvmC2cA5wvMG5wiOQzIpOVbbtGljnimY0KwkXCeHmZASQggh4qAiSoBtYEafnLXglfjQxgNZ4s+SuwfSoAGBhH/fc889nRuLkBm3zz77mFdYSQgP98zuJ68TYc80X2DASmmSyo2LA8qTbEHUsx10EQrN4NFmkJXs/gvg/ffff7/VrDuDZUQnHFDpRDW6UUdFruJfMAgrFnAL5TqIIjyeXC+6NWYiW0dSpZLsAsNhi9uWjDcaK/FzrutsVxdnkSguuEcm7j+a+dhk0ZGvm2oyD1GQ+70LrVq1MgJVlK6niy66yPvll19yvk4lC+Hp4HqULQixPNcg7qXaB0xmsgzrxXKZOllzjiIq4tLceeedra6rl112mfO68wy2//77ZxT13nzzzWWNsVybC0TZjICSa54LebbMp/iXCPu4d+/eZvKKSXKejypN/AOc5S7kozmNEEKIyqS8rDI5QPh1KuEueZafDnuJ5baUswSiIGJguhI8vsPlxk5JyKuvvmpegROMh1ceQANHCg+MDGhwYonCw4CRLm50ZU4HJWSUEdmC64JyIgaeiMbJLr611lrL5P9Qfp4OZt/5bpb7/fffQ5fhZ4S82zg9eKDn940KXJEEopcDuZQiMwjGTcLAgXP94osvjnTdxP9KqwM4nyj7zTVHTRQniaIbwh5RCAgjqWIVWIYmTSussELoz5m4wVlIFh3PBOm6AiOCcF/o37+/c55rOmjAlGvHb5xGlEfbONEDNtxwQyOU03E4G5jApHqBsnrEIeIRErcf984NNtjATJDZNtXimYjJLYRD9muq85j9xjNbNiImTjbbRikcE7hHcZu6VATYTPSI0oMYFc5XG2jmQ1SBEEIIEQcSACMgsTTs77//jrT7H4N/xEVmwOnyi7sJVwplTGSykeXCjLc6fxYPDKjIFkNMGDduXOgylMEwACVfygUGkgxyGPQ98sgjJruMfU+2Ek4821BzjhsGXzgVeChlMMbACAcFZVSbbbaZ9TrxnvPPP9+76qqrvCjAvUgzFcTvSoZBMB0ScZIQhk85l4gOrqGUDgbQUIDzQRQfOOcouSXzLZtsLJxkCHqJMBFHp1wctkxgBJMhuKZoYICjLJX4l3itx9mEOxuhiusobmmuiZyziItcs7neZvosVxC8mPjLFtYTdxifwfq6QmUC951sOtQDeX5c2yjdTSUSpoueCIP9gODGhCn3x6CMH3Cd9ejRw1xTk48FW2zFSGC7cI8/9thjTeMSm1JgJtNsSj+5F+BoJe6DfWeb3SgKB03YuK5wvUkHz3PkJgohhBBxUcNXsJH4DwZXCIwMWPr27avt4gA5RHfffbcZUOI0adeunRlA8qDOA98nn3xihGJcDbhAEQd5eC9FEKIRpXGiBuVK/G4EnzPQSeeEsYGyOh6UGcgVWzMPBFaX/MSo4HhJbCKSbxhgIpiR0YibJdd9XAx06tSpiuDHcafOi8UF1xhcsIh//B1BxyViIeCYY44xOZqprt0IRkw6INIRQ0D5N5N5HPc0ZKAjtG3XbiYuELdGjhxpnMzcT3fbbTfTSMTFpR92nU0E0dI1biQ47mm+gIsPx1kufPDBB6YktpgaFiAWI/oFohj7g+sVbvZcS6/ZZhMnTrReHkc+TTmI0sBVn67LMsfIM888k/a5gGOKhjZs9wAm7g466CDjLs1W2IwKngP4HRGX89ncg/MMxyW5kpTDsw3JeOQ5gntnrt2eo4JtQwUHMS1hIFLjYLUpYxe5k+kaK0SxUahrrChD7QYBUAgYMmSI379/f/OnsGP+/Pl+r169/Bo1amADrfKqVauWf/LJJ/sLFy4sq805ZcoU/7fffjN/JjN9+nT/mmuu8ffff39/77339k855RT/1ltvrbZt0r0GDRpkPmvy5Mn+xRdf7Lds2dLp/XG+Lr30Ur9+/foFX4+oX7vuuqvfuHHjav++2Wab+Q8++KC/ZMmSZfu4Z8+eBV/fKF6rrLKKOX8D+P9Cr5Ne/78Nmjdv7r/wwgtVri9XXXVVVtvo2GOP9ZcuXVrlsyZOnOh37do19Nqd/GrSpIn/8ssvZ7w2TpgwwV977bVDP2OFFVbw77333kius8B9J5ttMXbsWD9KFixY4D/88MN+t27dzD2vGI7h448/3o+DzTff3Gk9hg0btuy9r7/+euj7V1xxRb9v377+v//+m/a7+/Xrl/a7GjZs6L/zzjt+IeEc43kn+VyLk9dee8387qm2S+fOnf1Zs2b5xcQHH3zgH3PMMX6rVq38Zs2a+VtssYU/dOhQf+bMmYVetYoi0zVWiGKjENdYUZ7ajRyAIncVuUJhFoasIZqxpAMHCWVOzDJW4qwpy5JnQzfCTOBmoDQ50ZnC+ws9g8/3ExpPuRwl0rgNbGBGP1XGWDGx3nrreZ999pnJAsNF8d5773nz5s1b9nMyIymdw4l1yy23GFdLMcIxmdykKR24LYLMTByO2ZYzlhvMLOerOIBzneYAZLaRr4ZLbvfddzfX1uTmQ5TVTpkyJavvoZkROak04fj++++N68/FyYqriAzWVBm+H3/8sflZplJPzq9UjUVcrrNHHHGEU0kqbLvttqaLbVzOAcpRcbsXGkq+KemOutkEz0U4Um3BLZjoyuOc4tpKNAhRLhyPONQyNaTh+QFHfCbIl+Q+S1O4SnCncM/C6Zd4rwqDXMWXX3654M8RoriQA1CUGnIAimTkABQFU5ErleHDh1s7AR599FG/kmdNcfLUrFkz43YaOHBg6PvbtWtXECcJM/Q4LyZNmrRsXXAmrr766lbvD3PVFevrl19+8ddff/20y+yyyy7+XXfdVfB1TfWqXbu20/K4VQNwOxZ6/YtVNfEdAACB0klEQVTllcrFFvWrTZs2/jfffGN1DVm0aFFO31W3bt1I1jfVzPvWW29t9RkNGjTw//rrr6yvszjuHnnkkayd0ddee60fF7iYCn3sBq/Ro0dH/vt9++231t/PtTIKON5cnIdx7t9ic6fst99+1tvl6aefzss6idJBDkBRasgBKKLSbsrDkiREAWZhcK3Ygmuqktljjz2MiyFVjhZuATKMUoXa0yky39Dpm0xH8rJwagQ0b97cZISRNZUJcsVKpUHPrrvumtGliQNqyJAhXrGSLmMrleM0oFevXjGsUWlCTpxLh3JXWrZsaTItP//8c5OLasOMGTNy+k4cV7nC9SCsUcyHH37ovfvuu07darOBpk9bbLGFcYORXZiti42O4nE4PHE2uja2iotMDdmygU7J5513XsblcPS5OAXTwTmCu9QWOhwXCvJxyTHk+MQNi5OXhmVk9EXNb7/9ZrIVbSE/VAghhBCeJwFQiCwfPmmGYMvYsWMrvrywS5cu3jnnnGNK/hD8eCEI0r34iy++MB0cU5UNMbCkDDUTUZb4NGvWzHT1TBUGT5dJW+Fh66239jp06JDzOlF+HBc2Jdrw9ddfe+XCVlttVeUYQ/QtBgrdIIjuromNBrLhsMMOM+WmiImU7vLi75T60sF03333dYpFiLqLbrYggifz0ksvOX2G6/LBZALNAbhW5grNmnhFDaWnCLuZ9hXXMcoy4yQuIXLQoEGm632qexXl2mPGjDGNwKLgxx9/dFqec6sQcFy2adPGRCoQJcG5z3a48MILzaQZzUuiFJ0R3V3iHii9FkIIIYQEQCEyzr7zAHvsscd6p59+uplxZpY7m1y3OBwJpQJdGXH6DBgwwLgBGAjwIrvnueeeMw4/um+mc1TQoRXnUCpw2nXr1i2ydSbLqm3btiYnLgy6cLoMVlJ1/rOFfKcbbrjBZE7irBC5wQCd/KgAMgCfffbZguVnJboSybYi14McPJyZdPkkfxGXLJ1FEeeiEhiSIb9r4403NpMW2cK5SMfoHXfc0XwOeWy8+DvCD78L3VldoItrofcNzJkzp9q/kZ3rguvycOONN5rswqgg05QMrKjZfvvtvQkTJphsu2SBl6zR22+/3bixyBSNC85lJpzigN8JV9t3331nJrS23HJLI3xxnpLviGDXsWPHyL4v0aUcx/JRwHHJuc42CYNzHefkVVddFdl3ul4/XJcXQgghypWqCdtCCAONKHAEvfbaa1W2yE033eStvfbaxgXgSjEMXgsBzrI999wzrQBKKDri3RtvvJFyAEP51UknneRddNFFoaWeOC8I+o4SHAYHH3ywEQM32WSTKj9LPjbSwfrmGo5/zDHHeMsvv7wpp+ZFwwQaIiCqjho1KqfPrkQQd5NdPJRX7r///t5dd91VsPXC5YVYziu5DBfBnAkJXvPnz7dyxDJh4QICHYJ9LlAynyr2gHOB+ATEJ9fmSAgtXCsKSZhLtGnTpk6fkdjkyAa2Wa4TCGGfySRGv379vKhBQB49erRxgDFhwXfhtqVxSbC/EQgRtkeOHBn59zNhlypuIiqIgMDVFjc2UROpXM35guuUTYk+x9rhhx/utWjRIufvtKkISGSdddbJ+TuFEEKIckAlwEIkgVOFErhUAg85TD179qzS3S8TOLaKpYStEIMDG/fj+PHjzaAxFddff71xEaTKeSMTK1MHzmzAqUhZEyWNOFhwISLSTJ482elzEGLokpkNDJjOPvvsaqIDouQDDzzgde7cOavPrWRwlCZ3j8TZU0jxDz766CNT7pkMxzauJlygmcQ/yh/J05w6dapxzrlw9NFH5xRXgKiaygmUCM7axDJ6HDrkh3GeIxDiIkssGUSM/+abb7xCwu/GhEAyXB9cup7iLGeSyRaubdyXooZy7DjASYsQxX0v2J/cM8mFQxQEhEA6M1MOHGXHWBx5TIqUC5wTLjBJlk84NtnfNnAO33HHHZF872abbeZtuummThNoQgghhJAAKEQ1KE9D5Mv0IOsygIuz3KlYocyta9eupsQ316BuMhcptyoUlDghVpAJ+Msvvxhx2LWpAJmC2eRSITSTOxa4jHBUUgp63HHHmWP1+eefNwMwXKlkLZUjcWTiIbIlDq4p6x84cKBXaCiRDwvyp3mDbaMJzj3ETdy0CCIutG/f3tnRlq0zB2EIkY+GCYjclDyfeeaZ5rimPJtBPg4yQJTMtRFIrnA9C3Nkse442myZOHGiyUNEoM1XA5N8fS77FDf3+++/HzrJg3v57rvvXnZeUxJM2SzOsFxAUOQzXn311bKZbOPccHF+sg3iKn1OBfdCl2y/QADOFURjm4YsgeMWAVoIIYQQEgCFqAKuLkLMbWCAbdPYgXw7Gl1UEgsWLDC/s4v4B6kEjuHDhzt3eC0mEFRw6eFqcgFBlGYzOA8p+WVgTWko+V041RhsU0aHSEiJNAHwfAdiUTmxcOHCWD4XMTcAN1KyI9A2M49YANtutjYkD/oRvsgXc9leOAU55ii7tAVRigY3YfltNgI3x2WqxjlhUGrMwJzjlXL2ZMhC5DpC11y2cyFB+OM6lO5cdSnX5FylmYQNa665pvP+sCHqCQMEPrJy04FYxD0xsbMtrur77rvPNIqxhU6zuMtPOeUUky2HE23EiBHeSiut5JUL5E265D4yMenaNCRX8pF/mQpc+Tid09GoUSMz0cOfQgghhJAAKEQVeFB06SzHYOPcc881offJUHpHZ1sGhlGWOJUClPlkU16WKqibcs1ShrIsSjjDGgikAxcUxxYNUhBnUpVaIZ4gBD700EOm4zA5ifXq1Yto7csXMhUprURwC1xJtiC4IsrhTENIJOMx7DqQDTjEErP7yHhEVHeFdaLjLHmHmUBguuSSS8zfuQbaNhMIrm0cg8H7XUB4zSQYkenG57uIrPw+ZLSR65grBx54oBG30nWJ5mfkE3Jc2IKr2MbVSH4s7sOoyeSKYtsjrFGynKlhCPvnxBNPtHKDcWwjUCeCwGvrlOfahmuURjlMguAEI3ey3HDN78z2PbngmmfpunwmcL6TJZp8nnP+kwvMJC2xClEKj0IIIUQpowxAIRJI14k2DMoGr776aiMi0CAEoefkk082oh//RqlmHM6NYoYB4K233prVe1N1+S3lh3eaKiDIZdOdMSh9ZYBrk3+Gs4ayQgSDHj16FG3XyGIBQRX3HjlkiY4kG7bddlvTKCgQWhH/EKqiAFEtcdKAEvhsQTxEkE8nntEsBEcp2ZaBMGQrOLqU/2UL7l+uKQhMtnAdJjYAZ1ku7h86kNOowka4QAR0KVenBJeSVRuSG8JE0aiDzrWp1ouuwxtttJFpnkDWKA5PHKVPPPFElX2Oa5Y4As4jhEIX8TO5BJmc00xueY5Vck9Zn3KHbsYughkiaqp7aFzstddeTg1XcG5GDbmcdEbnmApEeiYxEK1pDMZzGW7XTJMNQgghRCVQWcqEEBlwHSjygA4ILrgXGKTS/ZKBajmVIrlAaRsOpmzo1atX6L83adLEK1UYSCMKcGy5OJj4nSkpJKvOduCCaBM0sRg8eLDJUEsH6+WSXVZOIMyTrZitYyas3BORJorzHsde4sRBLh1NEWvorv3ee+8ZR1xiN0wckIiY5LXR/ANwy7z99ttesUF5JwKrjcOOcyfIDEXowo2c3MXblrCmH5kmhVywaZAEiG843tKBaMz9B3E6HTijaLgUHGMcI5RjI4TvsssuphS3T58+1a7jY8eONW5IxFXew/UGAYhrjmtEA+8l1iB5MoL1YsIj7Dyi6QNucJquVALsT5fmFd27d7fKmf3qq6+8M844w7jKaXjGfZdzPhsxn2eg4NqRCe6BthNTrhAXcPzxx6fM1cSpzXcjHgshhBCVjARAIRLAfeBSrrvvvvtq+yWRbQdRBgc4ScLItntuMbDyyiubPzmuKNO1BbEDgY4STpewfhxfwAAa4Qc3V5jLD3EQ91E5dcx0waXUPxn2JY7M/fff34Tuc3zS/IKup/w917w6hJhEGKjnmm3K8YAoRkYf5ZqUdiJWUcaceH499thjXjGCWIT7K1NOHPuGslAcaYmCKuXQCFhk1Lk0RiFjzgXXyQqXxkAIzJzfYcJ+x44dTUMgxDlcT+zr5AktrgPkppG1GgipONXpzotoSCk814SwLtSJ0LgDMZlJhjfffNPLFgToZFhHMv1wvZL9iDjFeYYoiNCIQJkKrpMIQJm6ZJcSHH82kwpcczI1ymL7cD9AFKcEG2Gc0nauARwDO+64o2lC5Ar7K9M5xX7FoRfXxCguP5tKAc6PXLqcCyGEECWPL8R/DBkyxO/fv7/5s5Lp2rUr0+AZXw0aNPBnzZrlVxpTpkzxf/vtN/NnGL/++qvV9kt81a9f33/jjTfM++fMmeNPmjSpyrY9+OCDnT+zZs2azu+J+tW2bVt/6dKl5nf466+//FatWlmve4cOHfxbbrnFnI8u37nOOutU2yd//PGHf/PNN/sXXnihf8UVV/jjx49ftl6w3377FXxb6fX/2+Djjz+usv/YV+utt17W26hTp07+vHnzrM7vXr16FeW+WG655fxzzz3XatmWLVv6CxYsSPk7Llq0yN9nn30yfs7VV1/tu3LppZda/04rrLCC//fffztfZzkePvjgA/+BBx7wH3zwQf/TTz81/84+njZt2rLffe7cuf6TTz7pDx8+3H/44YfNdSCRP//802/dunVW+2PllVf2mzVrlvX+5HsTr0HJv9+tt97qt2jRotr7ttxyS/+ll16qsuyLL75o7tvBNb9GjRr+rrvuan73VN9RSnBv5FhJtS1r167tjxgxIu1nLFmyxOo6365du5THZDpmz57tH3300X6dOnWqfeamm27qjx071o8Lrpcux95NN90U27qI8nmWFaLY4H62cOHCsrivicJqNxIARc4HUbnx008/+auvvnrGh8iHHnrIr0QyPTT9888//mqrreb0QF63bl1/jz32MIO2ROGuY8eOZpC72WabOQ8wzzzzTH/VVVfNeoAaxYtBbABiQjafgdDssvzmm2/uvE8RJ7faaquCbiu9/n8bnHHGGdX2EQNohI1st9Paa6/tf/311xmPhdNOO60o98XOO+/sr7TSStbLP/roo2l/T0SyU089NVSw4Pp/5513Op9HPJTfd9991vvplFNOyXlwirDz+OOP+zvuuGMVQeiAAw7w33zzzbTv5fcv1P689tprU27DPn36pH0v9wiET353tmG6ZXv06GEE31Lnm2++8Y855hhzrwx+t1q1apn9/O6772Z8/6hRo6z3Dc+B2cC+YwIwcbJp3LhxsQ9WBw0a5HTs7b333rGujygNJACKUkMCoEhGAqDIGQmA/8/3339vHFhhD49Nmzb1R44cWbFHXLqHJtx7W2+9deSDRZeBf/B65plnjCPm3nvv9ffaay+zP3faaSd/u+22y0lIcXFdBU4cbto48/IxsL7kkktC98uwYcP8bbbZxogba621lhk4jhkzZtngDLfQ5Zdf7q+55pp5Wc9Se+FAy9d3cY0JY8MNN8zpcznujzrqKOPWSQXnTaG3ddirb9++kQ3y+f2ZIEi+rrCPd9ttt6wcIZxHCLe267fJJpsY4T2XwSnXF87jdN+DEBMmwLANVlxxxYLsy4033thMFIWBU9HmM9hXtmI1x065wDHz3nvv+e+8845xe9qCgG67f9ZYYw3jMimVwen555/vdPztsMMOeV0/UZxIABSlhgRAkYwEQJEzEgCrX2iZvcYlceCBB5ryFtxo//77b0UfbekemjK5MfL1atiwYbX9hFskm1LibF6UWiWKLNOnT8/L9+L8mTx5cpXf+5NPPklbqofzMnFdcctQUoe7pND7sRheiMa4lfL9vcmupS+//DKyz6aMMpUAs3jxYlNCW+jtnviivPPKK690eg8CWxhEC+CSTffeDTbYoFq5bCZcSvUR7WbOnJnz4PS4446z+r4bb7yx2ns5xwuxL9n2/F6pcHEi24ryLOe6P8sJriWukRjcN0plcOp6fd5///3zun6iOJEAKEoNCYAiKu0mt6RyIcoYwuQJRs/UUbHY+Prrr03Y/bx587w111zTNDZp0KBB7N9LN8t77rnHKwboYJkcME8X0WwaHLRr184El48bN67Kv9NN9fDDDzeNFL788kvzb4Sr04mQbpWJLFq0yMsHBLs3b968SmfErbfe2nTcTAVdNensSQMBmiwQJv/hhx9m3R233GC/v/7663n9Trqzsi8SIbA/Kj744APvoosuMsdLMnwvzSDo7ura2TUO6JzNeRu2rumoW7du6L9zfn788cdp30v32yOOOMJ0ibaB5gqXXHKJ9br179/fdI7PBZq5BB2/M3HZZZd5vXv3rnJNzHcjhGbNmpmO6DTOCmtKBN99953pVm2L7XWV5bg3nX/++V6uEJ3DOtIsZe7cuaajMtdPfr9ihePTtenRnDlzvFKBJjFnn322dRdjl2ZcQgghRLkhAVCIHKDr3KeffmoEFrpOBp0VCwGDWrpE0vk1kYYNG5rB3+WXXx7adTEqnnnmGSM6FhrEt379+lX7dzqDurLbbruZrpsIqIh877//vhFFWrVq5XXu3NkINbadQfkMBoy5wPcy8E+Gbp/XXnutd8wxx1QZ4O+0005pxb+AMWPGeM8+++yyrtYMbsX/WLhwYd43Bd2fk7uRu3SCtuHuu+/2rrjiCm/FFVes9rNdd93Ve/rpp70ePXp4M2bM8ApJixYtvHr16hkxO5vu24n8+OOP3hNPPGH1fs4Bru3JYn4YI0eOdLr20TWVCYlcuPPOO60Fjz///NNMTtBJl0kLrkWu3Ypz5amnnvI6dOiQdhk6/8YF+zLTNuIeiljI5M5GG21UbZkJEyZ4p556qpkgSYT77qGHHurddNNN1TovFwP169c3L5djdLXVVot1naKkZcuW3j777GOOsUzQRRzBUAghhKhU7EavQlQon3/+uRGTjjvuOOMqQ+TCGTV58mTvxBNPNLP+O+ywg7fLLrt466+/vtexY0fv8ccfz/t64g7afvvtq4l/gTNv8ODBxgloIwZlyx9//OHFTabBFYIXIl2yw+T33393cpYkig+Be5IB9NFHH22OBb7HVvwD1gdHUa5wzPH7cSziOkGgufLKK83gB4dU27Ztve7du5uB6umnn+7NnDnT+rMZ2PI7IjLyHSIaEN1djpVA7Et23yU6O6MAh88LL7yQ8ud77rmnEcxydarlCiIX6/rcc885vQ9na7LYh+hmK5rB/fffb7Xc6NGjndYNh3bcglYyTBwwEcREFdcIHHErrLCClw9wZ2US/wCRKi5S7ffA7YkwxIQP98k2bdoY53Ti8YMLmOt+svgHnKsPPvig16lTJ+MILza4/hx88MHWy2+xxRbmPlBK3H777Ua4TQcTCY8++qiZYBFCCCEqFqeCYVHWKAPw/yFHLVVoNgHZjRo1SpsxQyh1viDLq0mTJlbZN+edd15suSl0vI07P4ouwXxP27Ztl/0b2UZ0C3755ZdTrvPnn3+e1fdFmRVEF0fXHKZ0nafJEHMJdi/W1yGHHOIffvjhBV+PuF4nn3yyf8899zi9h/zF5BwtGtqQbRnlutGtMx3PPvtswbcfjR6ee+65rN5LQ5vELEXbzLzgRfarDdtvv73T5zZu3DjnfKrdd9+94PvG5jgeMGCAdSYcx3ime2uUzZHGjx+fscEU2To0SKIxj8339OrVyy9GPvroI+vmV3SyLsV8qt9//93v1q1b6O9J9qRNt2RROSgDUJQahb7GivLRbuQAFCIJ3GLbbbddyjJIfp5plp8SL1v3SK7gaqF8yYY77rgjtjLdLl26eHGDQ+2kk04y5YDTpk3zfvrpJ1Pq+s477xgXZiqyLcuifBpwTj788MPG/XfYYYd5Z555pnEUuriJyDK75pprvGyhVLNbt27m7/zOuE1LvVSXUlNKUU855ZTQkrtShzxFnJVdu3Z1eh9lp8klwLhXTjvttEjXL6z8N5FvvvnGKzScc9m6qigpxbWdKRcwFbaRCa7ltFFksnI9ybeLzPX35LwmGzH5WE4Fx3ivXr2czi8b+P7EeATAHY1zOlMW4oABA7y+fft606dPj/x+nE8233xzExORCbY/zvJShIoMogvIkuQZjNJs8jbHjx9vnJtbbbVVoVdRCCGEKDgSAIVIgtLJSZMm5bxdeAB1EYiy5aGHHrJeloF0urK/XAekO++8sxe3GBAM6Jo2bWqyf2wG0zRD2WyzzZy/D+GGMjDK5sjOInT/kUce8a6//npTIkaDGERIWxhIZhtET/leULJ38cUXe99++61XKiSXkbZv395sSwZrZ5xxhhHcaV5TTiCYIG4ibEbVwAMxJZ3Q7QLNPhJFe44nhG1yTDm3Ntxww9iuFbYg2FEWmksZcuK25zhzgVgFG/bbbz+nzyU2IqprYZystdZaplT4119/NXm3lMe6QCyGK1wfiV7IBOcBk0E29OzZs9pncm7aCnUu91gyQ22y6AoB5zelymHbl8zMgQMHmmxJW8G2WKF8mbxLBM9LL73U22abbUr+dxJCCCEiIzZPoig5VAL8v9LfXMs0E1+UGMXNeuut57RON954Y2xlE5TarrjiirGUcB1wwAE5rfedd97p9H3Nmzf3H3zwwYzLNWvWzP/555+d1uXpp5/227RpY70uXbp08f/9999lJd/169ePZRvH8Vp99dX9adOm+X///bf/448/+tOnT1+2HSiPzfR+yrlsS9eK5bXVVlv5L7zwgim7e+mll/xDDz3U6f2U+qaC8g+2aa7rGJS3U0oycODAot3Gm2yyiTnmsy0NPemkk5ZtO86hVVdd1ep9K6ywgj979myr83n+/PlO5+Snn34aSXnavvvuG+m2btWqlX/WWWeZCIunnnqqSvk0vPrqq9afVadOHXPeZ8MPP/yQ9vrYtWtXc0xwLnTv3j3teuy2226mtDgZl+uv62vQoEF+MbN48WL/+eef96+44gpTov3www+HbqOoytOWLFniT5061f/jjz/MdwtRDKgEWJQaKgEWUWk3EgBFzgdROXHLLbdEOhB44IEHYl9nBsgu64QQFudD03vvvWfEs7DvRlzNRmDt3LmzGfDlAoPZvffe2+r7lltuOX/06NF+gwYNrLOuevbsaX53lxs5mUTDhg3zL730UpNjGJYVxmA8EP8C8TCugWtcGX9hfPXVV9afsemmm0YqzEf1Wm211fwzzzzTHzp0qH/HHXf4d911l//+++8bkb1169Y5fXa6jJd27drl9Nkcr4ixwLoXejtmepHv2bdv36zei7iZCNdkm/fddNNNvgtXX3211eciXkU1OEVU33bbbSPd1rNmzUr5fRyTZKnZfE7v3r39XEBIevzxx/0999zTnEsbbrihf8QRR/hvvfVWlXMDQYnzbrPNNqvy/Qh83M/5nDDq1asX2/Ga6yRbuQxOOXb79etXZcKCvGKyiJlsFaKQSAAUpYYEQJGMBECRMxIAff/yyy+PdCDAzHrcnH766U7r9N1338X+0IRgNWLECCO4MWAkJJ8Qdh76J02a5F988cVmQMdgYN111zVOsOuuu87v1KlTtUEcjQoWLFiQ0zonrheNANK5nWjyguCQrTBy2WWXZb1+iDI0jOB3fuKJJ0z4fDKuDSUK/VpnnXUiOW533HHHgv8uya/777+/yu/E4He//faL5LOT3VeJ7LDDDjl99rnnnms+56+//rIWuQv5QlzHjWcrPgUvzvOffvqp2vajkVDt2rVTvueqq67K6sH81FNPTbs+7DdbV6Ht4JR9GOW2DoThXITOrbfeOvTaFSdsf/b1hx9+aByEmULSMzX/yOVFw6dKH5x+8MEHaRunMLk1bty4Qq+yqGAkAIpSQwKgiEq7sUtQFqJCyLZZRCq22GILL27IQbrxxhutlt1999299dZbL/Z1IjyfzDxeYVx22WXmlciMGTO8JUuWeP/++6/JZiL368ADD/QOPvhgr06dOpGt1/Dhw02WGhl0r732msm3Imusbdu25rv23Xdfb7nllvMGDRqU1Xfw2YTl2+ZTJbLOOuuYVz6P0biZP39+6L+PGzcu740TooR8s4MOOqjKv1100UXek08+mfNnr7baamkbHJB9mW2uIOfVueeea/7+wAMPeHPnzvWKHc5RGpZwvu62227e+++/b/W+Aw44wGyrZDg399xzT2/YsGHeyJEjvSlTpniLFi0y+W1AThrZg0cffXTGRikBZIxxHaaxDX8mNuihedHJJ59scvuiupYFsJ5RQrMErn80VCAnMpEXX3zRKsOUY9e14UqusP3Z12H7OwwaQrzyyiuRrwc5uPlu0FJscD5xfqVrnDJr1iyTKfnxxx9b7zMhhBBC5I6agAiRwF577RVZWDQh5QTqxw1h/TSXyAQD2SFDhnjFCI01aLRxzjnnmO66P/74oxmIXnDBBebf77vvvsjD7QkHHzt2rPmur776ynvssceM4MjgNxigZAsiIJ2D42CnnXay7k6ajuTBfVzQgCUM1+3z3HPPWTUHyAcMWOnyzflEMxgG/AgKN9xwQySff+KJJ2ZsapANiKijR4/2VllllaxE2EIRiEl0Jf7oo4+s3oPohsCXbh8eccQRZsIBETQQ/4hG+eKLL0wzqE022cSbOHGi9Xpy76CzLMIS4geNbRAvP//8cyMARi3+Aderdu3aRfZ5iNpcH9dYYw2vX79+3tSpU6tc12waW3FcjRkzxitmTjjhhMg/k67xtpNx5cxNN91k1TWZpmRDhw7NyzoJIYQQ4n9IABQigXXXXdeIgLnCQC/Z4RYn11xzjXf22Wen/Pnqq6/uvfzyy8blVmwgSOAUnDdvXujPGaDjxHn44Yfzul50RcwWHIyjRo3y4oBBposAhAjNNsbdSFdTXKB0qEZMyaW7qi1HHnlk6L8j7Lryyy+/eIUGUQhxqFOnTqYbM4I1HXRxpQUiUi7Q6TmTOEH33k033dSpIzHC1Pjx473OnTtXObdKgaBr7tVXX21cwrbuv3TH97Rp04ybEIEuFT///LNZBneyK7iAmZxBAI+7A2kmwTgb2D50haV7+meffWacWrbOS7jjjju8YobOzbZdnm3Auf366697bdq08SoZzk/c9bbce++9JXMdEkIIIcoBCYBCJHHzzTebErxsqVevnikr22abbfK2bRngDx482LhVzjzzTK99+/beRhttZMqR7rnnHuNyw6lUbFB2d8opp1i5ShBd8jlQYICYCzgY4wL3oo2bCJffiBEjzO/y6KOPmrJRyvjOO+88Uwr+xBNPmOM1LnAnpRIrs3WxFRrEkLPOOisSsS+snPOpp54y5ZeZznf2XSp3ZSIcJwg5fC7iZa4ibL5h/Y855hjjRHv66aet30d5czquv/567/fff8/4OZMmTfJuvfVWr5g56qijYis7/eOPP7w99tjD2S36ySefeMUMZcqcE9ttt13On4XQzCTA5ptv7lU6P/zwg5X7L2D27Nne5MmTY10nIYQQQvw/EgCFCCkNe/vtt1Pm9+HswI1G2SpumiCri5Ip8pFwVuG2KVQu2XXXXWfEJ8paKUXDPRenyJMLDMDIC7J11T3++ONevkCgss3/CsPWqZQNOCxsBKilS5d6K620UtpyYo71HXfc0YtL4KWcMozu3btnzDvMBwihmQS3uEGopfRywoQJxt1nQ6tWrbx3333XZFamg+OEUvowEasURFjE7lVXXdX7/vvvzfFsy08//ZTyHOG4vPPOO53cbC7fnW8o7X7ppZdiEwG5Rr/xxhtO77GZ1Ck0uLz5vZiw47xDgOd+biOsJ99302V2VgJEZpx22mkmCsGVUjhWhBBCiHJBAqAQKUQByp0QR3CoUU6Gy4LcL2arDz30UO+QQw4xgwcGmQwof/vtN+/KK68sCVdNsUDJlAs0AYgSRNJnn33W5FVR8pZcaot7ErdVNsTVbIVj7bbbbrMeWGVaFrco++GDDz7wtt1226x/31Sk+n6cXTi6gjy6QkGuGflshY4euPzyy52z3BAqbLMUcQYn5rkBkxy24q/NcUH5sqsAk2pygrJZxL+g6UQ2ZbSp3sM13MWlxLUdJ1wxQz4m5zAO9jiiHrgXukD5cymAcEf2K01byILk+krpNzmItpSCkB4nnEuUU99yyy0pozxSgejavHnz2NZNCCGEEFWRAChEmsEj5UEMqHCekVXTo0ePat0NWa7SZ/+zxXWw4Lp8KiifxKlAo4Bu3bqZXDzEFIRdgvsDEH7p6urqCOEYOeyww7w4eOedd6xdk2DrmkQMosyPTLRrr73WCEZ0i03MjMt2fVOBUIGLrVAgPuK8y3fH0mS+++47s51dMw5xxVHSbQMTFWHZXLiZMzUr4thguXROYlxorplqixcvNmILEyeUTyIEkKHGsUecQf/+/ZeJeAhKLk00+JygoU/Y97qSzXvyDQIsE1Y0HUEYpptxVI1zEI9dHIbHH3+8V6pwP+cYtAF3Ks8FlQwCKJNp2WbERt3JWgghhBCpkQAohCgYrqWXlFnnyoABA4zjIznQngE+OXlkJSa6XRAIESkQ0mwH0zRxyKWJSDpcGxJQOu26T8i4o5Scpgu4LnF2UOaWDZkcapSydujQwSsE5GYi/hVDKTICC9mMLlD26UKYWEiDIERaGkkg4iXSqFEj02EcpzNNZHCYkceXKJgiCnKs456yFSMTXYUIKLj86O6LM+/LL780x16yKMl3INbakq6RCoK+SydttksuubCFALGULsdksuFyjsLlyoSADQj7hYrBiIo+ffqkbGAUQLwCE0S5REWUOkQ8uJ73AQh/3GuEEEIIkT8kAAohCgbdf11gQJsLdOalrDAd//zzj8lVSxTOcITgBiTYfsstt0z7fgRDujLHRbpMvzAoZc4WSohxYtFQhvJ3usgOGjTIOVMzEyeddJKX78y9G264wevVq5f5/7333ttkexYanKku7k4C9F1ItTxOSEq1KXVF0LjvvvuMaMT/DxkyZFlpL646XISU/CHUIRAj8M6cOdPLBteSZ7IMbdxClFQH+zaVoEeEgy0IQS6CYTHBsc7xjYi/6667Zv05lMSyTSlVzxR9wLGTyn1ZKiBOcx4MHTq02sQPP+MegXCez2ZfycIbDZ5weSLMFypHL1OznVRwHnO9iyu3UgghhBDhSAAUQhQMnCK77LKL1bKUY6dqzGILgoUNCBph5ZI4onBDXXbZZdXKghnI3HTTTUZkdClVdIUBJ+thy1577eX8HQwmyT/cbLPNjOhDQH7Hjh2Nq4fOqYgKtpCdaSME23TQRPxMdqm5gNCFi4mOnXSVDsDRhuMnalz2U+BCdWm20LRpU6fPz7Q8YjHCBiV9iEapxDYEQfbDxRdfnFNzjHQuvTAo2UegTJc1iJsTZ2QmVxbORhuRCuEvjmOjECSKua707t3blGP369fPOL6ITUh2kvIzSvqjKjsuNAh9Z5xxhnFRkpPKJAgucRzhHIdcG/MNjb24FyKeI0xTfoyDmixXBLV8Q5dsF7h3HHfccaZRGd2lhRBCCJFfavhqvyX+g9wv3E8MnBgcCREGYfgM+hkcMejLFQQlssPo2pnOfUJZbi4NVsgoQkCwBUGPjs7pxBqytv7++2/jHuOzs2lUkA2cn5RJ2kCpcybXYiLsW8o8cb/kCoISZZ02JXKUwCI0psqSQrwKnEUMdl2hhJP9lSiCffrpp8bBwjoi9LC/k0vDE0H0pWT1448/zvh9e+65p/f888+bY5dcRVuGDRtmnZ9G4xo+36YjdNDNFiEnCijbtRXUU4n/OJeycdYhwJDNikgduA8R/ihj5vezFV4RcxBRUuX7IeTT7Z2O1aV+nQ3Axbv//vtXawiTDo55HGfJAjKfgUuUMnCcf6Xu+rOF6waCIJm07Jv99tsvtsiHRBAgcWGmE905J21LtaPg6KOPdrpXcG8Jm1wTolyusULEBZINzytUJeVrvCHKVLtBABQChgwZ4vfv39/8KUQqpkyZ4v/222/mz6j4448//MMPP9xfbrnlqGNa9qpdu7Z/8MEH+7/++mvO3/Hss89W+exMrzp16vjFyqxZs/w2bdpk/B369u3r/NkDBw502k7pXptvvrn19955551+zZo1U37Wlltu6c+cOdMsu88++zitx6qrruq/++67/tKlS837OXZ33nnn0GXr1avnN23atMq/NWjQwO/du7c57n/55Rd/rbXWSvt9rVu3Nsc0bLHFFk7r+uSTTzrtr549e1p9buPGjf1//vnHj4oWLVpkfVxstNFG/qRJk3JehyVLlvh//vmnOR+CfevKO++8Y46nxGOvVq1a/v777++///77fjldZwPmzJljzrcdd9zRX2ONNfwaNWqk3FecCx9++GFk383589577/lffPGFv2jRIr+U+OCDD/xtt9222jaqW7euf+KJJ0Z6fiXz+eefm/uhzfn1yiuv+Pli2LBhTuf+/fffn7d1E6JQ11gh4oDnnIULF2b9vCPKjyFZajcSAEXOB5GoLOJ8aOIz7777bnMMMkDle6LipZdechqoIPrEATfuN954wz/22GP93Xbbzd93333N7ztjxgynz5k6darfpUuXlOLlpZde6vyQMH/+fH+VVVbJWtgJe51zzjn+2LFj067Lc889l1aECF4IFog+iDY2g2FEnT59+hgBOXhomj59uhHoMr33zDPPNGLcyy+/7P/1119V1pfPO+SQQ6qtA9sdQW7atGnLlr3mmmust1WjRo38uXPnOu0zjhsEtXSfi7D+4osv+lGC6OF6LLRq1coc67Nnz/aLDa41r732mv/6668XxYAwn4PTr776yj/++OP9+vXrL9tXXAc4d6OYfOG8GzlyZDXxbM011/QHDBhQlMdDMlzDmBxId3xvvfXWsYmAxx13nPV5tvfee/v5gt93pZVWslovjinuMUIUAxIARakhAVBEpd2oBFjkbiMVFUUxl00wqfHqq6+a0j7Wk5wyMgYPO+ww06W0efPm3qJFi6w+a6eddjIdcKOE0kU6EJN/lAw5dFdccYXpiuhi7eez7r33XlNCTckiWX2Uibnmw8HIkSNNt9c42GSTTUzpV3I5MvuMbEebslp4+eWXzT6lNJOsulT7k7JssuAoF04smyB3bvjw4VZZVd9//33aJiY07OA7/vrrL1MCSNlv8nanmQyfwfGXiXPOOSerBjJ8B41UyJ9MLg8kp+zWW2/1Onfu7EUJ29elI/Vjjz1mjv2oylZ+/PFHU3r43XffmX3FMcTxkI9SzHK9zs6fP9+Uq7M9KS2PoqSXc4+8TUq2U0GeHdl2lBoXI5T6cg7T/CYTdFum4UqUcO0iToH1sIFzjPLsbO4B2XD77bdbNXK6++670zbnESKfFPOzrBBhqARYJKMSYJEzcgCKUp41xcXStm3blM6qBx980D/00EOtXRSPPfZYpOvHNstUOsrr8ssv9wvFoEGDInP+hb1wGE2YMKHKd1Jm6fIZBx544LL3fvzxx36PHj2M8y74eZMmTfzzzjvP//3336vNmuKWy+TiSXydf/75kWzX0aNHZ3Qsbrfddv68efNyLq8cPHiwf9ZZZ/kXX3yxcZrGVSpCab7tdlxhhRX8v//+O7LyVeICwhyjuBKZCcUlmopvvvnGuM5OOukk/+yzzzbOyHTLF4pivc66MnToUKtjhOO/WMuacKO7XOOSHcO5gtvb9VrLtTGfcN1JFeFASf0NN9yQ1/URolKusaJykANQRKXdqAuwEKLkwanVqVMnE1QfBg4twv5xodk0pNh2220jD/4/77zzTLOJTNBZle9//PHHvSVLlnj5gplwl+6+2YCDBTdm4u9FoL4Ln3zyybK/06WYYHycaF9//bVxg9FU5qqrrvKaNWtW7b04OnE52fL00087z87SBRWnI26X9957z/wbTQLonErjizDnJ67EMWPGmGYKuUCTnLPPPtvMCNKpGtdfXEHRp5xyivWydCqlg3OuLFiwwHS1fuihh8x2Tebff//1BgwYYDq3hrk1ee+GG27o9e/f37vttttMV1w6kdLwB+ewiNbtzDGNq9mGcePGOXXAzie4jV2uca7XjUxk0yiH60o+4bpDE6UzzzzTNITBIdy6devQrutCCCGEKBy1C/jdQogyZtKkSWYghDhD+dLee+9tBgTZMmvWLDPw//LLL83/03X3iCOOMB0/Tz31VFMGmQkGowhriIFB99BktttuO7PelItGBd1aKYG05Z133vEOOuggU+pKWaeNaJkNdFamXO25555bVv4fN5Qq0x23W7du5v9dRc6wDpgrrLCCEXZsjiEXEI5t4bhCfEoWoRGdL730UiMof/bZZ2abv/XWW0aIpCSdsthVVlnFKzV22GEH0wGU8vNMouQll1wSyXfeeOON3tixYzMud9NNN3kHHHDAsrJnSr04r1N1GmcCASHwqaeeMiKhyJ4XXnjBlLFnI+bdeeedJnqh2OD4iXP5THD/ZPIg1QRXWMfzVq1aefkG4Y8uxExAqEOlEEIIUZxIABRCRAoOrNNOO8178sknq4g1OAN23313kwXFQMEWBCIEhKFDh1Zzb5GZdtRRR5kcNlt3Bk6xiRMnGpfWPffcY0QBsq622mork2OEUBOl+Aevv/66t3DhQuf3kYuFY+6ZZ56JdEDFfmF/IKgkggiYD5544ollAqCNcJcIbq1scc2HY3kch+RpITKSJxjm0rvuuutS5qYi+u2///7e9ddf7/Xp08cIZ7zyBcfd7NmzjbibjZMoFRyPw4YNM04jMsBSZbshqkWRr8R1ANeeLQjbgQCI+yiV+JeYs8bEABMX7OswyJskI+/vv/82QmTyBAf5ZjifKpXBgwcbx1e2cF0uRsiSdSHV8ZML3JtsXbfHHXdcJPmNQgghhChDnAqGRVmjDMDKhhysWbNmZeximC43hY6RLVq0SJtNREYbOVy2eRdHHXVUpDl0dM7NN8OGDctpnd988820n7948WKTO7VgwQKr9enXr1/O25GOly1btszqvV27dq1y3K2//vrW7x01alTWuSkc33R3tv2ulVdeucr/N27c2O/bt2+Vjs1vv/229eeNHz/ezwf8vnS97tatm8nf4rvJ59prr71Mx2XbrLWff/7Zv+CCC/wNN9zQX3XVVf0NNtjA5Ob98MMPVZabOHGiyR2ky2uHDh38gw46yH/++ecjzdb75JNPnI4xciH5PSdPnrxsG9i87rjjjmrfzbWOPEiuXeneSwYheXGVmE/19NNP53xN2Wqrrfxi5MILL3T6PWzvby6QD9q+ffuM373OOuv4f/75p18IlE8lSolSu8YKoWusSEYZgEKIrLOayO+hA2Pjxo2NU2ijjTbybrjhBm/OnDlOn4UD5pdffkm7DKW6hxxySGiGV5hTjE6fUYJ7J074vcgqS/z9cnUFpXI+0QEYByT7jFJo3FhdunQx2y2sVDYoR86m02wiuCQp8aN0Epcizk4XcEwF0IHvoosusnofjrLAOZgNfC+dYm1JLhOnhJjytm222cY4XQP3ny2cU3HDfqcknn2CczQosebfKb3GqXb88cdnLL3G1YdT98orrzTZXhw3OLTIzaOUP/H3Xn/99c12IceN3EPK3emIzL6NCpdy7MD5SCZg4jawgXMn2cFJ1iS5kpliBvg+3FfkUlYaHCe5summm3rFCBmdtsfyzjvvnJNLORU4jymv3nrrrVMug5uaLMtSjBQQQgghRH5QExAhKpigMQGDd0rZAhjwE6S/5ZZbmpI4G7766ivv5ZdftlqWxg9vvvmmVZZX1MRVoodQ0Lt372VCHOWWiC3k65Hll0sThA8++KDavyHEsH8QG4LSaERHyo3JlaPxBIJEMmS2ZVOODPxeZBKSd8ffaRrCgJfGJS507dq1yv8jymXKiaOMlFw3ft9M5ZzpGDhwoMmPzAVC7VkXxGRKXF3Epblz53pxcvnll3u33npr2mUof0dMRTxG6Esu/WYbU3JIWWwYiImUPLds2dKUM/N3tkmcuJZvc3zysskGTSTxOogATDYgJeAuEIEQ934uJrhfkFuaKyeeeKJXjJBjSb5nJpiIodQ/LpikQ2QPsirXXHNN0+yI3ETycYkrWGeddWL7fiGEEEKUPhIAhahQEOFwcqUbqOL4YQBMdl4mHn300Ug7KzIQtwn8dwVxLGoY9OESGj58uMlbC/LCcFwhduG4QmzJlmQh5oEHHjD5h+nA+YQbKRkcWtmCoIgTJtkNQ9diW/cOAfVk4iXDADsQSxOpX7++EVMJ1qeZxrHHHmsC7hFXER5cweWK+JzKSWibtThhwgRndxn7ESddXOCSs3V3koUZCH0ICYjtgXsVR7ANuH1paoIbENcTn8VxHyWsE4JHWGffdCCAsy8R5LN1p5JxSPdgV7gGjBgxwqsUfvjhh5w/o06dOsZ5XqzgUqaJVKpO6ZxDuKHDOn1HCd+/zz77mGsleZQ4keluTlZslBmfQgghhChPJAAKUSQgriDs7LvvvkZQQXhDWHItfbOFwUyYQyxMKMBdkAlXl0zy8ggqPXr0ME4fBjmUFUYN4g8DpShhoE9DjXQlzYijuKxw7GVDYtMUBKd+/fpZr1vQNTkglavLlrDunggtuMoyheWzX2m8wmA/DFwtuEgZ1NIpl6YbiM+IUomwrRFXKcX9+OOPnX8HSuRo4IDAjXuR0nXEKxxINqXpATS6cSWsiUhUsL9txPpkODZplEGZKy7F6dOnZ/X9uAkRu122YTr4HBqnIOYhcrgQNEygFNkFhOUABP1scV3fUsbWJZ4OXMmuk0j5hGscIiCid//+/b3tt9/eXJ84Xrg/IoLSSKpYwSWOYzlVNIQQQgghKgMJgEIUATiSKN2hFBJhgnIqOtsiLOEsoGwzShDfRo8ebb18qi6fuXRKDJZnQIK7BzHnwQcfNDlr/Fty/lqu0NkXgcR1PdOBGHfBBRdYLcs+xFFEp1HXbLRjjjlm2d85LlwG3HxnIrjnciGVwLTFFlsY0WPddddN6fzDMWcjyFDWhhjw0UcfpV0OcRxxKNuSZkTmyy67zLv77rtN2Szr6AKuRJeSO7LzXL/DBUoAcwGBg32UC2R22pT320A0QTYxADgYEWgC8ZzJFFtx9uijjzZ/Z3Lkxx9/9LLFNT+VUmUyIhEuEWM5/pO7nhcrUZT/wsiRI71ih/sxTmQmKMhgffbZZ4vWfcfxQ34s7myc1LhhmzZtap4ronBtCiGEEKL0kAAoRIHB+cYAFTEhleCCQ+mWW26J7DtxhbmULlIunMnVs+uuuzqtQ1DqyWAqiuYIuDFSiUsILwhnrm4gmwzFyZMnWy+PUwSXJ++xLUVGwEgsmXV1vCWLaBxLuQ6AU4EDhiw4RCSEFMpsETz5vREtbbc/wh6inA18rouYnUkkdl3eJbeMZW1LjLMhV3cP5zjneq5Eca1CgMOR6MIKK6xgmlEkl0EjItpkfyKWBFmDue4nRGwbEK8R/DivmAhBiGZ9+Tui+h133BGZozIuuA5GgWteo0gNpesdO3b0Tj75ZJNPG8DEGpUFlCq75JcKIYQQojxwG+0IISKFgR2igE0pLp096QJ43nnnmeD9XHAR/wJhgXVNNyjebbfdjLvMxlnAIJtOwOShuQ7yU4GrAbEJAQr3DIIqggBCI40qouxIGoADJJvl11hjDdMp9ayzzkobGo8oQNZTorskm32XCAM/cglxrmTD4YcfnrHMl89PbvThAqW1LqWsOEc5nnKlQ4cOzsszwEbU/eKLLzIuT17ewQcf7DVv3jzrjt1sG/Ixyaqj/DAxNy2K7qNBd+NcBSEECEQwGrbQIAjatGlj7ZgMfk9bOnfubIRnGjGEieg4ttj2n3/+ebWf44y6+eabvSOOOGLZv3HO8T46XWdDqqgBMlcR8XFn0dSBcv5U5yIlm0yQUAI/aNAgr1iJSrgL23fCHURlrg2Jwl8yPHNwPnBeFHPpshBCCCGiRQ5AIQrI+PHjnRw3iEEMdBms5oJrvh7LZxLQ+DmlwjYuKlwulNuRBxdF0wDKQIMBN+tKrhsupKuvvto4E+MQ/7LJ00sU7xBTaZ7w8MMPVxOe6BiM4Pv+++9X21fZ7LtkaP6AY9IVHH2JeYRx4SpCRSFaAceKS0nvCSecYETmMWPGWOU74lSk1B0hz4XffvvNHOOUVyN0k99JExgENcRtsgyBCAFXF2MyrgJzqvJXRE7KDVnnQBDm70wU2DT3CURDWzif0glIG264obnWUqZOTiHHMtcMsivZvoniXwDLZQMiO51ZE2GygzxDxH8mcNgONA6yEeJxNXKvyAcIt5TFUzbKBATHGCXV6YRQ10YrqSADVOQOOZ42TnGEQva1EEIIISoHCYBCFBCEA1dw4p122mlGDMyWFi1aOJXshnWTDQO3HRmGQRldMuTvJbq1culICwh7vXv3No6/VN0Z48RVDEvO30O0OPTQQ812oKMtXSTHjRtnBAnKAMPKCBGCUm1f230XdMJFKLXNpENAQSzJB66NMsi3igKOJ0RjW/Ev2P/sJ0r5KdnMBJ072ee2ZZ0sT1MgyvXC3oOgxc8p61999dWzFq0CEO04xnIF52mYM4wmL126dDHXgXTEUSrNZyLMkYvJdYrSdPI1Ux0/bMt0Je+ptt/jjz9eZf3JEsRldeONNy7rEu5KrpM+NrBPEMBpcoF7DGGdJlBkMeIuxa2deAwyAfLqq6+aa0OuJOYvitygbNwWmilF0cRFCCGEEKWBBEAhCgjlYNmCCygXLrzwQqtBNqJCYhOKTJDzxoCCQTbZhgx8ERvJ+UPMSHTauDZv4LMOOugg8xowYIBxUjHYSdVVNm7I5sOtZ8uxxx6b8mcMsHFzIebgKktF3bp1jSPHhk6dOpnPC4PvwP3BviLEn8E/rqRkBxnfx3ojTCJu5IMdd9zRaXnKhbNtBJIMxxZZcOlcoxzDyc0pKD23LQl/9913zcsGtn2mATq5XpTzIbqR+5VLp2HEP4Tedu3aeXGBy5AsynRNS1y/P471RSinnNkmz49rKQ42zqXEUmxEMtyGdI/NhVGjRsXawZWSaxykyR23A/huGh5xHWf/DR482GvZsqWZ9ImiCQgCp8vEhkiNS05sVLmfQgghhCgRfCH+Y8iQIX7//v3NnyI/XH311dgpsn59/vnnOX3/sGHD/Jo1a6b8/CZNmvgffvhhlfdMmTLF/+2338yfuXL66ac7/b5Dhw71i41+/fpZrfsOO+zgL126NJLvXLJkiX/MMcek/b5NNtnEnzZtmvNns1/vvfde/4YbbvAffPBB/88///QLQceOHZ2Ojf33399slzDY7gsXLnTa/l9//bV/2mmn+U2bNjWf36BBA3+//fbzx4wZE/o5l1xyidP6nnrqqRnX4csvv3T6zOOOOy6n6wnXgokTJ5rv/uuvv8z5ueKKK+b0melePXv2TPm7L1iwwF911VXzdi1Mx9SpU/2LL77YX2211ZZ9X7169fxOnTr5Z5xxhn/zzTf733//feh7R48eHdn2+ueff2L5/RYvXuyvvfbaVutQt25df999943sd+L44nojooNrlcs+ePLJJyP53myus0IUiiifZYXIB7rGiqi0GwmAIueDSGTPDz/84NeoUSPrwdPIkSNz3vxvv/22ETYShcCVVlrJiB+//PJLrA9NH3/8sfXvutxyy5mBeLHB4PnQQw9Nu+4bb7xx5OvOg8ADDzzgd+jQocp3rbnmmv6AAQP82bNn+6XMhAkTjNjgcj48/PDDsTw0pRIWE3EV3xAsM8H1OCqhxeZ13XXXVVsHjqOnnnrKv+uuu5xF2Uyv5Zdf3p87d27K3//GG2+0+pyDDjrIz9e5PnnyZP/nn3/2//33X6v3dOvWLZJtVbt2bavjMBuefvrp2I+tPfbYw3/00Uf9Hj16+Lvttps5/m+99daSv04VI+3bt3faN1999VUk36vBqSglJACKUkPXWBGVdqMuwEIUEELx99lnH5PvlQ1R5GRtt9125jV9+nRTpkYJKI0jospVSwch+JSd2mQhUjJI18x0UKZGJholTUxwkE1FGXKujRHSQfbgiBEjTLYYGV9ksQWwvuSI0bCBrq1Rwr6n6zEvMsamTp1qynrpChvn75svtt56a9MgYffdd7duTEHjF/L1osamiYzr+WKzPI0j8gHHC2XlNBhJhsYaXKOAElG60lKuSYfaXKHclKYTydmYATTCIYcuXadwSlBpJpQPONddOzjbdEW3gfLiuJoZ0Qk2DjbffHNTzs+1OyjRplRdxAuxAR999JHVstz7EzuJCyGEEKK8Kf1RohAlDhl2X3zxRVYDxShzr8h3C8t4I1vt888/Nzlr5AGm67SZDQTxI57xHakgG4/sqXTQTZemFsnbkRB/8g5POumkSATT+fPnG8GWrpgIJzR+YP1oRoLYR/dShBu20yabbJKXfEKEZF7lBgKuS1fat99+2/vrr78i60rqAkIHArAtyV1iw0iXBRkl5NQhsvF9F110UcrlON7JjZw8ebLpJB0Fyy23XMqfcb7SAReRj22LIBzk4HHenXLKKV6PHj1CBW8mAcit/Pfff721117b23vvvXPKRsyWqMR4fte44JoWB+Sj0ulc5BfOCc5nztNMkOsohBBCiMpBAqAQBYYurAxUcbs88cQT1t1BERBw6sXFrFmzjCPoscceqzJARNSis+yBBx4YyfesssoqRrhhoD98+HBvxowZy3621lpreSeffLJ31llnpRXShgwZYlx2YdBRl8HzTz/9ZILrswUhatCgQd7QoUPNtkkEBxPrTwOJjTfe2LxE7uBKdYUuq4UQAGn0gMvTxhlHYxWabdDEBoGIJhNhXaxxx+ZyzLrSr18/I/Kna1YzcODAyMS/NdZYwwj0XPMQIVOJgQjsvObMmWManiBUpmoYMX78eONmTG5MwfJcB5gkSCc6Rs2WW25pOurmAk2YXLq2u8J1Ng5cussi7NIYB8cn7lgcwGoKkh1MPtHdl2Pmjz/+SLkc9zKEcSGEEEJUDjWoAy70Soji4Nprr/X++ecf8/DYt2/fQq9ORYJ7rXPnzka0SgdiwauvvmqWjQJca5TR8f0IEpSu0gkU90wqKD1FCIjCVRfA973//vtGREEY7NChQ0YHzYQJE7xtttnG6vNx7gXljC4wOD3qqKNMp9x03HrrrcZpKHJn0aJFpvz39ddfd76OUVKOUISAsO+++5quvbi/OJaiPF4Tjw/K5xF+bdxUrAPrg6sWEABxkDIJ0KRJkyqf26ZNG2/ixIlevkCQC4TJsK7liHaIrFGAsMU2eOaZZ8xnI+x1797dbAc6frvywgsvGGE1XUdozn8mWvJVJs/1LJvfBVhHXMV0nA4TiNPBscPjnc37cIrR0TfqLsOUlnJvSQffSUk5Dm+iDBJFcsr5cZzGJVCWOzxHMDnGvT2YmODas+eee5pnvC5dukT6fYGQH9d1VogoQRzn+kO0AhNfQhQ7usaKyLQbp8RAUdaoCcj/+Pvvv00zAbqgEnxP4Hs+ocEGTSPShcGPGDEiku+aOXOmv88++2Qd7D548GA/Sgi5p/PpO++843/77bdWTRsOO+ww6/Xt0qVLVus1fPhwq8+nkcoXX3yR1XeIqnBsZdMoIezfaWrz2GOPRd6d8o8//jDdYZs1axZJo4TmzZub7sOJvPHGG6YBTqb3rrXWWpE1bEjVFfSee+6J7DvYJ+l+TsOR8ePHW++z6dOnW3csHjRokJ9PaFKSaZ1oBsVy3bt39w888ED//PPPN02SXJotzZs3z3R2pwlE0FxqnXXW8S+//PKMHcFdrqO2Lxrj5NpAafXVV692Tgg3OC4++ugj01gpzo6nCqgXpYSagIhSQ9dYkYy6AIucqXQB8J9//vFPPfVUv0GDBtVEHTo5fvfdd3lblzlz5vjXX3+9v8EGGyxbj/r16/vHH398ZAIT37HlllvmNMBr2rSpv2DBgpzXZf78+UbwYbCa+PmbbLKJEd8YKIbBd9epU8dpnV0HQNxw27Zta/35J510UsbPXLRokT969Gh/zz339NdYYw0jIO20005G2LXtLlrOsL9btGgRqRjBeUy306hAnFlttdUiF034vZmESGTMmDHmXAtbHtHroYceMh1Vo1qHSy+9NPR3PvfccyP5/JVXXtl6Wa5RNgLQ1Vdfbf2ZnHN0hc6nAJOuGzAC74MPPpjT4JTuxOkmjlZZZRUjqKbir7/+ytg9lmNzu+22s97OH374Ydp1vuKKK6w+Z7311svr/hLZocGpKCUkAIpSQ9dYkYwEQJEzlSwAzp492+/QoUPaQQgDqM8//zzvF/sZM2aYB5WoB0Ds6ygG86NGjcp522caVB5wwAGhvz/bxXV9EW5ceP/9950+v3Hjxmk/b+rUqf7WW2+d8v0bbbSR/+OPP/qVzLvvvhvJsZn8WnPNNasdR/w/Tj4EEFvYh3GIf8EL93GYiHTvvff6Xbt29bfZZht/jz328G+66aZlYiHCMa65KL6fa0MY5513ntPnsI0233xzM3nBCzFv6NChft26dZ0+h2vvN998k3afbLrppk6f+fLLL/v5BHczAvTuu+/uL7/88su2z1lnneV///33ode2SZMm+W+++aY5H3766aeUnz137ty04l/watSoUdqJLK7Fffr0qeakZH2POuoos04ffPCBX69evYzf1atXr7Tbg+M1lagd9ho5cqTjFhf5RoNTUUpIABSlhq6xIirtpqZ9sbAQ5QvNLshqSgfNKcinIuMmX5CjQ44Z+SRRBteTkUX34Sj47rvvMi5DHtu3337rTZkypVqTk6OPPto0QUkHmV1h3QobNGjgvL4u76Hxh2umHw1CUmUnkg+3xx57mLD7VHz99dem62liM5RKI5vmH7aZWOTNAY0ZaHZB4w7OLxqH0ODmtttuS5t9Cbfccos3depULy7oxEtuV5ARCGQGkkPJ+tPogrw7svLotArLL7+8Cf6nWUaupGouxPZxoWfPnt5HH31k8v14BdfYTNs3Gc6FdI1JgOYRLrgunwgdwGk0QsYdmYlslwEDBpjrWyrImaJRzIsvvmiuA9xHyKAiv4UmQomw38nF23bbbU3OKw0x1llnHZMlSA5p8jWULNYvv/wy43rTIZtmRakgQ+b6668322b06NGmKRNNoH799Vfv3nvvNecJ3Zefe+65tI12OE5vv/32tOvC8etynnM+CCGEEEKIHHGSC0VZU6kOQLKRXMpIn3rqKb/UIWMvKrdSquOFmapnnnnG33XXXass365dO/+2224z5btfffWV9ffgGiKzMBmXMmZK2FKVE4dBaWU22+Tmm28O/bxbbrnF+jP69evnFxKcceSqUZ6db3A9RXV8Jr9OPPFEk+1Zq1atlMtsscUW5ndP5eSKKvMv0wuH1CuvvOK07Tjv2H5HHHGEKaHnfNtll12cynNxG4bBseBSvkuOZzKsV7bbgxyzVLiWjD/++ONO2zXYtldeeaUpJw/7TJxy9913n58LXOMyudFx43EcZuN+5Drq4nZNt564OSkbxsnYsmVLv2fPnubeYgPvddlfbdq0yXmdRbzInSJKCTkARamha6xIRg5AIbIEd1m6rpHJZOoEWwrgBIkKHCHJ4FDBVYnj5eWXX67ys88//9y46ujwmsklkgiuoYceeqjav5988snWn3HCCSc4ddPE6ZUNN954YzWXDuAuswX3DZ1w8w3uMrpv0pG1adOmxnm24447eiNHjoy8S2iY4/LOO+80zra4wIl63HHHme9KxYcffmi6B4ctgxstndMrSnBI7bXXXt7bb7/t5Bru1KmTuU59+umnxulIV+Rdd93V6v0429jnYdCZtV+/ftbuv9atW1f793Tb3aaLdyp22mkn68+hS+l2222X1XmNEznVebBgwQLjfhs1apSXLYcffnhGN/p9993nXX755ebvOAnZzy7X0UydeW1o3Lixd8YZZ5hzBSfjTz/9ZNarY8eOVu93dbTXqVMnyzUVQgghhBABKgEWFQ9lgXEuX4ysssoqkXzOqquuakrUkrnuuuu8G264Ie1733jjDVNe5ireJHPkkUcagSoTlOmddtpp1t9FmV6m0uR068nAOJG///7b++KLL6w/gxLTH374wcsnl112mRFGHn300Sqi+JtvvukdfPDB3v77729EjjhA7DzooIO8448/3ojEcYH4ESbOhgmhL730UrV/t3lvlLAfELlz+V5EwUceeSRUrE8EYfS8886r8m+TJ0/2br31Vu+KK64wgjjC6DnnnJP2cxD+U0UMrLvuul62ECWQCpeJAI5jylldJ00uvPBCq2URxsKiIvi3jz/+2Hv99dfNMZ4sJH7wwQemRNiGoUOHmrLqbATVfMZYpGKbbbaJdXkhhBBCCFEdCYCi4qlfv36syxcj7du391q0aJHz55BfhbiQ7DC56qqrrN6Pc8QFcrTCnCQ4g/bee++U79t+++2NExFXm4sAmAvJLjHX3DOIS2wLY9iwYV7//v3TLsN2xkUZBzjPyB1z5YADDnBa3uWYCxOxEM+bNGni5RPEIhcXYBhkiY4dO9acm8nnPuIK7lqOgeAcY6KDbduyZUvvlFNO8S6++GLjzFxvvfVMTiUOQ8TAxHOSzLoRI0aY/YhbMAwyP7MlXe5chw4djHicCfbdoEGDnL+bnL3ETMZ0IJqSxxjA+wYOHGhy/Lj2dunSxUxIbLjhhsZVGAhyd911l/X6MKGAe/2VV15x/l1yEWGjgu1ApqEtJ554YqzrI4QQQghRCUgAFBVPmIMtHTZus2KHMlgXx0wYOO94JfPkk096f/75pxcHm2++eei/0wiB5ggTJkzwevXqZZxOLHvYYYd5r732mhE+cCtmKrekjO2ff/5Z9pk0VsiW5GYjCDAu4jHC6hprrOHly2WWSfwLoMxv4sSJkX4/296lHDwo48SthlvRtuwQ8cqFsNJKzp1jjjnGyzfJpfTZwPHHNsNZ+s0335hS019++cW4HTlXAjEfAQtRkFLWZJcaTsRnn33WCLZMAHC+IBYiSOGYpYSVbcT7aPRA4ySaivDi7zTQOPDAA7Na/3322Sftz3EqpruuIWZyPUhuumHDW2+95bQ81xxgu1CeTOk0zTSSGyj16dPHCKmI/a7nFeXdRxxxhNN7aEJE45Ji4JprrjHncSYQjV0b0AghhBBCiOpIABQVDwPdTTfd1Go74DbL1I2yVKBMLZuOoeSDkT81ePDg0J/bdKPMNnOKEtFUIF7QLfPuu+82pXR0H8XVxOA72aWYWHZK1h5iIQIhzhi6wnbt2tUIBem+Lx04DXEkJR87iCO24Ggkgy8fIJ66OOPYZlHywAMPOOVwIsIjXOFmQ2zCdZappLNZs2ZWDrFEUmW9UUqezo0WB5R7RgXbbIMNNvC23HJLb+211672c3LsEAHTwfGCaMj1AKE66EYM06ZNM65b8guZEEDo4sXf+Tf2Hd/tAm6xTO9BTKJMmWsQ+wiX2cYbb2xEL64FCGzt2rXzssHVwRu4d9mW7733XtplcQv27dvXKZ8U+D0RGG3hOnjuued6xTT5RrZoqsxJ4JoZVcd6kbq0HmG+kjvPCyGEEJWCBEBR8TAouummm6xCyclIc82OKlYIVUf4QRQJc2HgWGOwiNMHlwn5YAzWGERH6YBq3ry51XKUIKYbKLoyZ84cIwz07t3b++STT6o4nJ577jnTpCSs5NiGHj16eCuuuGK1fz/99NOtB/k0UckXLk0EIHF7RYGr82m11Var4o5EuH3nnXeMaJos9vL/CLo4snbYYQen76FEM9Uxy7mDWJwv+J3zdSyQUWcDDkJct8lC5W677Wb2R7r3IZBdcsklVuXUbGeX8tg2bdqY0lpyOMndxImIWJlLIwnb61Ti8uRNpmtckiyqI8q6MGnSJOfrkkuzlHyw3377GfEJBzIOXVyqTHww+cJxSKm5GoBED5MbZPDSMIhYAxr2cC6SAfvwww/H3vBJCCGEEIUhc+2FEBUAwsDTTz9tup+GOSoQggYMGFAtIL/UQVAj9wthk4HWjz/+aMRAnDYMwMIEN5w/6QYHbdu2dR4AErCfrrvy+eefbxyLUUJZGS6/TLlfrB/OJVvWWmstI2yEgfsIIQMBNd02pDSOnLB84dpIIOrBYSqHpsvylHdSmsoxzJ+zZs0yrlEaUvAzctYQCnGE2bpU0zkGcbjR0IEyWI6ToHSc7DvOAcrJo3LU8PvShCUfUFLtAmJBYoMG3Fo2gjK5hrjjyMrkPVxfKQVPhv2Fe8/1uhI1iGe2ZercL3CuZWqElAgOWBdBmYko18YwxVpGi5h/6aWXmpeIH66FnHucV8kQB8CLex73ZNduzUIIIYQobiQACvEfuMEoTaMckUEwXVhxce26666m8QEB7uUKg0mcflGAYIaTwDYHkG3LIP+QQw4x5XtjxowxAhMDDzLDaDzg6tzKBAIFAfo24GS65557jEiKqJPJeYSQnM4lysArGPAy0Epks802M1lhro0tciWV0y0Vrk6lTNiW4Cdup1Qg8uG0TCQQShDScJIi9GeCY5JjOR1cE26++WZTDv/zzz+b76GklhJwBB2cZxwzCJKvvvqqly1kxCFi5gPXxjyJy/P7u2Q5suxZZ51lmoxwHcBVyTZjEoZrCFmBlHu7CsRxgMjJK52zMQCxlokAnG0uzJ4920xM3HvvvRmXRTDluuRCmCtZVB5MqIWJf4ngDiQ24frrr8/begkhhBAifiQACpEADgwEJ14iO2iccdFFF1mVsDLAD5w9lGlS5oj7EOcUgw9+vtFGG0W+K1wy7BCCEXTIMKPjJuWvv//+uylbxbGEew4hiOYjlKDalPgiKvOiPJEgfwRPRDialxRC7Nh///1NZpptnhjl4FGCW+qcc86xyrlDGM6lkyxCMy7BCy+8MOUylCJSBm7rfsEpm3ycUraIcBfkx2UrANI8I58ZaMnNazKR2FkbNx/niS0IZJxLNKXAeYzgz6sY4bxkYoiSScTeVJAnGoigNg0uEuHawXtxRKdzHSP+EV2A+Jpcgp1u/SnNFpUNE3NEnthAU50LLrggb/EDQgghhIgfZQAKISKHzpaE2qeDBiSB0wVHHiH/vK644grvtttuM2W0OOoYtOLMjBKEN9flGZyTC0gZOKV9L774oskYQxAcPXq06VDqGuKP+In4RTdlhM9COZ0QfXBi2TplESoDEC9xMj7yyCNGtEAEykZ4t21OgLsv1wEpg1q66u65555VtjnOTRyCNG1o0aKFFxXZiFqIR+TW0Vk3UwfrKNlll12clk9sJDR//nzn78vmPYUCVx8OQATo5A7hNEHhuvfmm28uK+VNPE9sYHk+F3cykxTbbrvtsuMTQZnjgXMtiBigRN1WpGaCJV8uUlG8EFdg23CJJlk2blQhhBBClA5yAAohIodB65AhQ4yYQBg/YllQhkn5JiV/lMIyeEVEoxtkKvcXQg3dfXG6FGoA65q1VYpQeky5aroBH52Ng9IxtglC7XXXXef98MMPy5ZBBEXwQsh1KRXm++keSxl4Knr27Gk6/0YBxyYvXJy40BBeWrVqFUvmFdsBIZvydpsyzYEDB5oy8MRGJ/kCFytCV6YuwECzBly6AQiz7H/bTEmWLTV3ESIxpbdc38gQDcqVOZYS3ZCAKxixjsy1TNB0KdiWZAgi2NExGRGGYwKBMdlRiEuaDMrkkvew/aRSzsLDNZNmRG+//bZxBRMXwD4nqzRf2OafZjtZJoQQQojiRg5AIURs4BZ7/vnnTUMGRCIEHhonUEKK0IJQQM5aptJPynBxv0QFzkIXyIMrdxAd7r77bm/EiBHGiZkIwuvVV1/tvfHGG2awykAW9xFCbqL4B+zTxx9/3Ii2OOlcvp/SNMRixI+gA3NQukg3VcRJ17LKTCCOkEFICXacgfc028kk6CFCkoNHOXYhxD9g+1KGatMBmxLBRCccAlim3MREKJEu1Vw6OqfSKIlrGb9zsvgXiIW2zloyQcOaLrF9EQdTHfccK+wHuueGwflDwxqb8noRH0xk4fgm05LJDiZIKOOm/J19mC8nbCVMZgkhhBAiNRIAhRCxQ0kczRkQWxIhZ+3XX3+1+gwcgK7uhWy6uybDOgdZbuUOYgElye+++67JOXv//fe9r7/+2mS1UaIbiAw0vqCbcTpwRlEWHXTHtf1+yqwRwRAsEH7586WXXjKfVQzNILKFkmLKN3faaafQn5MhiKMMN2yhwXlGGSqus1Ql4zhBE91/AS7dum1yQkudQYMGZbze4BLMJXf2pJNOMudImJiK4ENEAREDto2PRLSw3Ykb+Oqrr6r9DOGP6ynn3IIFC2Lf9K7dtCth8ksIIYSoJCQACiEKBll6LqQrD3WBoH4EJdu8uOS8r0oAwQrRAGdcYrYhDj/Kfm1AwMNRmA1169Y12XdhrqhS3qaIfDR+IWsQ4QZhlQYhiNtkvhULuNooA+aco7y1ffv2XpcuXUwpKaJ9KkcubjPKYzNB52SWLXc4d2jiQgMhmu2Q5QeI6T169DBiO009chG3Z86caToPpxPbyX1jn33wwQdZf49wh2sg+zlTWTzualyBccO6BMdg3A2XhBBCCFF8KANQCFEw6KTrQpSD1wceeMCUmr711lspl8HN5OJoqgTYXum6oCZD2e6JJ54YyXfjBvztt9+MqEJ+Vpwlu3HSrl078yp2cACefPLJ5uUCDYDYP5S1JrueKL/v37+/EawqBcQ9mqXwwpGH04tJhagcrTQMsWm+Q54gGZqU6Iv8cOedd1qX91J6f9FFF5nJj7jA0Y7b1GYSh+s2ZexCCCGEKB/kABRCFAw6yLpg21zAVtwglwmHU3KZE5lzlKEOHTq0pMtO48C1I3MUHZzpEk3TGHLXaKix3nrrmews3Jk4bETxQT4eDQRoeIADjhd/598qSfxLhusJAk+U1xVEJlvo1E0Wq8gPjz76qPWyf/75p/f66697cUOe66GHHpp2GZoQ0WBGCCGEEOWFHIBCiIKWRNo4V7Jt3pEJXDi4myjFZD0oocMhQei+SL3NXLdxOgEYVyeuPkoi6TKcvO0ZQFO2hnspEbr34ma67777THdd12wrET+IXNttt515RQUOOvLucEvRUZVuqnQt5hgha6/UugrnCqW9ZHS6TKJ89913prxexI+r2JqPCQ0ayhDNQLYtE2AI8wHbbLONae5EubhNIyAhhBBClBa6uwshCoZLMw6ga2JcQgVdV3GX2Yh/lHRR2opTkFJOOt7iRnMpjc0XiGuUXCKQUc7F70jzhW+//Tarz+N3dXEvMaAME/5uu+020/iCzyMbjY7RuPp69eq1zDVIPtqRRx5ZTfxLBOGWgH2ajojyZt68eSabkP1NV2i6i3MuciyTqdi6dWsjDlYScigXN2HdodORr67YiHu4AIl0YDKFcwixkkZFRxxxhMQ/IYQQokyRACiEKBh0nE3VaTQZyj6LoWnAO++8YzoaI1RRQkxJ43vvvWfcaPw7YhsupWIAdxzrdNlll5kmE7hLGOjRyIHmHgMHDsy4rjiGKIfGYYVIR9MKl86QyflxiH9sO/49WYTEzYWwutVWW5nsuCuvvNJbvHhxxu+gKcU999xjvU6i9OA4RQx++umnUy6DgxdXE+djpUAO5vrrr+/k/mISQOQHJolsoTlHp06dvHzTpEkTI57jfhdCCCFEeSMBUAhRMMjCevDBBzO6WCgjfeihhwrudiGLbtddd/X++OOPlCIFYhvNDwrNE088YTo4UiKYal379euXNgz+ww8/NOICHZPZT7iraCCA6GkDzr5k0ZZcxfvvvz/t+3CiIDYiPNoybNgw62VF6YFTafTo0RmXo8EGjRQqCRdnNNluCD4iPxAvYQvZmBLhhBBCCBEnEgCFEAWlW7duppyPBg9h0E30jTfeMPlwhYbSWTrRZuKKK64oaDkwrjnW1QZKJymlTOazzz7zdtppJ+/HH3/Mah26d+9eTdyllNem+yRMnjzZqUnM119/HWmTGFFckPlnyyuvvGJy7iqFY4891uQg2ky4nH/++XlZJ/E/iIg455xzMm4OIihwPAshhBBCxIkEQCFEUYiAlHHiDCOXiIwvyv3oWPnDDz94HTt2LPQqGoHJtkMjwlUhHWnPPfecEdBsIEONUuFkTjzxRFNSmQncmZQEN2rUyGQM4jBCgMGBWK9evSrLUjL9+++/e3GA0Fhoh6iIjwkTJjgtT35kpcC5hzuXDM1UcC6OHDnS22yzzfK6bsIz8RC4UmvVqhW6Obh+MsnVvHlzbS4hhBBCxIq6AAshigLcKeTM8SpGbMW/gFdffdUrFIldHW2XP+OMM5b9/8cff2yyDm2g5PLUU081gmEm4nRF0iG6HLpWIshyrBHMTz7mjjvu6DVu3NirdFKVske1fKlDQ51PPvnEdHVl8iEQ2mlC0bNnT69Pnz5OWYEiOrgu4QrnGjl8+HBv3Lhxy7pXH3XUUSYnsByuXUIIIYQofiQACiEqDhx6dDuk2ywONppOUGqcqQOpC67LRwmDy1yWf/75553e/8ILL1gJgDQscO2IaeNChBNOOMErZTheLr/8ciPezJw5s4pzi2Y5CAg4LCuVli1bmo7WtqyzzjpepUG2H02IKOsnp5SS+NVWW800lxCFB4ffgAEDCr0aQgghhKhgNOUohKgYaHxx2223GSfMDjvsYMqMDzroICMW0OiC3LtUNGvWzOm7XJePkkxiZjLJ+WGzZ892er/t8q6l3GQQ2ogXiEM4aUqVOXPmeLvssospFUwU/wJH4F133eVts8023qRJk7xKhYY2tnA8FKKbarGAm4xMOc5riX9CCCGEECJAAqAQomLEP1xqJ598sskVTHYE0nF22223Nd1GU+UUNmjQwPr7jjjiCK9QHHbYYSnzpsKgRDAR1y6htssTiL/ddttZfy5Opscee8yUh6cTO1988UVTLluqnH766RlLrimfPvDAA81xXIlwTKfLuEukb9++Tsd/1Hz//fdGzD3rrLOMIw+3caXuNyGEEEIIUTxIABRCVASUVmZqzEGH3/3226+aCwsQmOi2aQOlmgcffLBXyFKzQw45xNqVl+zM23///Z0aauCitAVhxKYUGMFnyy239Pbdd1+TSYh4myjAIgZddtll3kcffeRtsMEGXqlCqeYDDzxgtez777/vnO+YynGIaProo496r732mslxLHbY988++2zKbuEBvXv39k455RSvEJC717VrV69169beBRdc4A0dOtQco4je7du39957772CrJcQQgghhBAgAVAIUfbg8Lv22mutlkX8u/fee0N/duWVV2Z0sBG6P2rUqGodcPMNpc4IaJlKJXHYJYt9rVq18vbee2+r70GIQzS1ZfvttzcdguvXr59yGToJ33333cv+f8MNNzS/z4wZM0wZLEILf+IQzCQIFTuIcIsXL7Zenk7Z2cL2O+2000x5KJ226bi98847GxflJZdcYsqNixk62CKiUbqfXNrKMYLAf/vttxekG/SUKVPMtYEO3GHQoIOGLjSAEEIIIYQQohBIABRClD3vvvuu991331kvf99994X+O6LVmDFjTMlmWDkwmXU4tMhrKzQ4FukmSxliw4YNq/yMktpjjjnGmzBhQrX8vwCElExZgoicjzzyiHPOGOXU7I9LL73UW2+99cznrLzyyl737t3N9h05cmRo2S8NW1hf8hXLpWuma65ftjmACFSUuN98883VGqtMmzbNNCChGyku2GJm3XXXNY5JGoLQrAaxHVHwq6++8o4//viCiH+AQzVTl2sEVpzBldahWAghhBBCFAfqAiyEKHuiFFkQAW+44QYjmJAbiLDCvyH+bbTRRl4xgRsR5yNliJR6/vnnn0YMxImE4JbJ2Ud2GaIKXX6T2XTTTY3jig7K2YALjXw0XpUMoqYL6fIQU0H+HG6/b7/9Nu1yiNeI2zQdyRaEXcRjxDmawzRt2tRkFx533HGRdjEmdxIXYzHw008/mWuBDbhXR48ebV2iL4QQQgghRFRIABRClD2uIovN8jjsCtnowwXcirjuXEEERMhBOHr88ceNU2zFFVf09thjD+MmK5TbqpxwaYqSzfJBduDYsWOtlsVdN3DgQGexDpGR91FKnNjwAsHr008/NT+jrJtsx3IDF6JLkw8crhIAhRBCCCFEvpEAKIQoe3Cp0RV0yZIlsYks5cz666/vXXjhhYVejbIEMbVFixbeL7/8knFZSq179erl/B2pMi3DWLRokffQQw+Z0nEXcJqSyZiKf//91wjmuFKzEaOLmenTpzst/8YbbxjnMKXsQgghhBBC5IvyCFESQogM5aZ0k7XlpJNOysv2DJx1OII+++yzvHynKC4Qpq+//norNyXl0pTUxl0CbyNGJjcXSSf+BeCS69Onj2nKU07gBnbdXjhocUcKIYQQQgiRLyQACiEqgiuuuMJqoL7PPvuYzqhx8uabb5rMwA022MA76KCDTGMAMvW23npr6yyxcgVnFOWi+++/v9kXONE+//xzr5yhizKNZ9I1U+nXr593wQUXZPX5rk1aXJfHYYjDzzYv76WXXvLKiWyyCGkYQr6mEEIIIYQQ+UICoBCiIqBBB8JDOgcVLsGHH3441mw7yisRGCkDTIZupoheNBmpNCjPPvfcc03nYcQuGiUghg4dOtTbZJNNTNnoX3/95ZUrPXr08H744QeTocexynHaqlUr75RTTvG+/PJL03Qm2+OyY8eOTsvjTnPhrbfeinX5YmfzzTfPqvM3+Zou3cmFEEIIIYTIBQmAQoiKASGEAfdNN93kbbHFFqaTKI0u6FJKl1xEJzr6xsVXX33lHX300RmzCM844wzjEqwUKA09+eSTvcGDB3uLFy8OXebZZ5/1dtllF2/u3Ll5Xz9KVp977jmva9euXuPGjU1TFUS6q666yjn/LR3Nmzf3BgwYYI4TGq58//333s033+y1adMmp88lN9DW1Ue5vGtG3/z5852Wt3ULlhJ0PqZBjiuU/wshhBBCCJEPJAAKISqKhg0beqeeeqr3wQcfGPHm119/NYNwSnLj7mqLs48mCzZcd911XqXw+uuve8OGDcu43IcffmiaTeSTOXPmeHvttZcR/xABcSHOmzfP++abb0xJbuvWrc36FzO4CW0y+mDIkCFe7dpu/cHWWmstZ6Gz3MClynFQr149p/dNnTo1tnUSQgghhBAiEXUBFikdOUKkalpQs2ZNI5bpOLEH4W/EiBHWy+N4Q6DEpVju3HLLLdbL3nHHHd7555/vLbfcctbvCY5T1+MV5x/5jOky6/7++28jDo4bN87kOBYrdHFGzLz66qtTntc4Yw899FDn7XTkkUd6d911l9WyiIuHHHJIWV472rdvb/IAR40aZf0euiKHbQtdZ0Wpke11VohCoGusKDV0jY0mZ3zatGmmYqNly5ZmPFuJSAAUoaQqwxOiUaNGOk6yADHPpXwV8YlurInbu1wfaMhCs4XOqR999JEp4XYlU+l1Mi+//LL3wgsvZFwOR2CQW5gLf/75p2mogYDE33lA2X333b3evXubB5VcIUfwgAMOMCIqoibiJQJz9+7dzXesu+66WV37yQxkf+DQzATi36qrrlq295hdd93VSQDs0qVL6LbQdVaUKq7XWSEKga6xolTRNdZ9nPHEE08YswGT9QHrrbeeefY94YQTnKs3Sp0avqbqxH9QWvfPP/+YQSedN4UIA2GCywYOwEpwp0UFpaMrr7yy03vIgttwww29cmbhwoVe3bp1nYU5l07NHK88MDHj71LmTSfiJ5980mpZPpcOtzQxyQYeTsiHDBOJmaEcNGiQd84558Repp4tdLXt3LmzN3ny5JTLbLnllt4rr7xi1Y27VGH/UeKMuJqJjTfe2Pvss89C96mus6LUyPY6K0Qh0DVWlBq6xma3zU466aS0MUMdO3Y0RoRSNFwQFxVoN3379rV+nxyAIhQ9vIlU8ICPOy0oAxZ2cGOhccTXX39ttTwuKWanyn0b05yCMkjKU10y7bLZLrzH5X0TJkxwesggV7JFixbO64XLEGcc51UY/Dtlz8svv7xpEFOMrLPOOmZ7sZ6PPvqoEXYDEPyOPfZY77LLLjP7upzh97v11lu9I444Iu1y7EucmKnKT3SdFaWK63VWiEKga6woVXSNtYfYm0wZ4xMmTDDPbC7VSKVOZRY+CyFEAW7YzELZctxxxznl3JXydqEs1RaabrRr187LB4kiVhzLB+Le6aefnlL8S4SmIzNnzvSKFToI33///aaxDiLg8OHDTVk0ZdvMUpa7+Bdw+OGHew888IDpFp1K3Ef03W677fK+bkIIIYQQ5c78+fO9wYMHWy37wgsvWMXYlAsSAIUQIk/ggrIRr3CRnXnmmV6lcNppp1kve8opp+QttBdXW5zLw5gxY7zvv//eatl///3Xu++++7xiB4cmzVMQsffbb7+UQlg5Q2OU3377zXT+3mOPPUxO4j777GMEUrI96TouhBBCCCGihwlol0nzO++8s2J2gwRAIYTIE/Xr1zfNF+gWms7hRk5aJeUr0kCCBhWZ2GuvvYwAmC/I5LOFrMatt97a6fN5MCGA2IU333zTaXlROBo2bGjcncwsEzz91FNPeT169HDOvBRCCCGEEPZ88803sS5fykgAFEKIPNKsWTOTN/HYY4+ZRhYIfaussoopB6QD7Keffmqy/yoNuujSoYttEZaXduqpp5rZvNq18xdd27NnT2+11VazWta1QceCBQuMoJmuaUaqkgYhhBBCCCFEOK5ZtDUqKLtWTUCEECLPkO130EEHmZf4f04++WTvmGOO8UaNGmUaaixevNiIoWSqFcIRSfOKZ555xgi1dNlKBaWuvXr1cvpsxN53333XeZ3WXHNN5/cIIYQQQghRKWy66aZOy2+yySZepSABUAghRNFAeSSCH69iYO7cuSZ7Lx2UbE+dOtVbffXVrT+XTrHZZssJIYQQQgghwunatat5Lv/jjz+sNlFvx0ieUkYlwEIIIUQICH+HHHKIt2jRorTb5+effzbuRVtmz57tffbZZ1nNZhZz8wh+L7qo4d4s5m7FQgghhBCifKlTp453ySWXWC172GGHeW3atPEqBQmAQgghnF1xdMtCjKL5xeabb+6dddZZ3rfffltWW3LkyJHetGnTrJalwcOkSZNiy/GjBPqJJ54oyoySiRMnmtJt8hK33HJLr0OHDmbW9dBDD/U+/vjjQq+eEEIIIYSoME488UTv4osvTrvMnnvu6d11111eJSEBUAghhDXjx4/3WrVq5R1//PHeG2+8YcSfTz75xBs6dKi3wQYbeOeee663dOnSstiijz/+uPWy/M40KbGhcePGzp1gx4wZY7Z7sfH6668b0e+ee+6pUiqNa/LRRx/1OnbsaIRLIYQQQggh8gWT5pdddpn35ptvegceeGCVRoLbbLON9+CDD5qs73r16lXUTlEGoBBCCCsQ+nbbbTfjAEzF4MGDzZ/XXHNNyW/V6dOnOy3/559/WpclUFp83333WS2/xx57GJdlsfHLL794++67rzdnzpyUyyxcuNDkOb733nvOgcxCCCGEEELkQqdOncyLiepZs2Z5K6ywgrfiiitW7EaVA1AIIYQVZ599dlrxL1EE/O6770p+qzZs2NC5a7Atffr08WrWtLsFn3HGGV4xctNNN6XtjpwoAg4ZMiQv6ySEEEIIIUQyVN80a9asosU/kAAohBAiI5T6vvrqq9Zb6vbbby/5rUouSFzL4+iz6QRM6cLuu+/uFRtLliwxZb+2PPbYY6ZJiBBCCCGEEKIwSAAUQgiREfL+4ly+GOnZs6fXoEEDq2UpLWjbtq3T559wwgne008/7W222WbVfkaeItkkmcKLC8WMGTOcOv3iAqRkWAghhBBCCFEYlAEohBAi8s618+bNK/mt2qhRI++2224zQmCmUmEbN18Y3bp187p27ep98MEH3qeffur5vm86K2+//fZF2fE3oFatWs7vsS15FkIIIYQQQkSPBEAhhBAZWWONNWJdvljp0aOHEeJOPfVU7++//67289atW5vy1o033jjr7+DzO3ToYF6lwsorr+yttdZa3uTJk62WJ29l3XXXjX29hBBCCCGEEOFoOl4IIURG9t57b6cmF0cccUTZbNUjjzzS+/XXX7077rjDO+CAA0wmH8Lgc88953399dehJbzlDqJl7969rZc/6qijvHr16sW6TkIIIYQQQojUyAEohBAiI2ThkVlHh99MrL766t6hhx5aVlt1hRVWMIKXi+hVavz0009G0ETca9OmjdeiRYu0y5900klGFEUcTUfjxo29vn37euUKv//w4cO9p556yps1a5b5fffdd19zrKy55pqFXj0hhBBCCCEMcgAKIYSw4vLLL/e6dOmSUSgbNWqUV79+fW3VEuHNN9/0dt11V1Oii9Nzr7328tZZZx3T1Xj8+PEp37fKKqt4L730kte8efO0yzz//PNey5YtvXJk2LBhZrvRrZkMx0mTJpk/+X+2IQKpEEIIIYQQxYAEQCGEEFYsv/zyRsw599xzTeOLZHbZZRdv3Lhx3jbbbKMtWiLcd999RtR95ZVXqvw7zUhefPFFr3Pnzt6jjz6a8v04BRG8rrrqKiN4JWZAXnLJJd4XX3zhdezY0StHHnjgAeOKXbRoUejP+fcTTzzRLCeEEEIIIUShqeHzlC+E53nXXnut988//5iw9nIu1xK58ccff3hLly41HT0p9RSVydy5c40Y+Pvvvxu3H0LR+uuv7xUj3OYWL17s1a5du6g76+abDz/80Nt66629JUuWpF1uueWW8z766COvbdu2GbczxwXXB+4j5byt//33X+N8nDFjRsZlcUFSJly3bl3rz9d1VpQaus6KUkLXWFFq6BorotJulAEohBAiq0zAgw46SFuuhLnuuusyin+Bk+2GG24wOXfpQPCjBLwSGDlypJX4ByzH8jSOEUIIIYQQolCoBFgIIYSoMJgxRJSyZcSIEd6CBQtiXadSYuzYsbEuL4QQQgghRNRIABRCCCEqDEq3U2XXhTF//nxv2rRpsa5TqZUAu8D2E0IIIYQQopBIABRCCCEqDHL98vGecmXNNdd0Wj5dp2QhhBBCCCHygQRAIYQQosJYe+21nZr4tGjRwltttdViXadS4sgjj3RaXvl/QgghhBCi0EgAFEIIISoMOiIfd9xx1sufcMIJZd3V1xU6Iu+2225Wy7LcxhtvHPs6CSGEEEIIkQ4JgEIIIUQF0qdPH+MEzESrVq28k046KS/rVErcf//93vrrr592mdatW5vlhBBCCCGEKDQSAIUQQogKpEmTJt7LL7/srbvuuimXQeBimUaNGuV13UoBSqLHjRtnnJR169at8jP+n38fP368SqeFEEIIIURRULvQKyCEEEKIwoDA99lnn3kPPvigN2zYMO+rr74y/96uXTtT9nvYYYd59evX1+5JI6IOHz7cu+aaa7wxY8Z4s2bN8ho3bmzKfvlTCCGEEEKIYkECoBBCCFHBNGjQwIh9vER2IPYdcsgh2nxCCCGEEKJoUQmwEEIIIYQQQgghhBBljARAIYQQQgghhBBCCCHKGAmAQgghhBBCCCGEEEKUMRIAhRBCCCGEEEIIIYQoYyQACiGEEEIIIYQQQghRxkgAFEIIIYQQQgghhBCijJEAKIQQQgghhBBCCCFEGSMBUAghhBBCCCGEEEKIMkYCoBBCCCGEEEIIIYQQZYwEQCGEEEIIIYQQQgghyhgJgEIIIYQQQgghhBBClDESAIUQQgghhBBCCCGEKGMkAAohhBBCCCGEEEIIUcZIABRCCCGEEEIIIYQQooyRACiEEEIIIYQQQgghRBkjAVAIIYQQQgghhBBCiDJGAqAQQgghhBBCCCGEEGWMBEAhhBBCCCGEEEIIIcoYCYBCCCGEEEIIIYQQQpQxEgCFEEIIIYQQQgghhChjJAAKIYQQQgghhBBCCFHGSAAUQgghhBBCCCGEEKKMkQAohBBCCCGEEEIIIUQZIwFQCCGEEEIIIYQQQogyRgKgEEIIIYQQQgghhBBljARAIYQQQgghhBBCCCHKGAmAQgghhBBCCCGEEEKUMRIAhRBCCCGEEEIIIYQoYyQACiGEEEIIIYQQQghRxkgAFEIIIYQQQgghhBCijJEAKIQQQgghhBBCCCFEGVO70Csgio85c+Z41157baFXQxQpS5cuXfb3mjU1hyCEELrOCiFE6aBnWSFEOWg22SABUFTD933vn3/+0ZYRQgghhBBCCCGEKAMkAIplrLDCCtoaIiMzZszwlixZ4tWqVctbZZVVtMWEECJidJ0VQoj40DVWCFGpGk4NH7uXEEJYstdee3nTpk3zVl11Ve/555/XdhNCiIjRdVYIIeJD11ghRKWiAC8hhBBCCCGEEEIIIcoYCYBCCCGEEEIIIYQQQpQxEgCFEEIIIYQQQgghhChjJAAKIYQQQgghhBBCCFHGSAAUQgghhBBCCCGEEKKMqV3oFRBClBaHH364N3fuXK9BgwaFXhUhhChLdJ0VQghdY4UQImpq+L7vR/6pQgghhBBCCCGEEEKIokAlwEIIIYQQQgghhBBClDESAIUQQgghhBBCCCGEKGMkAAohhBBCCCGEEEIIUcZIABRCCCGEEEIIIYQQooxRF2AhRFqmT5/uvfPOO95nn33m/fzzz97MmTO92rVre02bNvU222wzr1u3bt7qq6+urSiEEBFyxRVXeO+99575e5cuXbwzzjhD21cIIXLkr7/+8p599lnv/fff96ZNm+YtWrTIa9y4sbfOOut4W2+9tbfzzjtrGwshyhYJgEKItOLfcccd5yU2C69fv763cOFCb/Lkyeb10ksvmYHp9ttvry0phBARMG7cuGXinxBCiGh49913veuvv96bO3eu+f86dep4tWrV8qZOnWpeTHRLABT/1969h1ZZ/3EA/6yMZbMpGhZzXUy6YEa6NClEMwIJE0vtj4jIKBAKSh0lRhfNjMwhCUZQQTeEJKlY9U8XcwYRRWq1XELaUrPothkujXTnx/eBDU033S3P7+n1gofznJ3nwJfv4HDO+/l+P5+AHBMAAh1qbW3NHquqqrIVKGnFX3l5eRw8eDAaGhri2Wefzb4srVixIiorK+O8884zmwA9kH6YPvfcc1FWVpatStm1a5f5BOihzZs3x7Jly+LAgQMxefLkmDlzZpxzzjnZa3v37o2tW7fGN998Y56BXCspHLq0B+AfP0TTHdHzzz//qPPS1NQU99xzT+zZsye7Y3rvvfeaP4AeePrpp7OV1XPmzMlWAtbX19sCDNAD+/bti7vvvjt+/fXXmDFjRsyePdt8Av9JmoAAHUorUDoK/5K0OuXyyy/Pzrdt22YmAXpgy5Yt8e6778YFF1wQ1113nbkE6AUffPBBFv4NGTIkbrnlFnMK/GcJAIEeSVuCk7QtGIDuSYXoV61aFSUlJXHXXXfFSSf5igbQG9avX589XnXVVXHKKaeYVOA/Sw1AoEfS9rTk3HPPNZMA3fTaa69l9f5SZ/URI0aYR4BekBrXbd++PTtPn63pc3bNmjXxxRdfZLX/0m6WSy+9NNsa3FYTECCvBIBAt33yySfx7bffZue6pgF0T+qovnbt2hg8eLDtaQC96Oeff84afyS7d++OZ555Jv7666+sA3A6fvnll1i3bl189NFHMW/evJgwYYL5B3JLAAh0S/rClIrVJ+PHj2+vBQjA8Uu92NJnafqBeuedd8Zpp51m+gB6SVrl1ybdaBk4cGAsWLAgqqqqslILaXVgKr+Qbmg/9dRTWe3riooK8w/kkgIzQLe+TC1ZsiTr/nvWWWdlnYAB6LrU8Tc1/0g3Uaw8Aej9myxtWltbY+7cuTF27Nj2Oqsp8HvwwQfj1FNPzbYL19bW+hcAuSUABLpk3759sXjx4mhsbMy2qz366KNx+umnm0WALvr999/jpZdeyrahzZkzx/wB9LL+/fu3n5999tkxZsyYI65J32cnTpyYnafagAB5ZQswcNxSzZQU+G3dujXbQpFWAaYVgAB03csvvxwtLS1x0003ZZ+p6QbLodJqlbYu622vlZaW6hAMcJxSuNemsrKyw+vaXkslbgDySgAIHHf4lwK/r7/+OgYMGJAFgelOKgDdL07f1gE4HR2pq6vLjqStRhUAx1ZeXp51+m1qajqu6SopKTGtQG7ZAgwc099//x2PP/54fPnll1mB+kWLFsXw4cPNHAAARW306NHZ465duzq8pu21oUOH/mvjAvi3WQEIdCp1pnziiSdi06ZNWYHkhx9+OC688EKzBtBD6cZKZx544IGor6+Pa665JitcD0DXpc/QDz/8MHbu3BkbN27MOgD/sx7rhg0bsvPUIAQgr6wABDqU6k7V1NTEZ599lhWpT13SRo4cacYAAPi/cNlll2Wd1pOVK1fG559/3l5j9bvvvoulS5fG/v37s6Z206dPP8GjBeg7VgACHWpoaIiPP/44Oy8UClkYeKyC9gAAUEyqq6uzG9nbt2+PxYsXZze2+/XrF3/++Wf2eqpvvXDhwsOahgDkjQAQ6FAK/Q6tA9jc3Gy2AAD4v5ICvuXLl8c777yTbff94YcfsjI3w4YNy1YH3njjjTFkyJATPUyAPlVSOPQXPgAAAACQK2oAAgAAAECOCQABAAAAIMcEgAAAAACQYwJAAAAAAMgxASAAAAAA5JgAEAAAAAByTAAIAAAAADkmAAQAAACAHBMAAgAAAECOCQABAAAAIMcEgAAAAACQYwJAAAAAAMgxASAAAAAA5JgAEAAAAAByTAAIAAAAADkmAAQAAACAHBMAAgAAAECOCQABAPjXNDY2RklJSXbMnj3bzAMA/AsEgAAAAACQYwJAAAAAAMgxASAAAAAA5JgAEAAAAAByTAAIAAAAADkmAAQAoGhcffXV7V2C27zxxhsxderUGDZsWJSWlkZFRUXMnDkzNmzY0KdjaRtHGlPS1NQUS5cujaqqqhg8eHCUlZXFyJEj47777ouffvqpT8cCANAT/Xr0bgAA6CP79++PW2+9NdauXXvY33/88cd4/fXXs+PJJ5/MAri+Vl9fH9dff318//33h/29oaEhO55//vl49dVXY8qUKX0+FgCArhIAAgBQlO64444s/Bs1alTcfPPNMWLEiGhpaYm33nor3nzzzeyaBQsWxJVXXhkTJkzos3Hs2bMnpk+fnoV/EydOjFmzZsWZZ54ZO3bsiNWrV8fmzZujubk5brjhhmxV4rhx4/psLAAA3VFSKBQK3XonAAB0UWNjYwwfPjw7v+222+LFF1887PW03baurq79+fz582P58uVx0kmHV6557LHH4qGHHsrOp02bFrW1tb3+vzh0G3KybNmyuP/++w/728GDB2Pu3LmxatWq7HnaEvzVV18dMV4AgBPJNxMAAIrSpEmToqam5qhh2sKFC7OagMl7770XBw4c6NOxzJgx44jwLzn55JNj5cqVMXbs2Oz5li1b4u233+7TsQAAdJUAEACAojRv3rwjVuEdGrxNnjy5vVbgtm3b+nQsRwv/2qSAsrq6uv35P2sWAgCcaAJAAACKUqrt15nKysr289Sht6+Ul5fHFVdc0ek11157bfv5p59+2mdjAQDoDgEgAABF6Ywzzuj09dLS0vbztAqwr6TmIx2tRDx0rIMGDcrOd+/e3WdjAQDoDgEgAABFqVgaaZSVlXXpur179/bxiAAAuqY4vlUBAECRamlp6dJ1AwYM6OMRAQB0jQAQAAA6kRqMFAqFTufot99+i+bm5uy8oqLCfAIARUUACAAAnfjjjz+O2djj/fffbz8fP368+QQAiooAEAAAjqGmpqbD11pbW2PFihXtz2fNmmU+AYCiIgAEAIBjWLt27WEh36Hh3/z589tXCF5yySUxdepU8wkAFJV+J3oAAABQzEaPHp1tA66uro7a2tpshd/QoUNj586dsXr16ti0aVN2XWlpabzwwgtF070YAKCNABAAADoxcODAeOWVV2LatGlRV1eXHUe7Zs2aNTFu3DhzCQAUHbcnAQDgGEaNGpWt9FuyZEmMGTMmBg0aFP3794+LLrooWxnY0NAQU6ZMMY8AQFEqKRQKhRM9CAAAKDYlJSXZ46RJk2L9+vUnejgAAN1mBSAAAAAA5JgAEAAAAAByTAAIAAAAADmmCzAAALmxY8eO2LhxY7fff/HFF2cHAECeCAABAMiNdevWxe23397t9z/yyCOxaNGiXh0TAMCJJgAEAICjKBQK5gUAyIWSgm82AAAAAJBbmoAAAAAAQI4JAAEAAAAgxwSAAAAAAJBjAkAAAAAAyDEBIAAAAADkmAAQAAAAAHJMAAgAAAAAOSYABAAAAIAcEwACAAAAQI4JAAEAAAAgxwSAAAAAAJBjAkAAAAAAiPz6H/9cALdQF6MTAAAAAElFTkSuQmCC",
+            "text/plain": [
+              "<plotnine.ggplot.ggplot object at 0x0000025EDB2689E0>"
+            ]
+          },
+          "execution_count": 14,
+          "metadata": {
+            "image/png": {
+              "height": 480,
+              "width": 640
+            }
+          },
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "(p9.ggplot(train_full, p9.aes('ln_p', 'ln_q')) + p9.geom_point() + p9.stat_smooth(color=\"red\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 497
+        },
+        "id": "t7axTjsnq8qI",
+        "outputId": "f2d9aa5e-e1f3-48f8-ebae-6ecff74ca1e4"
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAABQAAAAPACAYAAABq3NR5AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAewgAAHsIBbtB1PgAA0p9JREFUeJzs3QeY3GW5/vF7Zmd7770HwYKKwkERREE9bBICSegQIr1jaEIQEEQ6obcYWmghlARTsYEoR0U5KCACJjvbe+9tyv96f4fwR9gJCdnp3891zbW7yRvm5beTyew9z/M+Nq/X6xUAAAAAAACAiGQP9gYAAAAAAAAA+A8BIAAAAAAAABDBCAABAAAAAACACEYACAAAAAAAAEQwAkAAAAAAAAAgghEAAgAAAAAAABGMABAAAAAAAACIYASAAAAAAAAAQAQjAAQAAAAAAAAiGAEgAAAAAAAAEMEIAAEAAAAAAIAI5gj2BhA6li9fruHh4WBvAwAAAAAAANuRkpKiM844QzuKABAfMuHf0NAQVwQAAAAAACCCEADiE2w2m5UkA9PxeDwffm63c4oAAMw0nmcBwH94jgUQCcVbXq93p/8cASA+wYR/F110EVcG02pvb7deOJnwr6CggKuEkGf+cXS5XHI4HNYbHECo43kW4YbnWYQTnmMRbniOxcctW7bsM3VvUr4DAAAAAAAARDACQAAAAAAAACCCEQACAAAAAAAAEYwAEAAAAAAAAIhgBIAAAAAAAABABCMABAAAAAAAACIYASAAAAAAAAAQwQgAAQAAAAAAgAhGAAgAAAAAAABEMAJAAAAAAAAAIIIRAAIAAAAAAAARjAAQAAAAAAAAiGAEgAAAAAAAAEAEIwAEAAAAAAAAIhgBIAAAAAAAABDBCAABAAAAAACACEYACAAAAAAAAEQwAkAAAAAAAAAgghEAAgAAAAAAABGMABAAAAAAAACIYASAAAAAAAAAQAQjAAQAAAAAAAAiGAEgAAAAAAAAEMEIAAEAAAAAAIAIRgAIAAAAAAAARDACQAAAAAAAACCCEQACAAAAAAAAEYwAEAAAAAAAAIhgBIAAAAAAAABABCMABAAAAAAAACIYASAAAAAAAAAQwQgAAQAAAAAAgAhGAAgAAAAAAABEMAJAAAAAAAAAIIIRAAIAAAAAAAARjAAQEc3lcgV7CwAAAAAAAEFFAIiIVl9fr8HBwWBvAwAAAAAAIGgIABHR3G63Wlpa1N7eLo/HE+ztAAAAAAAABBwBIKJCX1+fVQ04MTER7K0AAAAAAAAEFAEgooYJ/+rq6tTf3x/srQAAAAAAAAQMASCiitfrVVtbm9UWTEswAAAAAACIBgSAiEpmMIjT6dT4+HiwtwIAAAAAAOBXBICIWlNTU9a5gL29vcHeCgAAAAAAgN8QAELR3hLc0dGhpqYmuVyuYG8HAAAAAABgxhEAApKGh4etASGjo6NcDwAAAAAAEFEIAIEPmArAhoYGdXV1WZWBAAAAAAAAkYAAEPiY7u5uNTY2WmcEAgAAAAAAhDsCQGAaphXYtAQPDQ1xfQAAAAAAQFgjAAR8cLvdam5uVnt7Oy3BAAAAAAAgbBEAAp+ir69P9fX1mpyc5FoBAAAAAICwQwAI7IDx8XGrJXhgYIDrBQAAAAAAwgoBILCDPB6PWltbrZv5HAAAAAAAIBwQAAI7yVQBmmpAUxUIAAAAAAAQ6ggAgc/AnAdozgXs7e3l+gEAAAAAgJBGAAh8Rl6vVx0dHWpqapLL5eI6AgAAAACAkEQACOyi4eFhqyV4dHSUawkAAAAAAEIOASAwA0wFYENDg7q6uqzKQAAAAAAAgFBBAAjMoO7ubjU2NmpqaorrCgAAAAAAQgIBIDDDTCuwaQkeGhri2gIAAAAAgKAjAAT8wO12q7m5We3t7fJ4PFxjAAAAAAAQNI7g3TVCWaScY2f+P4L5/9Lb22tVBBYXFysuLk6RICYmRna7XTabLWIeJ4hs2x6nPF4RLnieRbjheRbhhOdYhBueYzFTCADhc6hFJDDVd8GuwDMBYG1trfLy8pSenq5wl5GREXGPE0RPZS4QDnieRbjieRbhgOdYhCueY7GrCAAx/QPDERkPDVOpFio6Ozs1MTGhgoKCkNrXZxl0Yt6FMhWAOTk5wd4O8KnM49W8YDLv+JvHLRDqeJ5FuOF5FuGE51iEG55jMVMiI+XBjIuUH5LN/0co/b8MDg5qfHzcaglOSEhQODJBiqmq3NYGDISLUHs+AHzheRbhiudZhAOeYxGueI7FrgrfMiQgTE1OTqq+vt46HxAAAAAAAMDfCACBIJVxd3R0qKmpiXP0AAAAAACAXxEAAkE0PDysuro6jYyM8H0AAAAAAAB+QQAIBJmZpNvY2GgNCdk24h0AAAAAAGCmEAACIaKnp0cNDQ2ampoK9lYAAAAAAEAEIQAEQsjY2JicTqc1LRgAAAAAAGAmEAACIcbj8ailpUVtbW3W5wAAAAAAALuCABAIUf39/aqvr9fExESwtwIAAAAAAMIYASAQwkz4Z6YE9/X1BXsrAAAAAAAgTBEAAiHOTAZub29Xc3Oz3G53sLcDAAAAAADCDAEgECaGhoasasDR0dFgbwUAAAAAAIQRAkAgjExNTamxsVHd3d1WZSAAAAAAAMCnIQAEwowJ/rq6uqwg0OVyBXs7AAAAAAAgxBEAAmHKtAI7nU4NDw8HeysAAAAAACCEEQACYcwMBWlqarKGhHg8nmBvBwAAAAAAhCACQCAC9PX1qb6+XhMTE8HeCgAAAAAACDEEgECEMOGfmRLc398f7K0AAAAAAIAQQgCIyOZyKefeexXT16doGRDS1tamlpYWqz0YAAAAAACAABARLWP1auXee6+qa2qU+fjj0tSUosHg4KBVDTg2NhbsrQAAAAAAgCAjAETk6ulRzl13WZ/GDA6q4IYbVLVggZL+9CdFg6mpKTU0NKinpyfYWwEAAAAAAEFEAIjI9dOfKmZg4D9+Kb62VuWnnqqSc89VbGOjoqEluLOzU42NjXK5XMHeDgAAAAAACAICQESmkRFp3Tqfv5360kuqOvRQ5d5+u2xmbYQbGRmR0+nU8PBwsLcCAAAAAAACjAAQkSk5WXrnHfWcfro8sbHTLrFPTSlnxQpVz56tNBMWejyKZGYoSFNTkzo6OqzKQAAAAAAAEB0IABG5UlPVfeGFcq5fr6GDDvK5LLarS8WXXaby449XwttvK9L19vaqvr5ek5OTwd4KAAAAAAAIAAJARLypsjI133OPGh98UBNVVT7XJb35piqPPlqFl1+umK4uRbLx8XFrSnB/f3+wtwIAAAAAAPyMABBRY2S//eRcu1btS5fKnZbmc13GCy9YbcFZDz0kRXCVnMfjUVtbm1paWqz2YAAAAAAAEJkIABFdYmPVt2iRajdtUt/RR8trn/6vQMzIiPKXLVPVYYcp5fe/N+N0FakGBwetasCxsbFgbwUAAAAAAPgBASCikjsrS+0//anqnn1WI3vv7XNdfEODSs8+W6VnnKE4p1ORampqSg0NDeru7g72VgAAAAAAwAwjAERUm/j859W4cqWaly3TVEGBz3Upr76qqsMPV95NN8k+NKRIZCYDd3V1qbGxUS6XK9jbAQAAAAAAM4QAELDZNFRTo9qNG9V1zjnyJCRMe01sLpeyV65UdU2NMp57TorQc/NGRkbkdDo1PDwc7K0AAAAAAIAZQAAIfMCbmKjuc85R7YYNGqip8XldHL29KrzqKlUcfbQS//d/I/L6maEgTU1Nam9vt4aFAAAAAACA8EUACHyMq6hIrcuWqf6xxzS+xx4+r0/iv/6likWLVHTJJXK0t0fkdezr61N9fb0mJiaCvRUAAAAAAPAZEQACPoztvbc1JKTt6qvlysz0eZ3SN25U9Zw5yrn/ftnGxyPueprwz0wJ7u/vD/ZWAAAAAADAZ0AACGxPTIz6jzpKtZs2qXfRInljYqb/izQ2pty771bVoYcq9de/NhM1Im5ASFtbm5qbm2kJBgAAAAAgzBAAAjvAk56ujqVL5Vy7VsPf+pbPdXEtLSpZskRlJ5+s+Pffj7hrOzQ0pNbWVo1HYKUjAAAAAACRigAQ2AmTs2ap6Re/UNM992iytNTnuuTXXlPlwoXKv/ZaxURY66zL5VJHR4fVEmwqAwEAAAAAQGgjAAR2ls2m4YMOknP9enVeeKHcSUnTL/N4lLVqlaoPOUSZTz5pkrOIutYmAGxoaNDU1FSwtwIAAAAAALaDABD4jLxxceo59VQ5N29W/+GH+1wXMzioguuuU+WCBUr6858j6nqPjY1ZA0IGBweDvRUAAAAAAOADASCwi1y5uWq7/nrVrVqlsT339LkuYetWlZ9yiorPP1+xTU0Rc93dbrdaWlqsISEejyfY2wEAAAAAAB9DAAjMkPGvfEX1q1ap9YYb5MrJ8bku7be/taYF595xh2wjIxHVEmyqARkQAgAAAABAaCEABGb0b5RdA4cdptrNm9V96qnyxMZOv2xyUjm/+IWq58xR2rp1UoQM05icnFR9fb16e3uDvRUAAAAAAPABAkDADzzJyeq68EI5163T0He/63NdbGenii+7TOXHH6+Ef/4zIr4XZjKwmRLc1NRkTQwGAAAAAADBRQAI+NFUebma771XjStWaKKqyue6pH/8QxVHH63Cn/xEMV1dEfE9GR4etlqCzUcAAAAAABA8BIBAAIx861tyrl2r9qVL5U5NnXaNzetVxtq1qp49W1kPP2z6acP+e2MqAE0loKkINJWBAAAAAAAg8AgAgUCJjVXfokXW+YB9Rx0lr8027bKYkRHl33qrqg47TCmvvBIR3x9zJqA5G9CcEQgAAAAAAAKLABAIMHdWltqvvlp1zz2n0a9/3ee6+IYGlZ51lkrPOENxdXUKd2Y6sNPptKYFAwAAAACAwCEABIJk4vOfV8Njj6l52TJNFRT4XJfyxz9a1YB5N90k+9CQwplpA25ra1NLS4vcbnewtwMAAAAAQFQgAASCyWbTUE2NajduVNfZZ8sTHz/9MpdL2StXWucDpj//vOTxKJwNDg5aA0JGR0eDvRUAAAAAACIeASAQAryJieo+91zVbtigwf/+b5/rHD09KrrySmticOIbbyicTU1NqaGhQV1dXQwIAQAAAADAjwgAgRDiKi5Wy+23q2HlSo3vvrvPdYnvvKOKE05Q0SWXyNHernDW3d1tBYEmEAQAAAAAADOPABAIQaP77GMNCWm76iq5MjJ8rkvfuFHVc+Yo+4EHZJuYULgaGxuzBoSY1mAAAAAAADCzCACBUBUTo/5jjlHt5s3qPeEEeWNipl1mHxtT3l13qWruXKX+5jdm0obCkcfjsYaDtLa2Wp8DAAAAAICZQQAIhDhPero6Lr9czjVrNPzNb/pcF9fSopIf/UhlJ5+s+H//W+FqYGDAqgY0VYEAAAAAAGDXEQACYWJyt93U9OCDarr7bk2Wlvpcl/zaa6pcsED5P/+57P39CucBIeZ8QG+YVjQCAAAAABAqCACBcGKzafjgg+Vct06dS5bIk5g4/TKPR1lPPaXqmhplrloluVwKNyb4MxOCGxsbGRACAAAAAMAuIAAEwpA3Pl49p59unQ/YP2+ez3WOgQEVXHutKo84QkmvvaZwNDo6qrq6OgaEAAAAAADwGREAAmHMlZenthtvVP1TT2lszz19rkv4979VftJJKl6yRLEtLQo3brfbGhDS1tbGgBAAAAAAAHYSASAQAca++lXVr1ql1uuukys72+e6tF//WlVz5ij3rrtkGx1VuOnv77eqAcfHx4O9FQAAAAAAwgYBIBAp7HYNzJ9vtQV3n3KKvA7H9MsmJ5XzwAOqnjNHaRs2mMP2FE4mJydVX1+vnp6eYG8FAAAAAICwQAAIRBhPSoq6LrpItevWaeg73/G5LrajQ8U//rHKFy1SwjvvKNwGhHR2dloDQlxhOOAEAAAAAIBAIgAEItRURYWa77tPjcuXa6Ky0ue6pDfeUMVRR6nwyisVE2ZVdSMjI3I6nRoaGgr2VgAAAAAACFkEgECEGzngADlfeEEdl14qd0rKtGtsXq8ynn9e1TU1ynr0UdNnq3AaENLc3MyAEAAAAAAAfCAABKJBbKx6Fy+2zgfsO/JIeW22aZfFDA8r/+abVTV/vpL/8AeFEwaEAAAAAAAwPQJAIIq4s7PVfs01qn/2WY1+7Ws+18XX1anszDNVctZZiquvV7hgQAgAAAAAAJ9EAAhEofEvfEENjz+ulltu0VRBgc91qa+8oqp585R3yy2yDw8rnAaENDQ0aGpqKtjbAQAAAAAg6AgAgWhls2lwzhzVbtigrrPOkic+fvplLpeyH3nEOh8wfc0ayeNROBgdHVVdXZ0GBweDvRUAAAAAAIKKABCIct6kJHWfd56cGzZo8Ac/8LnO0dOjoiuu0JdOPVUpb7+tcBkQ0tLSwoAQAAAAAEBUIwBERMvLy1NcXFywtxEWpoqL1XLHHWp45BGNf+5zPtelvPuu9jzjDFVfc40cnZ0KpwEhY2Njwd4KAAAAAAABRwCIiJaZmanq6mqVlZUpJSUl2NsJC6P77qu6555T21VXyZWe7nNd7osvWm3B2cuXyzYxoXAYEGLOBezu7rbOCQQAAAAAIFoQACIqJCcnq7S01AoDs7KyZLfz0N8uh0P9xxyj2s2b1XvccfLGxEy7zD42prw777QGhaT89rdmAodCmQn+urq6GBACAAAAAIgqpCCIKqYdOD8/X7vttpsKCgoU72PwBf6PJyNDHVdcobo1azSy776+r2tTk0rPP1+lp56quC1bQv7ymVZgp9OpgYGBYG8FAAAAAAC/IwBEVDIVgKY9uKqqymoPTk1NDfaWQtrEbrup8eGH1XzXXRovKvK5LuXPf1bVggXKv+462UM8XPN4PGptbbWGhJhhIQAAAAAARCoCQEQ90x5cUlKiWbNmKTs7WzE+2l2jns2moe99T28+9ZQazzhD7oSEaS+Jze1W1pNPWucDZjz9tBnFG9KXbnBw0BoQMjo6GuytAAAAAADgFwSAwAdiY2OtqcEmCCwsLKQ92AdvfLxaFi/WP1av1sDcuT4fP47+fhX+7GeqPOIIJf31ryH9OJuamrLOBezs7GRACAAAAAAg4hAAAh//S2G3KyMjw2oPLi8vpz3Yh6m8PLXefLPqn3xSY1/8os/HUcL776v8hz9U8ZIlcrS0hPTjraenR/X19dbEYAAAAAAAIgUBILAdSUlJtAd/irG99lL96tVqvfZaubKzfa5L+/WvVT13rnLuvlu2EG63HR8ftwaE9Pf3B3srAAAAAADMCAJAYAfQHvxpzyR2DSxcqNpNm9Rz0knyOhzTL5uYUO7991tBYNqmTZLXG5KPP6/Xq7a2NjU3N8vlcgV7OwAAAAAA7BICQGAX24NtNhvX8AOe1FR1XnKJnOvWafjb3/Z5XWLb21V88cUqX7RI8f/6V8hev6GhIWtAyPDwcLC3AgAAAADAZ0YACOxie3B1dTXTgz9msqJCTQ88oMb779dERYXva/jGG6o88kgV/PSniuntDcnHoqkAbGpqUnt7uzweT7C3AwAAAADATiMABHYR7cG+jRx4oJwvvKCOSy6ROyVl2jU2r1eZzz6r6poaZa1caUbyhuRjsq+vz6oGNGcEAgAAAAAQTggAgZn6y8T04OnFxan3pJOs8wH7Fy6U10fLdMzQkPJvuklV8+cr+dVXQ/JxaaYDmynB3d3d1jmBAAAAAACEAwJAwA+YHvxJ7pwctV17reqfeUaje+3l89rFO50qO/10lZxzjmLr60Pu8WmCv66uLjU0NGgqRKsVAQAAAAD4KAJAwI9oD/6k8S9+UQ1PPKGWm2/WVH6+z2uX+vLLqp43T7nLlskegkM4xsbG5HQ6NTAwEOytAAAAAACwXQSAQADQHvwxNpsG585V7YYN6j7jDHni4qa9bjaXSzkPPaTq2bOVvnatFGJDOMxQkNbWVrW0tMjtdgd7OwAAAAAATIsAEAgw2oP/P29ysrp+9CM5N2zQ4Pe/7/OaObq7VfSTn6ji2GOV8OabCjWDg4NWNeDIyEiwtwIAAAAAwCcQAAJBQnvw/zdVUqKWO+9Uw8MPa3y33Xxes8S331blsceq8LLL5OjsVChxuVxqbGxUR0eHVRkIAAAAAECoIAAEQqg9uKysTKmpqYpWo9/4huqef17tV1whd1qaz3UZ69apavZsZa9YIdvkpEJJb2+vNSl4fHw82FsBAAAAAMBCAAiEkOTkZJWUlKi6ulpZWVlWOBh1HA71HXecal98Ub3HHSevj2sQMzqqvNtvV9Whhyrld78z43kVKiYmJqwQsLu725oaDAAAAABAMEVhugCEvri4OOXn52u33XZTQUGB9XW0cWdkqOOKK1S3Zo1G9t3X57q4piaVnneeSk87TXFbtypUmOCvq6tLDQ0NmgyxKkUAAAAAQHQhAARCmKkAzMzMtCoCS0tLlZKSomgz8bnPqfHhh9V8xx2aLCryuS7lT39S1fz5yr/+etkHBhQqxsbGVFdXp/7+/mBvBQAAAAAQpQgAgTBhwj8TApow0ISCUdUebLNp6Ac/sKYFd55/vjyJidMvc7uV9cQTqp49WxmrV0tut0KBGQrS1tam5uZma1gIAAAAAACBFEUJAhAZTDuwaQueNWuW1SZspglHC29CgnrOPFO1GzdqYM4cn+scfX0qvOYaVR5xhBJff12hYmhoSE6nU8PDw8HeCgAAAAAgihAAAmEqJibGGhRiKgLN4BAzQCRauAoK1HrLLap//HGNfeELPtclvP++Kk48UcUXXihHa6tCgdvtVlNTk1URaCoDAQAAAADwNwJAIMzZbDalpqaqrKxMVVVVysjIsH4tGox9/euqX71abT/7mVxZWT7Xpb34oqrnzlXOvffKNjamUGDOBDTVgOaMQAAAAAAA/IkAEIgg8fHxKiwstKYH5+XlRUd7cEyM+o84QrWbN6tn8WJ5HY5pl9nHx5V7771WEJi6ebMZ06tgm5qaUn19vTo7O62pwQAAAAAA+AMBIBCh7cHZ2dlWe3BxcbESfQzNiCSe1FR1XnqpnC+8oOH99/e5LratTSUXXaSyxYsV/+67CgU9PT1WEDgxMRHsrQAAAAAAIhABIBDBTCtwWlqaKioqVFlZqfT09IhvD56sqlLT8uVquv9+TZSX+1yX/PrrqjzySBVcfbVi+voUbOPj46qrq7PCQKoBAQAAAAAziQAQiBIJCQkqKiqypgfn5ORYVYIRy2bT8IEHyvnLX6rj4ovl9jEgxebxKPOZZ1RdU6PMxx83PbkKJhP8mXbgxsZGTU5OBnUvAAAAAIDIMf1hWVGor69P77zzjrZs2aLa2lrrNjIyYv3eihUrlJ+fv90/b/7s1q1bP/yzLS0t1oTPgw46SEuWLJmRPb799ttat26d3n//fWtvmZmZ2muvvbRw4UIVFBTMyH0g8jkcDuXm5lotwoODg9Zj31SfRaS4OPWefLIGDj1UeXfcoYy1a6ddFjM4qIIbbrDCwI6lSzWy334KptHRUasa0DzvmKEuAAAAAADsCgLAD2zevFlPP/30Z76QS5culT89//zzeuyxx6wKIdPCac50M5VCv/rVr/SHP/xBV155pb70pS/5dQ+ILHa73QqXzM0ETr29vRoaGlIkcufmqu2669R3zDHKv/56Jb355rTr4mtrVXbqqRr67nfVcemlmiorU7CYNxDa2tqs74kZ7GKCWwAAAAAAPgtagD9gQjVTFfWNb3xDJ5xwgk477bSdupBxcXHafffdNXv2bJ1//vn6/Oc/r5ny97///cPwb+7cuXryySetsHL58uXac889NTY2phtuuMGq5gI+i6SkJJWUlFjtwVlZWVY4GInG99xTDU8+qZYbb9RUXp7Pdakvv6yqQw9V7m23yf5BJXCwDA8Py+l08vcbAAAAAPCZUVLygaOOOkrHHnvshxfG/MC9M1avXv0fZ6q99tprminbwr999tlHp59++oe/bqqCfvKTn+jss8+2qrdMleBJJ500Y/eL6BMbG2u1nZowvL+/32oPjriz6Ox2Dc6bp6GDD1bOihXKeuQR2ac5+8/8Ws6DDyr9l79U14UXWm3E5s8Gg9vtto4VMNWApt0/os9vBAAAAADMuMgs8/kMdvUHan/9QN7U1GSdKWiYs/6mq9yqqamxPjetwEwPxUwwFYCmErC6ulqlpaVK9jFEI5x5k5PVtWSJnBs2WGGgL7FdXSpaulQVxx2nhLfeUjCZKl/z5oSpCgQAAAAAYEcRAIa4tz4IHEzQt8cee0y75mtf+5r1saenR83NzQHdHyJfSkqKysrKVFVVZZ0XaNrlI8lUaama775bDQ8+qInqap/rEt96S5XHHKPCyy+Xo6tLweJyuaw3Btrb261zAgEAAAAA+DQEgCHO/KBvmPPZfJ3LZsKZj68HZlp8fLzVdm4eiyYIjLQ21NH99pNz7Vq1X3653GlpPtdlvPCCqmpqlP3gg7IFsT3atGebakAzwAUAAAAAgO3hDMAQZ872M0w75vaCGdOiOTIy8uF6X5544gk99dRT0/7eV7/6VWuYiakqMtVFwHRMBWB6errS0tKsATTmXLqJiYmIuVjmrL/mAw5QyYoVyn/hBdmmqbKLGR1V3m23KfWZZ9Rw/vnq339/c2GCsl9T+ZuamqrMzMyIq84EotW26l7+PQYAnmMB4OM+aycYAWCIGx8f/zDk2x7z+yYANIHM9pg1nZ2dPgcNbENrIT6NCZtMa7q5mQDQnE8XKdVoU+npqrv4YnUcdpgq7rhD6X//+7TrEpubtcePf6z+//ov1S9ZorGKioDv1Zz7OTAwYF377OzsT32uABBe+PcYAHiOBYCZQAAYZUylYF5e3rS/99GWTl/txsBHfxjd9jhJTEy0buZ8OhMEmiEVkfBD69jnPqd3771XWS+9pPJ77lG8j8rYjL/+VV9etEgdRxyh5lNOkTs1NeB7NdfehPumMjMSz2oEov15FgDAcywA7IqoCACvv/56vffee5/49QMOOECnnXaaQllCQoL18dNaLLf9vglhtueEE06wbtNZtmyZ1c5pftgoKCj4zHtGZNs2fGJ7jxPz+/39/VZL+tTUlMKde8EC1c2ereyHH7bO/rN/UJn7UXa3W4WrVyv3179W149+pH4ztTtI5ySaSuCioqIPnz+inamSNAGpw+EgGEXEPM8CoYTnWYQTnmMRbniOxcd91jeIo+JtZVONZMKIj99MO2yo23b23/bO9jPh37b/l+2dFQgE8gnJPBarq6utoSGmTTjceRMS1H322arduFEDs2f7XOfo61Ph1Ver8sgjlfj66woG85xQX1+v7u5u6wUDAAAAACC6RU0FYLjaNuG3ubn5w2qAj2tsbPzw89LS0oDuD9ge04ZqBlSYmznP0gTZpkU4nEMpV2GhWm+9VX3HHKOCG25QwrvvTrsu4b33VHHiiRqoqVHnRRfJVVQU0H2aa9zV1WVV9ZpqQM4GBAAAAIDoFRUVgOHsy1/+svXRHPA/XRuz8fcPBhSYAQCm2goIRaYd1QRRs2bNUk5Ozn+cORmOxvbeW3XPPKO2a66RKzPT57r0zZtVPXeucu69V7ZpWof9zQSvdXV11rTgcA5eAQAAAACfHQFgiDOBnmmjNNasWfOJ3zfB4ObNm63Pv/3tb3O+FUKeOYctNzfXCgILCwvDuzItJkb9Rx6p2s2b1bN4sbyO6YuqzZmBuffeq+o5c5T64oumPC+g2zTBnxkQ0tDQ8KnniQIAAAAAIg8B4AdMe61pTdx2++j5gOYMwY/+3nTTTc2h+x9dYw6cN8wAhI/+uln3cU899ZTmzZtn3aZz4oknWh//+te/asWKFR/uzRxge91111mVPabFcqEZOgCECdPObqbVVlVVWa3rZkJ1uPKkpanz0kvlXLtWw/vv73NdbFubSi68UGU//KHifVT0+pN5/qEaEAAAAACiT1ScAbgjzFlZviYCX3DBBf/xtQnh8vPz/+PXli9frpdeeukTf/aPf/yjddvmoIMO0pIlS3Zqb3vttZcWL16sxx57TOvXr9fGjRutab/bgkDz+dKlS5WWlrZT/10gVKSkpFg3U51mzgkcGBgIy3bVyepqNS1frpRXXlH+jTcq7iPnc35U8t/+psojjrCqB7vOP1/u7bQQ+6sa0JwNGPYVmAAAAACAHUIFYJgw1X0///nPte+++1rVfiYoycvL0w9+8APdeeed+tKXvhTsLQK7zIRRJpQK63MCbTYNf+c7cq5bp46LLpLbxwRkm8ejzNWrVV1To8zHHzflwkGpBmRSMAAAAABEPps3HMts4BfLli2zqoJMwHjRRRdxlTEt03q+bSJ1QUFBQFrzTVVguJ5dF9PVpbzbb1fGCy9sd91EdbXaly7V6H77KdBMFXEkVwOaf+bMsQzm/EkzmRoIdYF8ngVmAs+zCCc8xyLc8ByLmcpuqAAEELIi4ZxAd26u2q6/XnVPP62xD6Z6Tye+tlblp56qknPPVayP1mF/oRoQAAAAACIbASCAsGDOCCwrK7PCQBMKhlsl1/iXv6z6p55Sy403aio31+e61JdeUtWhhyr39ttl+8gwokC8s2jOQq2vrw/baksAAAAAwPQIAAGElbA+J9Bu1+C8eXJu2qTu006TJzZ2+mVTU8pZsULVs2crbd060wsdsC2Oj49zNiAAAAAARBgCQABhyZznlpubawWBJhCMi4tTuPAkJ6vrggvkXL9eQwcd5HNdbFeXii+7TOXHH6+Et98OSjWgCQQBAAAAAOGNABBARJwTWF1dbZ0TmORj6m4omiorU/M996jxwQc1UVXlc13Sm2+q8uijVXj55dZQkUAx4Z8JAU0YyLwoAAAAAAhfBIAAIuqcwPLyclVWVio9PT1szgkc2W8/OdeutaYAu9PSfK4zk4RNW3DWQw9Jk5MB2ZsJ/rq7u622YDMsBAAAAAAQfggAAUSchIQEFRUVWVWB2dnZVpVgyIuNVd+iRardtEl9Rx0lr4/wMmZkRPnLlqnqsMOU8vvfm4QuINszg0FMNWBHR4c8ATyTEAAAAACw68Lgp2IA+GxiY2OVl5en3XbbTfn5+dbXoc6dlaX2q69W3XPPaWTvvX2ui29oUOnZZ6v0jDMU53QGbH+9vb1WNeDo6GjA7hMAAAAAsGsIAAFEPFMBmJWVZVUEFhcXWxWCoW7i859X48qVal62TFMFBT7Xpbz6qqoOP1x5N90k+9BQQPY2OTmphoYGtbe3Uw0IAAAAAGGAABBA1DBnAqalpVlnBJqzAs2ZgSHNZtNQTY1qN25U19lnyxMfP/0yl0vZK1equqZGGc89J7ndAdleX1+fnE6nhoeHA3J/AAAAAIDPhgAQQFQy04LN1OCqqiprinAoDwzxJiaq+9xzrSBw8JBDfK5z9Paq8KqrVHH00Ur83/8NyN6mpqbU1NSk1tZWuQMUPAIAAAAAdg4BIICoFh8fr8LCQs2aNUs5OTmKiYlRqHIVFanltttU/9hjGt99d5/rEv/1L1UsWqSiSy6Ro60tIHsbGBhQbW2tBgcHA3J/AAAAAIAdRwAIAKZ6zuFQbm6uFQQWFBSE9MCQsb33toaEtP30p3JlZPhcl75xo6rnzlXO/ffLNj7u932ZCsCWlhY1NzdblYEAAAAAgNBAAAgAH31StNuVmZn54cCQxMTE0Lw+MTHqP/po1W7erN5Fi+T1UbloHxtT7t13q2ruXKX+6leS1+v3rQ0NDVlnA5qJwd4A3B8AAAAAYPsIAAFgOwNDKioqQnpgiCc9XR1Ll8q5dq2G99vP57q41laVXHCByk46SfHvv+//fXk86ujosKYFjweg+hAAAAAA4BsBIADsxMCQ9PT0kBwYMjlrlppWrFDTPfdosrTU57rkv/5VlQsXKv/aaxXT3+/3fY2Njam+vl6dnZ1WKAgAAAAACDwCQADYiYEhRUVF1jmB2dnZVrtwSLHZNHzQQXKuX6/OCy+UOylp+mUej7JWrVL1IYco88knJZfLr9sybcA9PT2qq6vT6OioX+8LAAAAAPBJIfbTKwCEx8CQvLw8Kwg0H83XocQbF6eeU0+Vc9Mm9R92mM91MYODKrjuOlUuWKCkP//Z7/uanJy0WoLb2tqsgSEAAAAAgMAgAASAzygmJsaqBDRBYGFhoVUhGEpceXlqu+EG1a1apbE99/S5LmHrVpWfcoqKzz9fsc3Nft9Xf3+/amtrNTg46Pf7AgAAAAAQAALALjNnAmZkZFhnBJqzAkNtcvD4V76i+lWr1HrDDXLl5Phcl/bb31rTgnPvuEO2kRG/7slUALa0tKipqUlTU1N+vS8AAAAAiHZUAALADDLTgkNycrDdroHDDlPt5s3qPvVUeWJjp182OamcX/xC1XPmKG39enOAn1+3NTw8bFUD9vb2WmcFAgAAAABmHgEgAETR5GBPcrK6LrxQznXrNPTd7/pcF9vZqeJLL1X58ccr4Z//9OueTPDX0dFhDQkxU4MBAAAAADOLABAAAjA5uLq6WllZWSEzOXiqvFzN996rxhUrNFFV5XNd0j/+oYqjj1bhFVcoprvbr3uamJhQfX09Q0IAAAAAYIaFxk+iABDhYmNjlZ+fbw0Myc3NtQaIhIKRb31LzrVr1b50qdypqdOusXm9ylizRtU1Ncp6+GEzzjcgQ0IGBgb8ej8AAAAAEC0IAAEggEzwl5OTYwWBJhA0wWDQxcaqb9Ei63zAvqOOktdHu3LMyIjyb71VVYcdppRXXvH7kJDW1lY1NDRYlYEAAAAAgM+OABAAgsC0ApuWYNMabFqETatwsLmzstR+9dWqe+45jX796z7XxTc0qPSss1R6xhmKq6vz655GR0etswG7urrk8Xj8el8AAAAAEKkIAAEgiMxwEDMkxAwLKSkpUWJiYtC/HxOf/7waHntMzcuWaaqgwOe6lD/+0aoGzLvpJtmHhvw6JKS7u1tOp9OaGgwAAAAA2DkEgAAQIlJTU1VRUaGysjIlJycHdzM2m4ZqalS7caO6zj5bHh8VijaXS9krV6p69mylP/+85McqvampKTU1Nam5uVkul8tv9wMAAAAAkYYAEABCjAn/TAhYWVlphYLB5E1MVPe556p2wwYN/vd/+1zn6OlR0ZVXWhODE994w697GhoasoaE9Pb2WtWBAAAAAIDtIwAEgBCVkJBgtQWb9mDTJmzahYPFVVyslttvV8PKlRrffXef6xLfeUcVJ5ygoksukaO93W/7MecBdnR0WOcDmnMCAQAAAAC+EQACQIgzA0LMoBAzMCQzMzOoQeDoPvtYQ0LarrpKrowMn+vSN25U9Zw5yn7gAdn8OMXXTAg2k4JbWlpoCwYAAAAAHwgAASBMxMbGqqCgQLNmzVJ2drY1STgoYmLUf8wxqt28Wb0nnCBvTMy0y+xjY8q76y5VzZ2r1N/8xkzz8NuWBgcHrbbgnp4e2oIBAAAA4GMIAAEgzDgcDuXl5VlBYE5OjmJ8BHD+5klPV8fll8u5Zo2Gv/lNn+viWlpU8qMfqezkkxX/73/7bz8ejzo7O6224JGREb/dDwAAAACEGwJAAAhTJvjLzc21gkDzMVhB4ORuu6npwQfVdNddmiwt9bku+bXXVLlggfJ//nPZ+/v92hbc2NhotQWbycEAAAAAEO0IAAEgzJlWYFMJaILA/Px8q0Iw4Gw2DX/ve3KuW6fOJUvkSUycfpnHo6ynnlJ1TY0yV62SXC6/tgU7nU7aggEAAABEPQJAAIigIDArK8sKAs1ZgebMwEDzxser5/TTVbtpk/rnzfO5zjEwoIJrr1XlEUco6bXX/N4WXF9fT1swAAAAgKhFAAgAEcZMCTbTgs3U4MLCQsXFxQV8D678fLXdeKPqn3pKY3vu6XNdwr//rfKTTlLxkiWKbWnx234mJyettuDm5mbrcwAAAACIJgSAABDBQWBGRoaqqqpUXFys+Pj4gO9h7KtfVf2qVWr9+c/lys72uS7t179W1Zw5yr3rLtlGR/22n6GhIast2FQFmupAAAAAAIgGBIAAEAVBYFpaWvCCQLtdAwsWqHbzZvWcfLK8Ps4otE9OKueBB1Q9Z47SNmyQvF6/bMfr9VrnAtbW1qrfj8NIAAAAACBUEAACQBQJZhDoSUlR58UXW4NChr7zHZ/rYjs6VPzjH6t80SIl/OtfftuPy+VSW1ubdT7g2NiY3+4HAAAAAIKNABAAojgILCkpUUJCQkDve7KiQs333afG5cs1UVnpc13SG2+o4sgjVXDVVYrp6fHbfkz4Z0LA1tZWKxQEAAAAgEhDAAgAUSw1NVWVlZVBCQJHDjhAzhdeUMell8qdkjLtGpvXq8znnlN1TY2yHn3UTPPw234GBga0detWdXd3cz4gAAAAgIhCAAgA+DAILC0tDWwQGBur3sWLrfMB+444Ql6bbdplMcPDyr/5ZlXNn6/kP/zBb9sx5wN2dXVZg0IGBwf9dj8AAAAAEEgEgACAD6WkpHwYBCYmJgbsyrizs9X+s5+p/plnNPq1r/lcF19Xp7Izz1TJWWcptr7eb/uZmppSS0uLGhoaND4+7rf7AQAAAIBAIAAEAEwbBFZUVAS8InD8i19Uw+OPq+WWWzSVn+9zXeorr6h63jzl3Xqr7MPDftvP6Oio6urqOB8QAAAAQFgjAAQAfGpFoDkjMGBTg202Dc6Zo9qNG9V11lnyxMVNv8zlUvbDD1vnA6avWSN5PH4/H9C0B3v8eD8AAAAA4A8EgACAHToj0EwNLi4uVpyPQG6meZOS1H3eeXJu3KjBH/zA5zpHT4+KrrhCFcceq4Q33/Tffrxea0BIbW2t+vv7ra8BAAAAIBwQAAIAdlhaWpoVBBYVFQUsCJwqLlbLHXeo4eGHNb7bbj7XJb79tiqPPVZFl14qR2en3/bjcrnU1tZmtQYP+7H9GAAAAABmCgEgAGCn2Gw2paenW0FgYWGhYmNjA3IFR7/xDdU9/7zar7xSrvR0n+vS16+32oKzly+XbWLCb/uZmJhQU1OTGhsbGRQCAAAAIKQRAAIAPnMQmJGRoerqahUUFAQmCHQ41HfssardvFm9xx0nb0zMtMvsY2PKu/NOVc2bp9Tf/c707/ptSyMjI1Y1oKkKNNWBAAAAABBqCAABALscBGZmZlpBYH5+vhwOh9+vqCcjQx1XXKG6NWs0su++PtfFNTWp9PzzVXH66YrfutWvezLnAprzAc05gQwKAQAAABBKCAABADMWBGZlZVlBYG5urmJ8VOfNpInddlPjww+r+a67NFlS4nNdyl/+oqoFC5R/3XWyDwz4bT8m+DOTgk0Q2NfXx6AQAAAAACGBABAAMLP/sNjtysnJsYLA7OxsKxj0K5tNQ9/7npzr16vz/PPlSUycfpnbrawnn7TOB8x4+mnJ7fbblkwrcHt7u5xOpwYHB/12PwAAAACwIwgAAQB+YSoA8/LyNGvWLKtF2N9BoDc+Xj1nnqnaTZs0MHeuz3WO/n4V/uxnqjziCCX97W9+3dPk5KRaWlpUX1+v0dFRv94XAAAAAPhCAAgA8CtzJqAZEmKmBpvpwf7mys9X6803q/7JJzX2xS/6XJfw/vsqX7xYxRdcIEdLi1/3NDY2poaGBiYGAwAAAAgKAkAAQEDExcWpqKjICgJTU1P9fn9je+2l+tWr1XrttXJlZflcl/arX6l67lzl3H23bGNjft3TtonBra2tmpqa8ut9AQAAAMA2BIAAgICKj49XSUmJKioqlJyc7N87s9vVv2CB/r1hg7pPOkleHxOK7RMTyr3/flXPmaO0TZskr9ev2xoYGLAGhXR0dFjnBQIAAACAPxEAAgCCIjExUWVlZdYtISHBr/flSU1V58UXy7lunYa//W2f62Lb21V88cUqX7RI8f/6l1/35PV61dvbawWB3d3d1gRhAAAAAPAHAkAAQFCZKsDKykoVFxcrNjbWr/c1WVGhpgceUOP992uiosLnuqQ33lDlkUeq4Kc/VUxvr1/3ZIK/rq4uKwg0gaAJBgEAAABgJhEAAgBCQlpamqqrq5Wfn29NEPankQMPlPOFF9RxySVyp6RMu8bm9Srz2WdVXVOjrJUrJT+f2WdagU1LsAkC+/v7CQIBAAAAzBgCQABAyLDZbMrKyrKCwOzsbOtrv4mLU+9JJ6l20yb1L1wor4/7ihkaUv5NN6lq/nwlv/qq/M0MB2lra5PT6dTg4KDf7w8AAABA5CMABACEHFMBmJeXp1mzZikjI8Ov9+XOyVHbtdeq/plnNLrXXj7XxTudKjv9dJWcc45i6+vlb5OTk2ppabGCwOHhYb/fHwAAAIDIRQAIAAhZDodDhYWFqqqqUoqPVt2ZMv7FL6rhiSfUcvPNmsrP97ku9eWXVT1vnnKXLZM9AMHcxMSEmpqaVF9fr5GREb/fHwAAAIDIQwAIAAh58fHxKi0tVXl5uTU92G9sNg3OnavaDRvUfcYZ8sTFTb/M5VLOQw+pevZspa9dayZ5yN/GxsbU2Nho3cznAAAAALCjCAABAGEjKSlJFRUVfp8Y7E1OVtePfiTnhg0a/P73fa5zdHer6Cc/UcWxxyrhzTcVCKYK0FQDmqrA8fHxgNwnAAAAgPBGAAgACNuJweacQLvdf/+UTZWUqOXOO9Xw0EMa3203n+sS335blcceq8LLLpOjs1OBYM4FrKurU3Nzs9UmDAAAAAC+EAACAMKSmRBsJgWbIDAzM9OvE4NHv/lN1T3/vNqvuELutDSf6zLWrVN1TY2yV6yQbXJSgTA0NGQNCjEDQwgCAQAAAEyHABAAEPaDQgoKClRZWenfQSEOh/qOO061L76o3mOPlddH5aF9bEx5t9+uqkMPVcrvfid5vQqEwcFBgkAAAAAA0yIABABE1KAQczOf+4s7I0MdV15pVQSO/Nd/+VwX19Sk0vPOU+lppylu61YFyrYgsLW1VZMBqkIEAAAAENoIAAEAEcVUAZpqQFMVGBMT47f7mdh9dzU+8oia77hDk0VFvvfzpz+pav585V9/vewDAwqUgYEB1dbWEgQCAAAAIAAEAEQecx6gORdw1qxZ1jmBfjsf0GbT0A9+YE0L7jz/fHkSE6df5nYr64knrPMBM1avltxuBTIIpCIQAAAAiG5UAAIAIpaZEGwmBZuKQDM52F+8CQnqOfNM1W7YoIE5c3yuc/T3q/Caa1R5xBFKfP11v+3nE/vzej8MAtva2mgNBgAAAKIMASAAIOLFxsaquLhY5eXlSkhI8Nv9uAoL1XrLLap//HGNfeELPtclvP++Kk48UcUXXihHS4sCGQT29/dTEQgAAABEGQJAAEDUSEpKUkVFhQoLC/16PuDY17+u+tWr1fazn8mVleVzXdqLL6p67lzl3HOPbGNjCnRFoDkjsKWlRRMTEwG7bwAAAACBRwAIAIgq5jzAjIwMVVdXW+cE+u18wJgY9R9xhGo3b1bP4sXyOhzTLrNPTCj3vvtUPWeOUjdvNumcAmnb1GCCQAAAACByEQACAKKSqQA0k4LN+YDJycl+ux9Paqo6L71Uzhde0PD++/tcF9verpKLLlLZ4sWKf/ddBdq2ILC5uVnj4+MBv38AAAAA/kMACACIavHx8SorK1NJSYl1VqC/TFZVqWn5cjXdf78myst9rkt+/XVVHnmkCq6+WjG9vQq0oaEh1dXVqampiSAQAAAAiBAEgAAASEpNTVVVVZVyc3P91xZss2n4wAPl/OUv1XHxxXL7qDy0eTzKfOYZVc+erczHH5empgL+PRoeHv4wCBwL4PmEAAAAAGYeASAAANv+UbTblZOTY50PmJaW5r/rEhen3pNPVu2mTepfsEBeH4FjzOCgCm64QVXz5yv5f/4nKN8nEwTW19ersbFRIyMjQdkDAAAAgF1DAAgAwMeYVuDi4mKVl5dbLcL+4s7NVdvPf676p5/W6Fe+4nNdvNOpstNOU8k55yi2sTEo3y8T/pkQ0ISBJhQEAAAAED4IAAEA8CEpKckaEpKfn29VB/rL+J57quHJJ9Vy442aysvzuS715ZdVdeihyr3tNtmDVI1n2oFNW7BpDzaDQ7wBnloMAAAAYOcRAAIAsB3mPMCsrCz/twXb7RqcN0+1Gzeq+7TT5PExkMQ+NaWcBx9U1ezZSv/lLyWPR8FgJgW3tLRYk4P7+/sJAgEAAIAQRgAIAMAOcDgcVluwmRjsz7Zgb3Kyui64QM4NGzR08ME+18V2dalo6VJVHHecEt58U8EyOTmptrY21dbWqq+vT54gBZIAAAAAfCMABABgJyQnJ1ttwXl5ef6bFixpqrRUzXffrYYHH9REdbXPdYlvvaXKY49V4eWXy9HVpWCZmppSe3u7FQT29PQQBAIAAAAhhAAQAICdZIK/7Oxsqy04NTXVr9dvdL/95FyzRu1Ll8q9nRbkjBdeUFVNjbIffFC2yUkFi8vlUmdnp7Zu3aru7m653e6g7QUAAADA/yEABABgF6YFl5SUqLS0VHFxcf67jrGx6lu0SLWbN6vv6KPl9TGQJGZ0VHm33aaqefOU8vLLUhAHdJjgr6urywoCOzo6rApBAAAAAMFBAAgAwC5KSUlRVVWVcnNz/doW7M7MVPtPf6q6557TyD77+FwX19io0nPOUenppyuutlbBZM4E7O3ttVqDzVmB5sxAAAAAAIFFAAgAwAwwwV9OTo4VBJpA0J8m9thDjY8+qubbbtNUYaHPdSn/8z+qOvxw5d9wg+yDgwomr9drTQs2QWBzc7M1RRgAAABAYBAAAgAwg0wrsGkJNq3BZnKw39hsGjrkENVu3Kiuc8+VJyFh+mVut7Ief1zVNTXKeOYZ05urYBsaGlJdXZ0aGxs1MjIS7O0AAAAAEY8AEAAAPzDDQcyQkMzMTL9eX29CgrrPPtsKAgdmz/a5ztHXp8Krr1blkUcq8fXXFQpM+GdCwPr6eisUBAAAAOAfBIAAAPjrH1m7XQUFBaqsrFSCjwq9meIqLFTrrbeq/rHHNL7HHj7XJbz3nipOPFFFF10kR1ubQsHY2JjVFmzag02bsGkXBgAAADBzCAABAPAzE/5VVFQoPz/fCgX9aWzvvVX37LNqu+YaubZTfZi+ebOq58xRzn33yRYi5/GZASFmUIiZHNzT02MNEAEAAACw6wgAAQAI0JCQrKwsa0iIaQ/2q5gY9R95pGo3b1bPiSfK6+MsQvv4uHLvuccKAlNffNFM6lAocLlc6uzs1JYtW6yP5msAAAAAnx0BIAAAARQbG2sNCDE387k/edLS1HnZZXKuXavh/ff3vae2NpVceKHKfvhDxb//vkKFqQA0lYCmItBUBpoKQQAAAAA7jwAQAIAgMFWAphrQVAX622R1tZqWL1fTvfdqsqzM57rkv/1NlQsXquCaaxTT16dQYc4ENGcDmjMCzVmB5sxAAAAAADuOABAAgCAx5wGacwEDMSRENpuGv/tdOdetU8dFF8mdlDT9Mo9HmatXq7qmRplPPCFNTSmUmGnBZmpwQ0ODhoeHg70dAAAAICwQAAIAECJDQvLy8qyzAv3JGxen3lNOkXPzZvUffrjPdTGDgyq4/npVLVigpD/9SaFmdHRUTU1NcjqdGhgYYHIwAAAAsB0EgAAAhAAT/GVnZ1ttwcnJyX6/P1durtquv151Tz+tsS9/2ee6+NpalZ96qkrOO0+xTU0KNRMTE2ptbWVyMAAAALAd048FRNQz5y0B04mJibHaFk1YweME4WDb4zRcHq9mMEhpaal15p2ZgOt2u/16f2N77qm6J59U+vr1yrvtNsV2d0+7LvV3v1PyH/6g3h/+UF2nnSZvAELKnTE1NaWOjg51d3crIyPDOlvR4WP6cajjeRbhJtyeZxHdeI5FuOE5FjMlPF8Zw+9cLhdXGdMyP1jzOEE48neQNtNSUlKs1mATAppz7/yt79BDNXDQQcpdsULZjz0m+zRn/5lfy1mxQukvvKCOCy5Q/5w55iBDhRIzObirq8sKAs2gFRMExsfHK5zwPItwFW7Ps4hOPMciXPEci11FAIjpHxhhWjUB/zM/VJt3oUwFYE5ODpccIc88Xs0LJvOOv7/P1/PHc3FZWZk17KK9vd2qcvOr1FR1XXih+hcuVP6ttyrtpZemXRbb1aWSyy9X1urVal+6VON77qlQZK6buZkw1QSBgWitngk8zyLchPPzLKIPz7EINzzHYqaQ8mBavHiDL+YFvqmw2dYGDIQL83gN18esqWQz4ZWpBuzr6/P7/bkqKtRyzz3q/9OflH/99Yp3Oqddl/Tmm6o65hhrmEjnBRfInZurUDQyMmLdTEWlOWfRXM9QfizwPItwFc7Ps4gePMciXPEci10VWn07AABgWiZ0LygosKYFB6qldWS//eRcu9aq8nOnpvpcl/HCC6qePVtZDz0k2+SkQtX4+LhaWlpUW1ur3t5e680MAAAAIBoQAAIAEEYSExNVWVmp3NzcwFTaxMaqb9Ei1W7erL6jjpLXx33GjIwof9kyVc2bp5Tf/970qyhUbRsYsmXLFquqknNvAQAAEOkIAAEACDPbzuA0QaAJBAPBnZWl9quvVt1zz2lk7719rotrbFTp2Wer9IwzFOejdThUmArAnp4ebd26Va2trVaFIAAAABCJCAABAAhTphW4vLxceXl5ATt3a+Lzn1fjypVqXrZMUwUFPtelvPqqqg4/XHk33ST74KBC/XDtgYEB1dXVqbGx0RocAgAAAEQSAkAAAMKYCf7MYIuqqiolJSUF6k41VFOj2o0b1XXOOfIkJEy/zOVS9sqV1vmAGc8+a05eV6gzw0KamprkdDrV399vhYMAAABAuCMABAAgAsTFxVnVgPn5+dbAkEDwJiaq+5xzVLthgwZqanyuc/T2qvCnP1XlUUcp8X//V+FgYmJCbW1tVntwd3e3NTUSAAAACFcEgAAARJCsrCyrGjA5OTlg9+kqKlLrsmWqf+wxje+xh891Ce++q4pFi1R08cVytLUpHJgBIV1dXdbAkPb2dk2G8JRjAAAAwBcCQAAAIkxsbKzKyspUWFgYsGpAY2zvvVX37LNqu/pquTIzfa5L37RJ1XPnKuf++2ULk8EbphW4r69PtbW1am5u1ujoaLC3BAAAAOwwAkAAACJURkaGVQ2YkpISuDuNiVH/UUepdtMm9S5aJG9MzLTL7GNjyr37blXNnavUX/3KJGwKF0NDQ2poaFB9fb0GBwc5JxAAAAAhjwAQAIAIrwYsLS1VUVGRYnyEcf7gSU9Xx9Klcq5dq+FvfcvnurjWVpVccIHKTjpJ8e+/r3AyNjamlpYWqyqwp6eHcwIBAAAQsggAAQCIAunp6VY1YGpqakDvd3LWLDX94hdquuceTZaW+lyX/Ne/qnLhQuVfe61i+vsVTqamptTZ2WkNDOno6LC+BgAAAEIJASAAAFHC4XCopKRExcXFAa0GlM2m4YMOknP9enVeeKHcSUnTL/N4lLVqlaoPOUSZTz5pJnAonHg8HvX29lpBoDkn0FQIAgAAAKGAABAAgCiTlpYWlGpAb1ycek49Vc5Nm9R/2GE+18UMDqrguutUuWCBkv78Z4Ujc06gOSOQcwIBAAAQCggAAQCI4mrAQJ8NaLjy8tR2ww2qW7VKY3vu6XNdwtatKj/lFBWff75im5sVjj56TqCpDnS73cHeEgAAAKIQASAAAFEsWGcDGuNf+YrqV61S6/XXy5WT43Nd2m9/a00Lzr3jDtlGRhSOzLmA5nzAbecETk5OBntLAAAAiCIEgAAARLlgVgPKbtfA4YerdvNmdZ96qjyxsdMvm5xUzi9+oeo5c5S2fr3k9SocbTsn0FQEmnMCR0dHg70lAAAARAECQAAA8B/VgCkpKQG/Ip7kZHVdeKGc69Zp6Lvf9bkutrNTxZdeqvLjj1fCP/+pcGbOCWxoaFBdXZ0GBgbkDdNQEwAAAKGPABAAAPxHNWBpaakKCwtltwf+ZcJUebma771Xjb/4hSaqqnyuS/rHP1Rx9NEqvOIKxXR3K5yNj4+rtbXVqgrs6emxqgQBAACAmUQACAAAPiEjI0PV1dVBqQY0RvbfX861a9V+2WVy+zif0Ob1KmPNGlXX1Cjr4YelMD9Xz5wT2NnZabUGmzZh8zUAAAAwEwgAAQBASFYDKjZWfSeeaJ0P2HfkkfLabNMuixkZUf6tt6rq8MOV/MorCnemAtC0B5vpwU1NTRoJ08EnAAAACB0EgAAA4FOrAc3ZgMnJyUG5Uu6sLLVfc43qnn1Wo1//us918fX1KjvrLJWeeabi6uoUCYaHh9XY2Cin06n+/n7agwEAAPCZEAACAIBPFRsbq7KyMuXn58vmoxLP3ya+8AU1PPaYmpct01RBgc91KX/4g6oOO0x5N98s+9CQIsHExITa2tq0detWdXV1yeVyBXtLAAAACCMEgAAAYIdlZWVZ1YCJiYnBuWo2m4ZqalS7caO6zj5bnvj46Ze5XMp+9FFVz56t9OefN321igRut1vd3d1WEGgGh5gBIgAAAMCnIQAEAAA7JS4uTuXl5crNzQ1aNaA3MVHd556r2g0bNPjf/+1znaOnR0VXXmlNDE78+98VKbxerwYGBlRXV6f6+nrrzEDzawAAAMB0CAABAMBOM8FfTk6OKioqlJCQELQr6CouVsvtt6th5UqN7767z3WJ77yjiuOPV9Ell8jR3q5IMjY2Zk0Orq2tVU9Pj1UlCAAAAHwUASAAAPjMTPhnQkATBgarGtAY3Wcf1T33nNquukqujAyf69I3blT1nDnKfuAB2SYmFEmmpqbU2dlptQe3t7drcnIy2FsCAABAiCAABAAAu8QEf6Yd2LQFm/bgoImJUf8xx6h282b1nnCCvDEx0y6zj40p7667VDV3rlJ/8xvTT6tI4vF41NfXZ1UENjU1aWRkJNhbAgAAQJARAAIAgBlhBoNUVlZag0KCyZOero7LL5dzzRoNf/ObPtfFtbSo5Ec/UtnJJyv+3/9WJBoeHlZjY6OcTqf6+/utcBAAAADRhwAQAADM3AsLu135+flWNWBsbGxQr+zkbrup6cEH1XT33ZosLfW5Lvm111S5YIHyf/5z2fv7FYkmJibU1tZmtQebNmGXyxXsLQEAACCACAABAMCMS0pKUlVVldLT04N7dW02DR98sJzr1qlzyRJ5EhOnX+bxKOupp1RdU6PMVaukCA3IzIAQMyjEBIEtLS3WABEAAABEPgJAAADgnxcZdruKiopUUlKiGB/n8QWKNz5ePaefbp0P2D9vns91joEBFVx7rSqPOEJJr72mSOX1ejU4OKj6+nrrZj43vwYAAIDIRAAIAAD8KjU11aoGNB+DzZWXp7Ybb1T9U09pbM89fa5L+Pe/VX7SSSr+0Y8U29ysSGaqAE01oKkK7O7upj0YAAAgAhEAAgAAv3M4HFYlYGFhoVUZGGxjX/2q6letUut118mVne1zXdpvfmNNC8696y7ZRkcVycy5gF1dXVYQaM4LHB8fD/aWAAAAMEOC/wocAABEjYyMDKsa0JwRGHR2uwbmz7fagrtPOUVeh2P6ZZOTynngAVXPmaO0DRtM/6wimWkFNhOD6+rq1NDQoKGhIdqDAQAAwhwBIAAACCgzHdhMCc7Ly5PNZgv61fekpKjrootUu26dhr7zHZ/rYjs6VPzjH6t80SIlvPOOosHo6Kiam5tVW1ur3t5ea4gIAAAAwg8BIAAACIrs7GxVVlYqPj4+JL4DUxUVar7vPjUuX66Jykqf65LeeEMVRx2lwiuvVExPj6LB1NSUOjo6rPbg9vZ2TU5OBntLAAAA2AkEgAAAIGhM+GdCQBMGhoqRAw6Q84UX1HHppXKnpEy7xub1KuP551VdU6OsRx+VoiQQ83g86uvrsyoCm5qaNDw8HOwtAQAAYAcQAAIAgKAybcCmHdi0BZv24JAQG6vexYut8wH7jjxSXh+tyjHDw8q/+WZVzZ+v5D/8QdHEhH8mBDRhoAkFTTgIAACA0EQACAAAQoIZDGIGhJhBIaHCnZ2t9muuUf2zz2r0a1/zuS6+rk5lZ56pkrPOUlx9vaKJaQc2bcFbtmyx2oRpDwYAAAg9BIAAACBk2O12FRYWqqSkRDExMQoV41/4ghoef1wtt9yiqYICn+tSX3lFVfPmKe+WW2SPsvZYUwFoBoWYikAzOGRkZCTYWwIAAMAHCAABAEDISU1NtaoBU3ycwRcUNpsG58xR7YYN6jrrLHl8DC+xuVzKfuQR63zA9OefN8mYos3Q0JAaGxvldDrV399PezAAAECQEQACAICQ5HA4VFpaqoKCAuucwFDhTUpS93nnyblhgwZ/8AOf6xw9PSq68kpVHHOMEv/xD0WjiYkJtbW1WdODOzs7rWnCAAAACDwCQAAAENIyMzOtasDExESFkqniYrXccYcaHnlE45/7nM91if/8pyqOO05Fl14qR0eHopHb7VZPT8+H7cGjo6PB3hIAAEBUIQAEAAAhLy4uzpoSnJOTE1LVgMbovvuq7rnn1HbVVXKlp/tcl75+vapnz1b28uWyTUwoGnm9Xqs9uKGhQXV1dbQHAwAABAgBIAAACAsm+MvNzbWCQBMIhhSHQ/3HHKPazZvVe9xx8voYYGIfG1PenXeq6tBDlfrb35pETNFqfHz8P9qDXS5XsLcEAAAQsQgAAQBAWDGtwJWVlcrIyFCo8WRkqOOKK1S3Zo1G9t3X57q45maVnH++yk45RXFbtiiabWsPNkFgS0sL7cEAAAB+QAAIAADCjt1uV2FhoTUkJMZHtV0wTey2mxoffljNd92lyZISn+uS//IXVS1YoPyf/1z2/v6A7jEU24MHBwf/oz3Y/BoAAAB2HQEgAAAIWykpKdaAEPMx5NhsGvre9+Rcv16dP/qRPD6GmNjcbmU99ZR1PmDG009LtMJ+2B68ZcsWdXV10R4MAACwiwgAAQBAWHM4HFYlYEFBQcgNCDG88fHqOeMM1W7apIG5c32uc/T3q/BnP9OeJ52ktDfeCOgeQ7k9uLu7m/ZgAACAXUQACAAAIkJmZqZ1NmBCQoJCkSs/X60336z6J5/U2Be/6HNd8tat+uK552q3yy+Xo6UloHsMVbQHAwAA7BoCQAAAEDHi4+NVUVGh7OxshaqxvfZS/erVar32Wrm2s8/sl19W9dy5yrn7btlGRwO6x1BGezAAAMDOIwAEAAARxbQB5+Xlqby8XLGxsQpJdrsGFi602oJ7TjpJXodj+mUTE8q9/34rCEzbtMmUwgV8q6GK9mAAAIAdRwAIAAAiUlJSktUSnJ6erlDlSU1V5yWXyLlunYa//W2f62Lb21V88cUqX7RI8f/6V0D3GI7twR6PJ9jbAgAACCkEgAAAIGLFxMSoqKhIxcXF1ueharKiQk0PPKDGBx7QWFmZz3VJb7yhyiOPVMFPf6qY3t6A7jGc2oO3bt2qzs5OTU1NBXtLAAAAIYEAEAAARLy0tDSrGtBUBYaykW9/W2898YTqzz1XruTkadfYvF5lPvusqmtqlLVypUTINW17cE9Pj2pra9Xc3KxRzlAEAABRjgAQAABEBXMeoDkX0JwPaM4JDFXe2Fi1HXec3nzmGfUvXCivj73GDA0p/6abVDV/vpJffTXg+wyX9uChoSHagwEAQNQjAAQAAFHFTAg2k4Lj4uIUyqaystR27bXWxODRvfbyuS7e6VTZ6aer5OyzFVtfH9A9hhPagwEAQDQjAAQAAFEnISHBagnOzMxUqBv/0pfU8MQTarn5Zk3l5/tcl/r736t63jzlLlsm+8hIQPcYju3B5pxA2oMBAEC0IAAEAABRyW63q6CgQKWlpSE9IMRis2lw7lzVbtig7jPOkMdH9aLN5VLOQw9Z5wOmv/CCxDTc7drWHux0OpkeDAAAIhoBIAAAiGopKSmqqqpSso+hG6HEm5ysrh/9SM716zX4/e/7XOfo7lbR5Zer4thjlfDmmwHdYziamJhgejAAAIhoBIAAACDqORwOlZWVKT8/P6QHhGwzVVqqljvvVMNDD2l81iyf6xLffluVxx6rwqVL5ejqCugeI6E9eIRWagAAECEIAAEAAD6QlZVlDQiJj48Pi2sy+s1vqm7NGrX/5Cdyp6X5XJfxy1+qqqZG2StWyDY5GdA9hnN7cGNjo9Ue3NfXJw/t1AAAIIwRAAIAAHxsQIgJAcNhQIjF4VDf8cer9sUX1XvssfLap395FzM6qrzbb1fVoYcq5aWXJK834FsN1/bg9vZ2bdmyRR0dHZokQAUAAGGIABAAAGA7A0JMe3A4cGdkqOPKK1X3/PMa+a//8rkurqlJpeeeq9LTT1fc1q0B3WM4MxWAvb29qq2tVVNTk4aHh4O9JQAAgB1GAAgAALCdASGVlZXWx3AxsfvuanzkETXfcYcmi4p8rkv5n/9R1fz5yr/hBtkHBgK6x3Bnwj8TApow0ISCtAcDAIBQRwAIAACwHaYC0FQCmorAcBgQYrHZNPSDH8i5YYM6zz9fnsTE6Ze53cp6/HFVz56tjNWrzRSMgG81nJl2YNMWbNqDTZuwaRcGAAAIRQSAAAAAO8CcCWiqAcNlQIjhTUhQz5lnqnbjRg3MmeNznaOvT4XXXKPKI49U4uuvB3SPkcBUAJpBIWZgiBkcYgaIeDljEQAAhBACQAAAgB1kwj8TApppweHEVVCg1ltuUf0TT2jsC1/wuS7hvfdUceKJKr7wQjlaWwO6x0gxMjKi5uZmqz24p6dHbqoqAQBACCAABAAA2AmmDTg/Pz+sBoRsM/a1r6l+9Wq1XnutXNsJMdNefFHVc+cq5957ZRsbC+geI8XU1JQ6Ozut9uC2tjaNj48He0sAACCKEQACAABEyYAQS0yMBhYuVO3mzepZvFheHyGmfXxcuffeawWBqZs3S7S0fiamFbi/v191dXVqaGjQ4OAg7cEAACDgCAABAAB2cUCIqQgMmwEhH/Ckpqrz0kvl/OUvNXzAAT7Xxba1qeSii1S2eLHi3303oHuMNKOjo2ppadHWrVvV3d0tl8sV7C0BAIAoQQAIAACwi8yZgOE2IGSbycpKNS1frqb779dEebnPdcmvv24NCSm4+mrF9PYGdI+RxgR/XV1dVhDY2tqqMdqsAQCAnxEAAgAAzAAT/lVUVFjTgsPR8IEHWtWAHRdfLHdy8rRrbB6PMp95RtWzZyvz8cfNQXcB32ektQcPDAyovr7eupnPmR4MAAD8gQAQAABgpl5Y2e0qKCiw2oJjYmLC77rGxan35JNVu2mT+ufP97ksZnBQBTfcoKr585X8P/8T0C1GKlMFaKoBzdAQUx1ohogAAADMFAJAAACAGWYGg1RVVSnZRyVdqHPn5qrtuutUt3q1Rr/6VZ/r4p1OlZ12mkrOOUexjY0B3WOkcrvd1vmAtbW1am5uts4NBAAA2FUEgAAAAH4aEFJWVhaWA0K2Gd9zTzU8+aRabrxRU3l5Ptelvvyyqg49VLm33Sb7yEhA9xipTCvw0NCQNTnY6XRak4Q9Hk+wtwUAAMIUASAAAICfB4SYswHDcUCIxWbT4Lx5qt24Ud2nny5PbOy0y+xTU8p58EFVzZ6t9F/+UiKsmjETExNqa2uzhoZ0dHRocnJy5v7jAAAgKhAAAgAA+FlCQkJYDwgxvMnJ6lqyRM4NGzR08ME+18V2dalo6VJVHHecEt56K6B7jIb24N7eXqs9uKmpScPDw8HeEgAACBMEgAAAAAEcEFJSUhKeA0I+MFVaqua771bDgw9qfNYsn+sS33pLlccco8LLL5ejqyuge4wGJvwzIaAJA00oaMJBAAAAXwgAAQAAAig1NdUaEJKUlBTW1310v/1Ut2aN2i+/XO60NJ/rMl54QVU1Ncp66CHZaF2dcaYd2LQFm/bg9vZ2q10YAADg4wgAAQAAgjQgJDc3N2wHhFgcDvWdcIJqN29W3zHHyGuf/qVlzOio8pctU9W8eUp5+WUz4SLgW410ZkBIX1+fNTDEDA4xA0TMIBEAAACDABAAACAITPCXk5Oj8vJyxfoYrBEu3JmZar/qKtU995xG9tnH57q4xkaVnnOOSs84Q3G1tQHdYzQZHR1Vc3Oz1R7c3d0tl8sV7C0BAIAgIwAEAAAIosTERKslOD09Pey/DxN77KHGRx9V8223aaqw0Oe6lFdfVdX8+cq78UbZBwcDusdoMjU1pa6uLqs9uLW1VePj48HeEgAACBICQAAAgBAYEFJUVKTi4mLr87Bms2nokENUu3Gjus49V56EhOmXuVzKfuwxVdfUKOOZZ8yI24BvNVqYVuCBgQHV1dWpvr7e+pz2YAAAokuYv8IEAACIHGlpaVYQGB8fr3DnTUhQ99lnW0HgwOzZPtc5+vpUePXVqjzqKCW+/npA9xiNxsbGrGrALVu2WNWBpkoQAABEPgJAAACAEBsQkp+fr4yMDEUCV2GhWm+9VfWPPabxz3/e57qEd99VxYknqujii+VoawvoHqOR2+22zgc05wSa8wLNuYEAACByEQACAACE4IAQEwBGwoCQbcb23lt1zzyjtmuukSsz0+e69E2bVD1njnLuu082zqzzO9MKbCYGm8nBZoKwmSRsJgoDAIDIQgAIAAAQopKSklRZWanU1FRFhJgY9R95pGo3b1bPiSfK63BMu8w+Pq7ce+6xgsDUF180KVXAtxqNJiYm1N7ebrUHd3R0aHJyMthbAgAAM4QAEAAAIITFxMSopKREBQUFVmVgJPCkpanzssvkXLtWw/vv73NdbFubSi68UGUnnaT4998P6B6jmakA7O3ttdqDGxsbNTw8HOwtAQCAXUQACAAAEAYyMzOtasBIGBCyzWR1tZqWL1fTffdpsqzM57rkv/5VlQsXquCaaxTT1xfQPUa7kZERNTU1aevWrerp6bHODgQAAOGHABAAACBMmPCvoqLCCgMjhs2m4e98R85169Rx0UVyJyVNv8zjUebq1aquqVHmE09ILlfAtxrNzLTgzs5Oqz24ra1N45zPCABAWCEABAAACCN2u91qBy4tLbXagyOFNy5OvaecYp0P2H/44T7XxQwOquD661W5YIGS/vSngO4R/zc0pL+/X3V1daqvr9fg4KD1awAAILQRAAIAAIShlJQUVVVVKTk5WZHEnZurtuuvV93TT2vsy1/2uS5h61aVn3qqSs47T7FNTQHdI/7P2NiYWlparPbg7u5uuajKBAAgZBEAAgAAhCmHw6GysjLl5eVFzICQbca//GXVP/WUWm68UVO5uT7Xpf7ud6qaO1e5t98u28hIQPeI/2OCP3M+oAkCTSA4OjrKpQEAIMQQAAIAAIS57OxslZeXKzY2VhHFbtfgvHlybtqk7tNOk8fH/599ako5K1aoes4cpa1bZ/pUA75V/F97sGkJbmhosFqETauwmSgMAACCjwAQAAAgAiQmJlotwenp6Yo0nuRkdV1wgZzr12vooIN8rovt7FTxZZep/PjjlfD22wHdI/6TGRJihoWYqsCOjg5NTk5yiQAACCICQAAAgAgaEFJUVGTdzOeRZqqsTM333KPGBx/URHW1z3VJ//iHKo8+WoU/+YliuroCukf8J7fbrd7eXtXW1qqpqUnDw8NcIgAAgiDyXhkCAABEOVMFWFlZqYSEBEWikf32k3PNGrUvXSp3WprPdRlr16p69mxlPfywRAVa0Jnwz4SAJgw0oaAJBwEAQGA4AnQ/Ia+vr0/vvPOOtmzZYr0oMbeRDw6SXrFihfLz87f7582fNS0O2/6sOQDZnHly0EEHacmSJbu0t8svv1z//Oc/t7tm77331lVXXbVL9wMAACJHXFycKioq1NXVZQ1oiDixsepbtEiDZgDIXXcp49lnZZvmvLmYkRHl33qr9fudl12m4QMPDMp28f+ZdmDTFtzZ2WmF1ZmZmREbVgMAECoIAD+wefNmPf3005/5Qi5dulT+Zl4Y+XpxlJKS4vf7BwAA4cVMBjYTgpOSkqzz2My01kjjzsxU+09/qr6jjlL+DTco+fXXp10X39Cg0rPO0vABB6jj0ks1WVUV8L3ik0NDzKAQczOPURMEpqamRtxEawAAQgEB4AfMC43c3FxVV1dr1qxZ1kHapvJvZ95lN6022/78b37zG7377rsz+s06/PDDddxxx83ofxMAAEQ+80aheZ1iQsBIPYNt4vOfV+PKlUp98UXl33KLYtvbp12X8sc/KvnPf1bv8cer++yz5UlNDfhe8Umjo6PWzeFwWEFgRkaG9TkAAJgZ/Kv6gaOOOkrHHnvshxfG6XTu1IVcvXq1YmJiPvz6tddem6FvEQAAwK4zYUppaal19pppvTTVVxHHZtNQTY2Gv/MdZT/8sLIffFD2iYlPLnO5lL1ypdLXr1fXkiXqnz9f+sjrOASPqVI1bevd3d1WNaAJA011IAAA2DUMAfnAR8O7YPx5AACAQMjKyrLOBjTdC5HKm5io7nPOUe3GjRo85BCf6xy9vSq86ipVHH20Et94I6B7xPaZgHpwcFANDQ3WG/OmTdicrw0AAD4bAkAAAIAoY84UNi3BZgBDJHMVFanlttvUsHKlxnff3ee6xH/9SxUnnKCiSy6Rw0frMIJnYmLCal83A/fM8BAzRAQAAOwcWoDDyCuvvKLf/e531sRi88K9pKRE++67r2pqamiNAAAAO8Vut6uoqMg6H9CEK5FcXTW6zz6qe+45ZTz3nHLvvFOO/v5p16Vv3KjUl15S92mnqfeHP5SXybQhxe12Wy3s5mYet6Y9mEF4AADsGALAMGJenJvze+Lj4zUyMqL33nvPum3atElXXHGF9U7+p3niiSf01FNPTft7X/3qV612IPMDQDvvfsOHbT8g8jgBgMh5nk1OTrbOXTOVVpFs4JBD1Lzffip56CEVPP+8bG73J9bYx8aUd9ddSnv2WTWed556v/Md62xBhJaBgQG1tLQoNjbWCgHNeYEm1AY+Da9lAYS7z/qmLQFgGPjSl76k733ve9prr72siWhmYvHQ0JD+8Ic/6PHHH7desF9zzTW6y7xYTUvb7n/LBIfm4G9f76puE8lVAJg5PE4AIDKeZ01wkpeXZ52zZs5di2Su1FTVL1mijnnzVHHnncr429+mXZfQ1qbPXX65Br72NdVfcIFGq6sDvld8OtMObCoCTYeMCbJNEBjJ51tiZvFaFkA0IQAMA8cdd9wnfs28uJkzZ4523313/fjHP7Ze+Lzwwgs68cQTt/vfMi+MzAv8Txtkwjuo2JEXSjxOACCynmezs7OtY0XMBNaPvjEYicarq/XenXcq849/VPlddymhpWXadelvvKEvL16sjsMPV/Ppp8sV4ecmhjPzRre5maNyzGtl81g2b5wDH8VrWQDRKioCwOuvv95qlf24Aw44QKeddprC2axZs6z/j5dffll/+9vfPjUAPOGEE6zbdJYtW2ZVFpofNgoKCvy0Y4Q7045mXjjxOEE4TZJ0uVzWEQr8IIhwEArPs6WlpdbRI8PDw4p0nkMPVf1//7eyVq5UzgMPWC3AH2fzeFSwZo1yf/tbdZ13nvqOPlpyRMXL6B1+nt32mA2V51lTGWj2ZLpnzFmB5t8AIFSeY4GdwWtZfNxnfYM4Kg7KMC9eTUvLx2/mHcJI8LnPfc76yLl9AABgJpiwxISA+fn5IRPo+JM3Lk49p52m2s2b1X/YYT7XxQwOquC661S5cKGS/vzngO4RO8+8+WOqWc304ObmZo2OjnIZAQBRK2oqAAEAALBzsrKyrDZKM2zBVFRFOldentpuuEF9xxyjguuvV+Lbb0+7LmHLFpWfcooGv/c9df74x5oqKQn4XrFz1TOmy8XczDA9UxGYnp7OUSYAgKgSFRWAke7f//639dG8Sw8AADCTzHlqlZWVVmASLca/8hXVr1ql1uuukys72+e6tN/+VlVz5yr3zjtli5DOkkhnJl2brpktW7ZYH6Mh2AYAwCAADIN3LLentrZWf/zjH63P99lnnwDtCgAARNtZM0VFRSouLo6eqim7XQPz51ttwd2nnCKvjzPk7JOTylm+XNVz5ypt/Xrz4i3gW8XOM2fAmcnB5rV0Y2OjVR34aa+7AQAIZ1HRAryjLwI+etD1R88HNL+emJj44dcpKSmfePE7Njamqamp/zhzxDC/Njg4+OGvx8bG/sd/y3jqqaf09NNPW5+vW7fuP37vueeeU2trqzXow0z8NVN8t+3JBH+PPfaYdV+mlWH+/Pm7fB0AAAB8SUtLsyoCzWsT89onGnhSUtR10UXqX7hQ+bfcotSXX552XWxHh4ovvVSZTz+tjqVLNf6lLwV8r9i16cHmdboZGmJuDA0BAEQaAsAPdHV1+ZwIfMEFF/zH1ytWrPhEu+3y5cv10ksvfeLPmpBuW4WecdBBB2nJkiU7/A0yAeLvfvc762aYc3hM+GhepGx7l9JMr1q6dKn1ohwAAMCf4uLiVF5ebr126unpiZqLPVVRoeZ771Xyq68q/8YbFe90Trsu6e9/V8XRR1vVg51LlsidkxPwveKzMa+7zePaDA4xr6vNG+wff+MeAIBwRQAY4vbff3+rOvG9996zzikx7Qnj4+PWOTzmxfc3vvENHXzwwda78QAAAIFgJgPn5eVZb0yaakC32x01F35k//3lXLtWmatWKffeexUzNPSJNTavVxlr1ij1V79S91lnqfeEE0xyGpT9YueZN9kHBgasmwkATRCYmpoaPe3vAICIZPP64bALU+Xmrxeb2yrhMPOWLVtmBYzmBc5FF13EJca0TBBtQmnzIthUnwKhzvwzZ45KMO1c5t8RINSF2/Os+ftlQsCPHp8SLWJ6e60BIBnPPWeFfr5MlJer87LLNHzggYrU59ltj9lIfZ6NiYmxWoNNGGhahRG+wu05FuC1LGYqu/FLBeDvf//7Gf/H3zzoI/UFBQAAQLgy4XpZWZnVDmzaJ6NpkII7K0vt11yjvqOPVsENNyjpf/932nXxDQ0qPessDR9wgDouu0yTlZUB3yt2jalyNY9xczM/cJkgcNvZ3AAAhAO/1bGbF38ffQG47evpbjuzBgAAAKEnOzvbOp4kGqujJr7wBTU89pialy3T1HYqilL++EdVHXaY8m6+WfZpWocRHkzVhZkcbCYI9/b2RlULPAAgfPklADQl1f39/VqwYIEV3pWWluqmm27S66+/bv26OWDXfDRfm183LxbNuoULF1pnbZg/P92Nf1wBAABClzkvrbKyMjoHk9lsGqqpUe3Gjeo6+2x54uOnX+ZyKfvRR1U9e7bSn3/evHAO+FYxMyYnJ9XR0aGtW7dabaUTExNcWgBA9AWAhx12mNauXaujjjpK7777ri655BJ97Wtfs14QmjM0zEfztfn1f/3rXzr66KO1Zs0aHX744VT8AQAAhCnzOq+4uFiFhYVReXyLNzFR3eeeq9oNGzR4yCE+1zl6elR05ZXWxODEv/89oHvEzP/s09fXJ6fTqYaGBg0ODvLzDAAgOgLAhx9+WK+88op23313PfHEE9a7wdtjJtg+9thj+tznPmedH2j+PAAAAMKXGZhgqgHjfVTCRTpXcbFabrtNDStXanz33X2uS3znHVUcf7yKLrlEjvb2gO4RM290dFQtLS1WVWB3d7c1JAcAgIgNAE3oZ97xXbx4sXUw9I4w58WcdNJJ1rtljz/+uD+2BQAAgAAy4V9FRYU1MCFaje6zj+qee05tV10lV0aGz3XpGzeqes4cZT/wgGy0koY9E/yZoTgmCDSBoAkGAQCIuADwvffesz5WVVXt1J8z7xJ/9M8DAAAgvNntdhUUFKikpMRqD45KMTHqP+YY1W7erN4TTpDXx3Wwj40p7667VHXooUr97W/NhLyAbxUzyxQ3mJZg0xpsWoTNOeimZRgAgIgIAM0gD6Onp2en/ty29eYfSQAAAESO1NRU683epKQkRStPero6Lr9czjVrNPzNb/pcF9fcrJLzz1fZyScrfsuWgO4R/mOGhLS1tWnLli3W8BAzRAQAgLAOAM2hz8bzZrLZTti23rxLDAAAgMhijnwpKytTbm6uotnkbrup6cEH1XT33ZosLfW5Lvm111Q5f77yf/5z2fv7A7pH+I+pAOzt7VVtba0aGxs1PDzM0BAAQHgGgN/73vesf8Reeukl3X333Tv0Z+677z797ne/s84O/P73v++PbQEAACDIzGu9nJwclZeX7/BZ0RHJZtPwwQfLuW6dOpcskcfH0Dybx6Osp55SdU2NMletMofLBXyr8J+RkRE1NTVZYaDphmJoCAAgrALACy+8UHFxcdbnS5Ys0THHHKO//vWv067929/+pmOPPVbnnXee9bX5c+bPAwAAIHKZVmBzXrRpDY5m3vh49Zx+unU+YP+8eT7XOQYGVHDttao84gglvfZaQPcI/5uamlJnZ6c1NKS1tVVjY2NcdgBA6AeAe+yxh+65554Pv3722Wf1zW9+U+np6dprr730rW99y/povv7GN76hZ555xqoYNO8Imz+3++67+2NbAAAACCFmKIgZDpKfn2+9Doxmrrw8td14o+pWrdLYnnv6XJfw73+r/KSTVLxkiWJbWgK6R/if+ZnInKdeX19v3RgaAgAI6QDQOPXUU63gz7R4mH/IzG1oaEhvvfWW/vKXv1gfzdfbfs+cBWPWn3LKKf7aEgAAAEJQVlaWKioqPuwgiWbjX/mK6letUut118mVne1zXdqvf62qOXOUe9ddso2OBnSPCAxTBWiGhpiqQFMdaKoEAQAIuQDQWLBggTXl6o477tCBBx6o5OTkDwM/czNff+c739Gdd95prTPrAQAAEH0SEhKsKcGmQyTq2e0amD/fagvuPuUUeX2clWifnFTOAw+oes4cpW3YYMrHov7SRSK3222dD2iCQHNeoBkaAgDAzvL7yctpaWk6//zzrZthStrNP1opKSm8wAMAAMCH7Ha7ioqKrNeJpvLJTEuNZp6UFHVddJH6Fy5U/s03K/X3v592XWxHh4p//GNlPv20OpYu1fgXvxjwvSIwzM9R5maqZTMzM62fp0wrPQAAQa0AnI75R6q4uHinw7/3339fP/vZz6wbAAAAIpd5A9lUA5qqQEhTFRVqvu8+NS5fronKSp+XJOmNN1Rx1FEqvPJKxfT0cOki2OTkpDo6OqwuKhOWj4+PB3tLAIAQF/AA8LN67733dPXVV+uaa64J9lYAAADgZ6bCyZwLaM4HxP8ZOeAAOV94QR2XXip3Ssq0l8Xm9Srj+edVXVOjrEcfNUkRly+CmWOVzKCQuro6a2jI4OCg9WsAAIRtAAgAAIDoYiYDmwnBpaWltDluExur3sWLrfMB+444Ql4f05NjhoettuGq+fOV/Ic/BPC7hmAODWlpabHOCuzq6pLL5eKbAQD4EAEgAAAAQpo5E7CqqsoaIIf/487OVvvPfqb6Z57R6Ne+5vOyxNfVqezMM1Vy1lmKq6/n8kUBE/x1d3dbQWBzc7NGRkaCvSUAQAggAAQAAEDIczgcViVgbm6uVRmI/2MGfjQ8/rhabrlFU/n5Pi9L6iuvqGrePOXdcovsTJGNCqYVeGhoSI2NjXI6nerr64v6wToAEM0IAAEAABAWTPCXk5OjsrIyxcbGBns7ocNm0+CcOarduFFdZ50lT1zc9MtcLmU/8oh1PmD6889LUT5lOZpMTEyovb3dGhpiPpqvAQDRhQAQAAAAYSUpKcmaEpyamhrsrYQUb1KSus87T86NGzX4gx/4XOfo6VHRlVeq4phjlPiPfwR0jwguj8djVQKaisCGhgaGhgBAFCEABAAAQNiJiYlRSUmJCgoKaAn+mKniYrXccYcaHnlE47vt5vMaJv7zn6o47jgVXXqpHB0d/v6WIcSMjo5+ODTEnBnI0BAAiGwEgAAAAAhbmZmZqqioUHx8fLC3EnJG991Xdc8/r/Yrr5QrPd3nuvT161U9e7ayly+XjdbQqGOCPzM12ASBJhA0wSAAIPIQAAIAACCsJSQkWCFgRkZGsLcSehwO9R17rGo3b1bvccfJGxMz7TL72Jjy7rzTGhSS8tvfmgkSAd8qgj80ZHBw0GoNNi3C/f39DA0BgAhCAAgAAICwZ7fbVVhYqOLiYutz/CdPRoY6rrhCdWvWaGTffX1enrimJpWef77KTjlFcVu2cBmjlBkS0tbWZg0N6ejo0OTkZLC3BADYRbw6AgAAQMRIS0uzBoSYqkB80sRuu6nx4YfVfNddmiwp8XmJkv/yF1UtWKD8666TfWCASxnFQ0N6e3tVW1urxsZGDQ0NWZWCAIDwQwAIAACAiBIXF2e1BGdlZQV7K6HJZtPQ974n5/r16jz/fHkSE6df5nYr68knVV1To4ynn5bc7oBvFaFjZGREzc3NVhjI0BAACD8EgAAAAIg4NptN+fn5Ki0ttSYG45O88fHqOfNM1W7apIG5c31eIkd/vwp/9jNVHnGEkv72Ny5llJuamvpwaEhra6vGxsaCvSUAwA4gAAQAAEDESklJUVVVlZKSkoK9lZDlys9X6803q/7JJzX2xS/6XJfw/vsqX7xYxRdcIEdLS0D3iNBjWoEHBgZUX1+vuro6hoYAQIgjAAQAAEBEczgcKisrU25ubrC3EtLG9tpL9atXq/Xaa+XKzva5Lu1Xv1L13LnKuftu2aj+gqTx8XFraIipCuzs7GRoCACEoLAJAL/2ta/pkUce0cMPPxzsrQAAACAMW4JzcnJUXl6u2NjYYG8ndNntGli40GoL7vnhD+V1OKZfNjGh3PvvV/WcOUrbtMmUgwV8qwg9brdbPT091jmBTU1NGh4eDvaWAADhFgCa81sWL15s3QAAAIDPwrQCmynBqampXMDt8KSmqvPHP5bzl7/U8Le/7XNdbHu7Si65RJU//KES3n2Xa4oPmfDPhICmKtCEgiYcBAAEz/Rv6flhfLx5F6ivr88qD98R397OCw0AAADgszJDQUpKStTb22u1K5qzzDC9ycpKNT3wgJJfeUX5N92k+Pr6adclv/GGKo88Uv1HHKGuH/1IbiYw4yNDQ8zfMzM4JC0tzZrOnZCQwPUBgEgKAP/0pz/p5ptv1m9+85sdDv62tWi4XC5/bg0AAABRzgQRpiKwpaWFM8s+xciBB8r5zW8q68knlXPffYoZGfnEGpvXq8xnn1Xaiy+q65xz1HfssRLt1vjY0BBzS0xMVGZmplWJa7eHTVMaAIQ1vz3bLlu2zKriW79+vTUa3jzh78wNAAAA8DdTiWRagtPT07nYnyYuTr0nnaTazZvVv2CBvDbbtMtihoZUcOONqpo/X8mvvsp1xSeYnw9bW1s/HBpiqgQBAGFYAfjHP/5Rl1xyiVXJZ8K84uJiffe737VaLeLj4/1xlwAAAMBnYiqQioqKlJycrPb2duv4GvjmzslR289/rr5jjlH+DTco6e9/n3ZdvNOpstNP19B3v6uOSy7RVEUFlxXTDg0xN1MNmJGRoZSUFK4SAIRLAHjnnXd++Pm1116rpUuXUtoNAACAkGaqAE1romkJ3pnja6LV+Je+pIYnnlDqhg3KX7ZMsZ2d065Lffllpfzxj+pZvFg9Z5whDwEPpjE0NGTd4uLirPZg8/fRnNcJAAjhFuA///nPVvXf4Ycfrp/85CeEfwAAAAgLJnwoLy+3AgjsAJtNg3Pnasv69eo6/XR54uKmX+ZyKeehh1Q9e7bS1641UwK5vJjW5OSkOjo6tGXLFrW1tRHGA0AoB4CmhNs49NBD/fGfBwAAAPzaElxQUGAdX0MF0o7xJCVZ03+d69dr8Pvf97nO0d2top/8RBXHHquEN9+cse8ZIo85Sqq/v191dXWqr6+3hodwVjwAhFgAmJOTY30056gAAAAA4cicSWYGhJi2YOyYqdJStdx5pxoeekjjs2b5XJf49tuqPPZYFV52mRw+WoeBjw8NMVWBXV1dDA0BgFAJAL/61a9aH2tra/3xnwcAAAACIjY21moJ3vYGN3bM6De/qbo1a9T+k5/InZbmc13GunWqrqlR9ooVsk1McHnxqUNDuru7renBzc3NGhkZ4YoBQDADwFNOOcUqz3766af98Z8HAAAAAsacbZ2bm6uysjI5HH6ZoReZHA71HX+8al98Ub3HHiuvffofPexjY8q7/XZVzZunlN/9zvR+BnyrCD9mYEhjY6NVdNLb22uFgwCAAAeA8+fP18KFC/XWW2/pxz/+sT/uAgAAAAgoc7yNaQnmmJud487IUMeVV6ru+ec18l//5XNdXFOTSs87T6Wnnaa4rVt3+fuF6BoaYqoC29vbGRoCAIEMAI0nnnhCxx13nJYtW6aDDz5Y69evt8q1AQAAgHBlKgBNJWBeXp5VGYgdN7H77mp85BE133GHJouKfK5L+dOfVDV/vvKvv172gQEuMXaIx+NRX1+fNTSkoaFBg4ODDA0BgI/wSw/DR6elmVbg3//+99ZtR5kXUy6Xyx9bAwAAAHZZdna2kpKS1NLSwkCCnWGzaegHP9Dwt7+trEcfVc6KFVYL8CeWud3KeuIJpW3YoK7zz1f/kUeaHzJ45GKHjI6OWjcT2GdkZCgzM5P2fQBRzy8VgCb023b7+Nc7egMAAABCmZkObFqCzbRg7BxvQoJ6zjxTtRs3amDOHJ/rHP39KvzZz1R5xBFKfP11LjN2iikqYWgIAPixAvDb3/42LREAAACIeKbzpaSkxGo9NOeQ8Ub2znEVFKj1llvUd8wxyr/hBiX+61/Trkt4/31VnHiiBg85RB0XXSRXcfGMfP8QHczfSzM0xNzGxsasczwJ7gFEG78EgDvT7gsAAACEO9NiaCoCTUuwGUqAnTP29a+rfvVqZaxdq9w77pCjt3fadWkvvqiUl19WzymnWDdvYiKXGjvF/P2cmJjQwMCA7Ha79Xc3Pj6eqwgg4vltCAgAAAAQTRISEqyW4PT09GBvJTzFxKj/iCNUu3mzehYvltcxfa2CfWJCuffdp+o5c5S6ebMp7wr4VhE5Q0OcTidDQwBEBQJAAAAAYKZeXNvtKioqsm7mc+w8T2qqOi+9VM5f/lLDBxzgc11se7tKLrpIZYsXK/7dd7nU+MzMwBBTvbt161Z1dXUxkBJAROJVCQAAADDDTBWgqQY0VYH4bCYrK9W0fLma7r9fE+XlPtclv/66Ko88UgVXX62Yvj4uN2ZsaIgJBgEgUuzSGYAnn3yy/MFms+mhhx7yy38bAAAACIS4uDhVVFSos7NTvT7OtMOnGz7wQA1/85vKeuIJ5dx/v2JGRj6xxubxKPOZZ6wzArvOOccaKqLYWC4vdnloiDkf0JwTaEJ9qnoBRG0A+Oijj/pt2i8BIAAAAMKdea2cn5+vpKQktbW1ye12B3tL4SkuTr0nn6yBQw9V3h13WMNCphMzOKiCG25Q5urV6rj8co3st1/At4rIYgaGtLe3W0G+CQEZGgIgaluAzbsjM30DAAAAIklqaqrVEmwmBeOzc+fmqu2661S3erVGv/IVn+vinU6VnXqqSs45R7GNjVxy7DKGhgCI6grAurq6mdsJAAAAEMFiY2NVXl5unTFmbvjsxvfcUw1PPqm0DRuUd9ttiu3snHZd6ssvK/nVV9W7eLF6zjhDnuRkLjt2mTkb0NwcDodVEZiRkWF9DgChbJeepcwLGAAAAAA73hKcm5trtQS3trYybXRX2O0anDdPQwcfrJwVK5T1yCOyT019ctnUlHIefFDpv/ylui680GojNn8WmImhIWZqsAn0TZWvCQPN320ACEX8ywcAAAAEWHJystUSbD5i13iTk9W1ZImcGzZYYaAvsV1dKlq6VBXHHaeEt97ismPGmGOsBgcH1dDQIKfTqb6+PqtlGABCCQEgAAAAEASmZbCsrEx5eXl+G6wXTaZKS9V8991qePBBTVRX+1yX+NZbqjzmGBVefrkcXV0B3SOiZ2jIli1brI/mawAIBQSAAAAAQBBlZ2dbR+uYMwKx60b320/OtWvVfvnlcqel+VyX8cILqqqpUdZDD8k2Ocmlh9+GhjQ2NmpoaIiBlwCCigAQAAAACDIzHdi0BJtzxDADHA71nXCCajdvVt8xx8jr48y/mNFR5S9bpqp585Ty8suml5PLjxk3MjKi5uZm1dbWWucFmrMDASDQCAABAACAEBATE6OSkhIVFBTQEjxD3JmZar/qKtU995xG9tnH57q4xkaVnnOOSs84Q3G1tTN198B/mJqasoaGbN26VS0tLdYkYQAIFAJAAAAAIISYSaIVFRWKi4sL9lYixsQee6jx0UfVfNttmios9Lku5dVXVTV/vvJuvFH2wcGA7hHROzSkv7+foSEA/I4AEAAAAAgxCQkJVktwenp6sLcSOWw2DR1yiGo3blTXuefKk5Aw/TKXS9mPPabqmhplPPOM5HYHfKuIHmZISFtb24dDQyY5jxKAnxAAAgAAACHIbrerqKjIupnPMTO8CQnqPvtsKwgcmD3b5zpHX58Kr75alUcdpcTXX+fyIyBDQ8w5gQwNAeAPvJIAAAAAQpipAjTVgPHx8cHeSkRxFRaq9dZbVf/YYxrfYw+f6xLefVcVJ56ooosvlqOtLaB7RHRiaAgAfyAABAAAAEKcOQ/QnAtozgfEzBrbe2/VPfus2q65Rq7tXN/0TZtUPWeOcu67T7bxcb4N8DuGhgCYSQSAAAAAQBgwbcBmQrCZFGwmBmMGxcSo/8gjVbt5s3pOPFFeh2P678H4uHLvuccKAlNffNFMc+DbAL9jaAiAmUAACAAAAISR1NRUqyU4MTEx2FuJOJ60NHVedpmca9dqeP/9fa6LbWtTyYUXquyHP1T8e+8FdI+Ibh8dGtLR0cHQEAA7jAAQAAAACDOxsbEqLy9XdnZ2sLcSkSarq9W0fLma7r1Xk6WlPtcl/+1vqjziCBVcc41i+voCukdENzM0pLe3l6EhAHYYASAAAAAQhmw2m/Ly8lRaWkpLsH8usIa/+105169Xx0UXyZ2UNP0yj0eZq1eruqZGmU88YQ5u88t2AF8YGgJgRxAAAgAAAGEsJSVFVVVVSk5ODvZWIpI3Lk69p5wi5+bN6j/8cJ/rYgYHVXD99apasEBJf/pTQPcIGAwNAbA9BIAAAABAmHM4HFYlYG5ubrC3ErFcublqu/561T39tMa+/GWf6+Jra1V+6qkqOfdcxTY2BnSPgMHQEADTIQAEAAAAIqQlOCcnxzob0ASC8I/xL39Z9U89pdYbbpArJ8fnutSXXlLVoYcq9/bbZRsZ4duBoGBoCIBtCAABAACACJKUlGS1BJvWYPiJ3a6Bww5T7ebN6j71VHliY6dfNjWlnBUrVD17ttLWrTOTG/iWICgYGgKAABAAAACIMDExMVZLcH5+vlUZCP/wJCer68IL5Vy3TkMHHeRzXWxXl4ovu0zlxx+vhLff5tuBoGJoCBCdCAABAACACJWVlaWKigrF+qhQw8yYKi9X8z33qPHBBzVRVeVzXdKbb6ry6KNVePnliunq4vIjqBgaAkQXAkAAAAAggiUkJKiyslJpaWnB3krEG9lvPznXrlX70qVyb+d6Z7zwgtUWnPXQQ9LkZED3CHwcQ0OA6EAACAAAAERBS3BxcbEKCwtpCfa32Fj1LVqk2k2b1HfUUfL6aMGOGRlR/rJlqjrsMKX8/vcmhfH71oBPw9AQIHIRAAIAAABRIiMjw2oJjo+PD/ZWIp47K0vtV1+tuuee08jee/tcF9/QoNKzz1bpGWcozukM6B4BXxgaAkQeAkAAAAAgylqCTQhowkD438TnP6/GlSvVvGyZpgoKfK5LefVVVR1+uPJuukn2oSG+NQgZDA0BIgMBIAAAABBl7Ha71Q5cVFRkfQ4/s9k0VFOj2o0b1XXOOfIkJEy/zOVS9sqVqq6pUcZzz0luN98ahAyGhgDhjX/tAQAAgCiVnp5uDQgxVYHwP29iorrPOUe1GzZo8JBDfK5z9Paq8KqrVHH00Ur83//lW4OQwtAQIDwRAAIAAABRLC4uzmoJzszMDPZWooarqEgtt92m+sce0/juu/tcl/ivf6li0SIVXXKJHO3tAd0jsLNDQ9rb2zXJVGsgZBEAAgAAAFHOZrOpoKBAJSUl1sRgBMbY3ntbQ0LafvpTubZzJmP6xo2qnjNH2Q88INv4ON8ehOTQkL6+PtXW1qqxsVFDQ0NWpSCA0EEACAAAAMCSmppqtQQnJiZyRQIlJkb9Rx+t2s2b1btokbw+Alj72Jjy7rpLVYceqtRf/9r0YfI9QkhiaAgQmggAAQAAAHwoNjZW5eXlys7O5qoEkCc9XR1Ll8q5dq2G99vP57q4lhaVLFmispNPVvy//833CCGLoSFAaCEABAAAAPCJluC8vDyVlpbSEhxgk7NmqWnFCjXdfbcmS0t9rkt+7TVVLlig/GuvVUx/f0D3COzK0BDTKmxahgEEFgEgAAAAgGmlpKSoqqpKycnJXKFAstk0fPDBcq5fr84LL5Q7KWn6ZR6PslatUvUhhyjzyScll4vvE0J+aIgZFrJtaIj5GkBgEAACAAAA8MnhcFiVgLm5uVylAPPGxann1FPl3LRJ/Ycd5nNdzOCgCq67TpULFyrpL38J6B6BXRkaYioCGRoCBAYBIAAAAIBPbQnOycmxzgY0gSACy5WXp7YbblDdqlUa23NPn+sStmxR+cknq/j88xXb3BzQPQK7OjRk69at6u7ulotKVsAvCAABAAAA7JCkpCRrSrBpDUbgjX/lK6pftUqtN9wgV06Oz3Vpv/2tqubOVe6dd8o2OhrQPQKflQn+urq6rCCwpaVFozx2gRlFAAgAAABgp1uCzZAQUxmIALPbNXDYYardvFndp54qT2zs9MsmJ5WzfLmq58xR2vr1ZhID3yqEBYaGAP5BAAgAAABgp2VnZ1stwXFxcVy9IPAkJ6vrwgvlXLdOQ9/9rs91sR0dKr70UpWfcIIS3nknoHsEdhVDQ4CZQwAIAAAA4DNJTExURUWFUlNTuYJBMlVeruZ771XjL36hiaoqn+uS/v53VRx1lAqvvFIx3d0B3SMwk0NDGhoaNDg4aFUKAthxBIAAAAAAPrOYmBgVFRWpoKCAluAgGtl/fznXrlX70qVy+whkbV6vMp5/XtWzZyvrkUekycmA7xPYVeZsQHNGIENDgJ1DAAgAAABgl2VmZlrVgLQEB1FsrPoWLbLOB+w76ih5fZzRGDM8rPxbblHV4Ycr+ZVXAr5NYCYwNATYOQSAAAAAAGZEQkKCNSU4PT2dKxpE7qwstV99teqee06jX/+6z3Xx9fUqO+sslZ55puLq6wO6R2CmMDQE2DGOHVyHKMN5Cthem4/dbrdafHicIBxse5zyeEW44HkW4f48a14jFBYWWucDdnR0WGd3ITjG99hD9StXKu3FF5V/662KbW+fdl3KH/6g5D/9Sb0nnKCuM8+UJ4LPdDSvY7fhtUHkGR8fV1tbmzo7O5WWlmZVJsfHxyuc8VoWM4UAED7LqYHpZGRk8DhBWHK73cHeArBDeJ5FpDzPpqSkKDY21vph3EzyRPD0//d/a+Db31buww8r55FHZJ/m+2FzuZT96KNKX7dO7UuWqP+ww0xapkiTlJT04eeE05HLfG97enqsm/mem39bzXOSeYMiXPFaFruKABDTPzAcPDQwve7ubutdKPOPZ05ODpcJIc88Xs0LJlNVFc4v+hA9eJ5FJD3PmteUVVVVVjWOmeCJIEpOVvd552lg4ULl3Xqr0n/1q2mXOXp7VXLVVcpevdoaKDK2116KJMPDwx9+bgIhREdVYHt7u/WGhDmewFQFhtPPu7yWxUwJn0c9AoofkuHL/2vvTsDjrsr9gb/ZtyZNkzZJ26RJUwUvbuAVufKgXkXvtS0g+yaCKMoVRVnc4AqKyKIsIoKooCgggiBgKRRXRO7FDTdcEDFt6b7ve7P8n9/vT3tZMoW2yWRm8vk8zzyZNCeTw5lhkvnOec+b/IGfvKO2rQwY8kXyePWYJR94nqXQnmeTYDApCa6pqUl3A9p1NbS6x4+PBV/8Yqz67W+j+eKLo/KJJ/odV/XXv8bEE06I1VOnxpKzz47ulpYoBMnjb9ub2f4uGH5VbsmOwBUrVqThbxIEJs9L+cJjlt1VeHu6AQCAnJOcx5U0CEkahTD0Nuy7b9okZOH550f3M454ea6R990Xk6ZOjcavfjWKlHJTAJIAeO3atTFnzpyYOXNmGgh6Y4LhQAAIAABkRXl5eXR0dERDQ4MVzwUlJbHq2GOja8aMtAFIX0lJv8OKN26Mpquvjs6DDoraH/84SVCyPlUYDMn5pEmzoieffDItE3ZeKYVMAAgAAGS1jK25uTna2trS8mCGXu/IkbH43HNj5l13xbrXvz7juPL586P1Ix+JCe95T1Q8+WRW5wiDKdkBmJxTmuwIfOqpp2LNmjW6RFNwBIAAAEDWJWdwJSXBVVVVVj9HbHnpS2PuDTfE3C9/Oba0tWUcV/PrX8fEww6L5s99LopXrcrqHGGwbdiwIebPnx///Oc/Y+nSpbF161aLTkEQAAIAAEMi6crZ3t4ejY2N7oFcUVQU6w48MGZOmxZLzjgjejMEtEW9vdFw660xafLkGPXd7yYdFrI+VRjspiHLli2Lrq6umDdvXqxfv96Ck9cEgAAAwJCWBDc1NcWECROitLTUPZEj+ioqYvn735+eD7jqkEMyjitdvTpaLrwwJh55ZFT/+tdZnSNku2lIEgYmTUN6enosPnlHAAgAAAy5mpqatCQ4+Uju6G5qioWXXhqzvvvd2PjKV2YcV/mPf0T7ySfH+I98JMrmz8/qHCFbtmzZkjYNScqDFy5cGJs2bbL45A0BIAAAkBOSHYDJTsAxY8YM9VR4jk2vfnXM/u53Y8FFF0X3Dkq263784+icOjXGXH11FG3YYB0p2KYhq1atilmzZsXs2bNj9erVmoaQ8wSAAABAThk9enR6NmByRiA5pLg4Vh92WFoWvPw974m+DCXbxVu2xOivfjUmTZ0addOnJzWUWZ8qZMvGjRtjwYIF8eSTT2oaQk4TAAIAADmnuro6LQlOugWTW3pHjIglH/1odE2bFmv//d8zjitbvDjGf/zj0f6ud0XlX/+a1TlCtiXnAiZNQ5LyYE1DyEUCQAAAICeVlJREW1tbNDc3p81CyC1bOzpi3le+EnO+9rXYPHFixnHVv/99dBx9dIw977woWb48q3OEoaBpCLlIAAgAAOS0hoYGJcE5bP0b3hAz77knFn/iE9GTYcdmUV9f1H//+zFp8uRouPHGpJtC1ucJQ9U0JCkP1jSEoSYABAAAcl5VVVVaElxbWzvUU6E/ZWWx4qST0vMBVx51VPRl2LFZsm5dNF92WXQedljU/OIX1pJhoa+vT9MQhpwAEAAAyJuS4NbW1mhpaVESnKN6Ghtj0QUXxOw77ogNr3lNxnEVs2bFhP/6r2j9wAeifPbsrM4RcqVpyJIlS2Lr1q3uELJCAAgAAOSVUaNGRUdHR5SXlw/1VMhg0157xVM33xzzL7sstra0ZFyn2oceis5DDommyy6L4nXrrCfDqmnI8uXL06Yhc+fOjXUe/wwyASAAAJB3Kisr05LgkSNHDvVUyKSoKNZMnRpd06fH0g98IHorKvof1t0djTfemJ4POPKuuyJ6e60pw0oS/iUhYFdXVxoKJuEgDDQBIAAAkJeKi4tj3LhxMXbsWCXBOayvujqWnX56zJw+Pdb8x39kHFe6fHmM+9SnouPYY6Pqj3/M6hwhV5qGJGXBSXlwUia8adOmoZ4SBUQACAAA5LX6+vp0N2BFhh1m5Iat48fH/KuuiqduvDE27bFHxnFVf/lLdBx/fIz7xCeidMmSrM4RcqVpyOrVq2PWrFkxe/bs9HqvnbHsJgEgAACQ95LwLzkXMAkDyW0b9tsvZt15Zyw8//zo3kEJ98h7703Lghu/9rUo2rw5q3OEXGoasmjRovSswGR3YLJLEHaFABAAACiYkuCkHHj8+PHpdXJYaWmsOvbY6JoxI1Ycf3z0lZT0O6x448Zo+tKXovPgg6P2Jz9JtkZlfaqQS01DknMCNQ1hV/itCAAAFJS6urq0JDhpFEJu662vj8Wf+lTMuuuuWL/ffhnHlc+bF60f/nBMeO97o/zJJ7M6R8jVpiHJrkBNQ3ixBIAAAEDBKS8vT0uCGxoahnoqvAibX/rSmPPNb8a8q6+OLa2tGcfV/OpX0Xn44dF80UVRvHq1tWVY27p167OahiTlwpCJABAAAChIRUVF0dzcHK2trVGSocSUHFJUFGvf+taYee+9seQjH4neqqr+h/X0RMN3vpOeD1h/221JbWTWpwq52DQkaRiSNA5ZtWqVpiE8jwAQAAAoaLW1tWlJcFWGQInc0ldREctPPTW67r8/Vh90UMZxpatWxdjPfjYmHnlkVP/mN1mdI+SqTZs2xcKFC9Py4MWLF2sawnYCQAAAoOCVlZVFe3t7NDY2DvVUeJG6m5tjwRe+ELO/853Y+PKXZxxX+cQT0f7ud8f4M86I0vnzrS883TRkxYoVadOQOXPmpOcGJjsFGb4EgAAAwLApCW5qaoq2tjYlwXlk4z77xOzbb48FF14Y3TsIcOt+9KOYdNBBMfrLX44iZ6HBduvXr0+bhiRh4LJly6K7u9vqDEMCQAAAYFgZMWJEdHZ2RnV19VBPhReruDhWH3FEWha8/N3vjr7S0v6Hbd4cY667LiZNnRp199+fHI5mjeEZTUOWLl2algdrGjL8CAABAIBhp7S0NCZMmBBjxowZ6qmwE3pra2PJxz8eM3/wg1j3xjdmHFe2aFGM/+hHo/3EE6Pib3+zxvAMmoYMTwJAAABg2JYEjx49Oj0bMAkEyR9bJk6MuV/9asy57rrY3NGRcVz1734XE486Klo+/ekoWbEiq3OEfKBpyPAhAAQAAIa1pBQ46RJcU1Mz1FNhJ61/05ti5j33xOKPfSx6Mtx/RX19MeqOO2LS5MnRctttUeT8M3jBpiFr167VNKTACAABAIBhb1tJcNIkJNkZSB4pL48VJ58cXTNmxKrDD4++DPdfydq10fGlL8Wr3vWuGPmrX2V9mpBPTUPmzZunaUiBEQACAAA8rbGxMQ0Cy8rKrEme6Rk9OhZ+7nNpx+AN++yTcVz1U0/Fv5x5ZrR+8INRNnt2VucI+do0ZP78+bFhw4ahnhK7QQAIAADQT0lwbW2tdclDm17xinjqllti/he+EFubmzOOq33wwZh0yCEx5ooronj9+qzOEfKtaciaNWviqaeeipkzZ8bKlSujt7d3qKfFThIAAgAAPEdJSUm0trZGc3OzkuB8VFQUaw46KLqmT49lp54aveXl/Q/r7o7R3/hGej7gyHvuiRBqwA5t3rw5Fi1aFE8++WT6Mfmc/CAABAAAyKChoSE6OjqUBOepvpqaWPqRj8TMe++NNW97W8ZxpcuWxbhzz42O446Lyj/9KatzhHyU7ABMdgImOwKTnYHJDsFkpyC5SwAIAACwA5WVldHZ2Rl1dXXWKU9tbWuL+V/6Uvzt6qtjQ2dnxnFVf/5zTDzuuBj7yU9G6ZIlWZ0j5KvkbMDkjMDkrMBly5ZFt07bOUkACAAA8EIvnIqLY/z48TF27FglwXlszb77xp++9a2YdfbZ0bODQLd+2rTonDIlGq+/Poq2bMnqHCFfJcHftqYhSRdhTUNyiwAQAADgRaqvr09LgssznClHHigtjcVHHhldDzwQK447LvqK+39ZXLJhQzR98YvRefDBMeKnP006IWR9qpCPklLgtWvXahqSYwSAAAAAO1kSnHQJHjlypHXLYz319bH4vPNi1l13xfr99ss4rnzu3Gg7/fRoe9/7ovyf/8zqHCHfaRqSOwSAAAAAO/tCqrg4xo0bl16KioqsXx7bvMceMeeb34x5V10VW8aNyzhuxCOPROdhh0XzxRdH8erVWZ0j5DtNQ4aeABAAAGAXJbsAk92AFRUV1jCfFRXF2v/4j5g5fXos+fCHo7eqqv9hPT3RcMstMWnKlKi//faInp6sTxUKqWlIcmagpiHZIQAEAADYDUn4l5wLmJwPSH7rq6yM5f/1X9F1332xeurUjONKV66MsRdcEBOPPDKqHn00q3OEQpEEf0nX4G1NQ9avXz/UUypoAkAAAIDdfWFVXJx2CE46BSfXyW/dLS2x4LLLYvbNN8fGvfbKOK7yiSei48QTY/xZZ0XpggVZnSMUWtOQOXPmRFdXV6xYsSJ67K4dcH4zAQAADJC6urq0JDhpFEL+2/iv/xqzb789Fn72s9Hd0JBxXN0DD8Skgw6K0ddeG0UbN2Z1jlBItmzZEosXL053BS5cuDA2bdo01FMqGAJAAACAAVReXp6WBI8aNcq6FoKSklh15JHRNWNGLD/ppOgrLe13WPGmTTHm2mvTILB2xoxkW1PWpwqF1DRk1apVMWvWrJg9e3asXr063SnIrhMAAgAADLCkM3BLS0u0trZGSUmJ9S0AvbW1seQTn4iZ99wT6w44IOO4soULo/Xss2PCSSdFxeOPZ3WOUIg2btwYCxYsiCeffDKWLFkSW7duHeop5SUBIAAAwCCpra1NS4KrMnSVJf9s6eyMuV/7Wsz9yldic3t7xnE1jz4aE486Klo+85koWbkyq3OEQpScC7h8+fLtTUPWrVs31FPKKwJAAACAQVRWVhbt7e3R2NhonQtFUVGs+/d/j5k/+EEsPvvs6Kmp6X9Yb2+M+t73YtLkyTHq5psj7FyCAZE0DZk7d66mITtBAAgAAJCFkuCmpqZoa2tTElxIystjxXvfG1333x+rDjss47CSNWui5ZJLovPww6PmkUeyOkUYDk1DkvJgTUN2TAAIAACQJSNGjIjOzs6orq625gWkZ8yYWHjRRTHr9ttjw6tfnXFcRVdXTDjllGj90IeibM6crM4RClnSIOS5TUOSRiL8HwEgAABAFpWWlsaECRNi9OjR1r3AbHrlK+Op73wn5l96aWwdMybjuNqf/Sw6Dz44xlx5ZRSvX5/VOcJwaRqSnBWYNA1JdgkiAAQAABiSkuAxY8akQWASCFJAiotjzSGHpGXBy973vugtK+t/2NatMfqGG6JzypQY+YMfRNitBIPSNKSrqyuWLVs27FfXDkAAAIAhUlNTk3YJTj5SWPpqamLpmWfGzHvvjbUHHphxXNnSpTHunHOi4/jjo/Kxx7I6RxguttgFKAAEAADIhZLgZEdgsjOQwrJ1woSY9+Uvx1M33BCbJ03KOK7qscdi4rHHxthzz43SpUuzOkeg8NkBCAAAkAOSMwGTILAsQ8ko+W3D/vvHzLvvjkXnnhs9dXUZx9Xfc090Tp4cDd/4RhTZtQQMEAEgAABAjki6AyclwUm3YApQaWmsPOGE6JoxI1Yec0z0Fff/krxkw4ZovuKK6DzkkBjx4INJi9OsTxUoLAJAAACAHFJSUhJtbW3R3NysJLhA9YwaFYs+/emYdeedsX7ffTOOK58zJ9o++MFoO/XUKO/qyuocgcIiAAQAAMhBDQ0N0d7eriS4gG1+2ctizre+FfOuvDK2jh2bcdyI//mf6DzssGi69NIoXrMmq3MECoMAEAAAIEdVVVWlJcG1tbVDPRUGS1FRrH3726Prvvti6Yc+FL2Vlf0P6+6OxptuikmTJ0f9974X0dPjPgFeNAEgAABAjpcEt7a2RktLi5LgAtZXWRnLTjstDQJXT5mScVzpypUx9jOfiYlHHx1Vjz6a1TkC+UsACAAAkAdGjRoVHR0dUV5ePtRTYRB1jx0bCy6/PGbfdFNsetnLMo6rfPzx6DjxxBj30Y9G6cKF7hNghwSAAAAAeaKysjItCa6rqxvqqTDINr72tTHrjjti4QUXRPeoURnHjbz//pg0dWqM/spXomjTJvcL0C8BIAAAQB4pLi6O8ePHx9ixY5UEF7qSklh11FHRNWNGLD/xxOgrLe13WPGmTTHmmmvSILD2gQci+vqyPlUgtwkAAQAA8lB9fX26G7CiomKop8Ig662riyWf/GTMvPvuWHfAARnHlS1cGK1nnRUT3v3uqHjiCfcLsJ0AEAAAIE8l4V9yLuDIkSOHeipkwZZJk2Lu174Wc6+9Nra0tWUcV/Pb38bEI46IlgsuiJKVK903gAAQAAAg30uCx40bl16S6xS4oqJY9+Y3x8x7743FZ58dPdXV/Q/r7Y1Rt98ekyZPjlG33BKxdWvWpwrkDr8dAAAACkCyC1BJ8PDRV14eK9773pg5Y0asOvTQjONK1qyJlosvjs7DD4/qRx7J6hyB3CEABAAAKBDl5eVpSfCoHXSNpbB0jxkTCy++OGbddltsfNWrMo6r6OqK9lNOidYPfSjK5s7N6hyBoScABAAAKCBJGXBLS0vaKVhJ8PCx6VWvitm33hrzL700to4Zk3Fc7c9+Fp0HHRRjvvjFKFq/PqtzBIaOABAAAKAA1dXVpSXBlZWVQz0VsqW4ONYcckjMvP/+WHbKKdFbVtb/sK1bY/T118ekKVOibtq0iN5e9xEUOAEgAABAgZcENzQ0DPVUyKLemppYetZZMXPatFj7lrdkHFe2dGmM/+Qno/2d74zKP//ZfQQFTAAIAABQwIqKiqK5uTlaW1ujpKRkqKdDFm1tb49511wTc264ITZ3dmYcV/2nP8XEY46JseeeGyVLl7qPoAAJAAEAAIaB2tratCS4qqpqqKdClq3ff/+Yeffdseicc6KntjbjuPp77knLghu+8Y2ILVuyOkdgcAkAAQAAhomysrJob2+PxsbGoZ4K2VZWFivf9a7omjEjVh59dPQVFfU7rGT9+mi+4orofMc7YsTPfx7R15f1qQIDTwAIAAAwzEqCm5qaoq2tTUnwMNTT0BCLPvOZmHXnnbH+ta/NOK7iqaei7bTTou3UU6N85syszhEYeAJAAACAYWjEiBHR2dkZ1dXVQz0VhsDmf/mXmPPtb8e8K66IrS0tGceN+J//ic5DD42mz38+iteuzeocgYEjAAQAABimSktLY8KECTF69OihngpDoago1k6eHF333RdLTzsteisq+h/W3R2N3/52TJo8OervvDOipyfrUwV2jwAQAABgmJcEjxkzJg0Ck0CQ4aevqiqWfehDaRC45u1vzziudMWKGHv++dFxzDFR9fvfZ3WOwO4RAAIAABA1NTVpl+DkI8NT97hxMf/KK2P2TTfFpj33zDiu6m9/i44TTohxH/tYlC5alNU5ArtGAAgAAEAq2QGYNAdJdgQyfG187WvTJiELP/3p6K6vzzhu5H33xaSpU6Pxq1+Nok2bsjpHYOcIAAEAAHhWSXByJmB7e7uS4OGspCRWHXNMdM2YESve9a7oKynpd1jxxo3RdPXV0XnwwVH7ox9F9PVlfarACxMAAgAA8DxJd+CkJDjpFszw1TtyZCw+55yYeffdsW7//TOOK58/P1rPOCMmvOc9UfGPf2R1jsALEwACAACww5LgpqamdGcgw9eWl7wk5l5/fcy95prY0taWcVzNr38dEw8/PJovvDBKVq3K6hyBzASAAAAA7FBjY2NaElxWVmalhrOiolj3lrfEzHvvjSVnnRU91dX9D+vtjYbvfjcmvf3tMeo734no7s76VIFnEwACAADwgqqqqtKS4NraWqs1zPWVl8fyU06JmfffH6ve8Y6M40rWrImWiy6KiUccEdW/+lVW5wg8mwAQAACAF6WkpCRaW1ujublZSTDR3dQUCy+5JGZ997ux8ZWvzLgilU8+Ge3veU+M/8hHomzePCsHQ0AACAAAwE5paGiIjo4OJcGkNr361TH7u9+NBRdfHN2jR2dclbof/zg6DzooxnzpS1G0YYPVgywSAAIAALDTKisrlQTzjHShOFYfemh0zZgRy9773ugrLe0/hNiyJUZ/7WsxaerUqLv33oi+PqsIWSAABAAAYLdKgltaWpQEk+qtqYmlZ58dXdOmxdo3vznjqpQtXhzjP/GJaD/hhKj861+tHgwyASAAAAC7ZdSoUWlJcHl5uZUktbWjI+Zde23M+frXY3NnZ8ZVqf7DH6Lj6KNj7HnnRcmyZVYPBokAEAAAgAErCR45cqTVZLv1BxwQM+++OxZ98pPRk6GDdFFfX9R///sxacqUaLjxxogtW6wgDDABIAAAAAPzArO4OMaNGxdjx45VEsz/KSuLlSeeGF333x8rjzoq+oqK+l2dknXrovmyy6Lz0EOj5qGHrCAMIAEgAAAAA6q+vj7dDVhRUWFl2a6nsTEWXXBBzLrjjtjwmtdkXJmK2bNjwgc+EG3/9V9RPnu2FYQBIAAEAABgwCXhX3IuYBIGwjNt3muveOrmm2P+5ZfH1paWjIsz4he/iM5DDommL3whiteutYiwGwSAAAAADFpJcFIOnJQFJ9dhu6KiWDNlSnRNnx5LP/CB6M2wW7Souzsav/Wt9HzAkd//fkRvr0WEXeAZGAAAgEGVNAZREkx/+qqrY9npp8fM6dNjzX/+Z8ZFKl2+PMadd150HHNMVP3hDxYTdpIAEAAAgEFXXl6elgSPGjXKavM8W8ePj/lf/GI89a1vxaY998y4QlV//Wt0vPOdMe7jH4/SxYutJLxIAkAAAACyIikDbmlpifHjxysJpl8bXve6tEnIwvPPj+6RIzOu0sjp09Oy4MavfjWKNm+2mvACSl9owHCxcuXK+Otf/xpPPvlkdHV1pZf169enX7v++uujubk54/du2bIlHn300fj973+ffv+iRYti69atUVdXF3vssUe89a1vjde97nW7Pcc///nPMW3atHjiiSfSuSXvnO2zzz5xxBFHpL9EAQAA8kHyWqmysjLmz58fmzZtGurpkGtKS2PVscfGmre/PcZce22Muu22KOrped6w4o0bo+nqq6P+rrtiycc/HmsPPDA9WxB4PgHg02bMmBG33XZb7IoLL7ww/vSnP/3fopaWRllZWaxYsSJ+9atfpZc3vOENcdZZZ0VJScku/Yzvf//7cdNNN0VfX18UFRVFVVVVLFmyJH74wx/GL37xizjvvPPiFa94xS7dNgAAwFCVBC9evDjdkAHP1VtfH4v/+79j5dFHR8sll0TNr37V/2Np3rxo/fCHY/1++8Xic8+NzS99qcWE5xAAPi0J1caMGROTJk2Kl7zkJWnAluz8ezF6enrSHXhve9vbYr/99ou2trb09pYtWxbf+9734oEHHoiHH344mpqa4qSTToqd9Yc//GF7+HfQQQfF8ccfHyNGjIiFCxfGNddck+4MvOSSS+K6665L30kDAADIB8nrpuS1VE1NTfr6JnltBc+15aUvjTnf+EaM+OlPo/kLX0gDv/7U/PrXMfGww2LlscfG0g99KA0Qgf9PAPi0o48+Oo477rhtn8bMmTPjxTrhhBNizz33fN7uvtGjR8dpp50WmzdvjgcffDCmT58exx57bFRkaG+eybbwb9999433v//92/997Nix8d///d/pz0h2Gya7BE8++eSdum0AAIChVltbu70keOPGjUM9HXJRUVGse+tbY/0b3hAN3/52jP7a19IS4OcN6+2Nhltvjbr77otlH/5wrDzqqLSkGIY7TUCetquluYm99tprh9+fnAGYSILAeRneqchk7ty56XmEieSsv+eqrq6OyZMnp9eTUuAkKAQAAMg3yTFK7e3t0djYONRTIYf1VVTE8ve/P7ruvz9WHXJIxnGlq1dHy4UXxsQjj4zqX/86q3OEXCQAzIJnluX29vbu1Pc+9thj24O+l73sZf2Oec1rXpN+XL58+U4HjAAAALlUEpwcnZQcq7Q7mzQofN3NzbHw0ktj9q23xsYdnIdf+Y9/RPvJJ8f4M86IsvnzszpHyCUCwCz4y1/+sr05yLhx43Z6B2CitbU1iov7v7smTJjwvPEAAAD5KjnzfOLEienZ7LAjG/feO2bfdlss+NznonsHu0frfvSj6Jw6NcZcfXUUbdhgURl2FMIPsuT8iuRsvsTrX//69HDbnZGc7ZdoaGjIOCY5UzC53fXr128fn8ktt9wSt956a79f23vvvdNOXMkuxUWLFu3UPBk+tu1i9TgB8DwLMNiS1zqbNm2K1atXD8hxR9tuI/mY3CaFY/WBB8b8f/u3GH/jjdFy++1R3N39vDHFW7bE6K9+NWrvuivmfPCDsfxtb0vPFqTw9fT0ZNxUlW92trJ0GwHgIEu69CbdgJOAblc6ACe/7BIv1Dgk+XoSAL7QgbnJmCVLlvT7tWd23NrVBxTDi8cJgOdZgGwcqZScD5gceTSQXYKdn154uqur46kPfjAWH3xwtH/5y9Hwv//b77iKJUvipZ/+dDR///sx+8wzY/2ee2Z9rmT/tWvvMM85BICDKNlp9/DDD6fnWJx++unpWRZDLQkiM83jmWdsFEoyzsB75pOmxwmA51mAbL2OSTY9JCHg7nQJfmbol7xOozBtbm+Pf1x+eYz85S+j46qromrOnH7H1T32WLzyPe+JJQcfHHNPPTW6d1B5R34rLi4e9q9fh0UAePHFF8ff//735/37G97whnjf+943KD/z7rvvjttuuy29fuqpp8b++++/S7dTWVm5vYPwjmz7+gudkXHCCSekl/5cccUVsXbt2vR/ipaWll2aL4UvKQ9PQkCPE/JF8od+d3d3eg6rP/TJB55nyTeeZ8mm8ePHpyHg0qVLd+n7t5USJ38TjBw5csDnR455+9tj9oEHRsOtt8boa6+NknXrnjekqK8vmqdNi9E/+1ksO+20WHH88RHl5ZErksfrttdf/pbddSNHjiyYnGNXN+IMi21e69ati1WrVj3vkpTDDobp06fHjTfemF4/+eSTY8qUKbt8W9vO/tvR2X5J+Lftv2VHZwUCAADksyQAGT16dLS3t6dv7sELKiuLFSedFF0zZsTKo46Kvgw7P5NwsPkLX4jOww6LmocftrAUnGGzAzBbHnjggfj617+eXj/++OPjsMMO263b29bhd968edtT/+ea84ztzG1tbbv18wAAAHJddXV12iV4wYIFg7axg8LS09gYiy64IFYdc0w0X3xxVP/+9/2Oq5g1KyacemqsfdObYvEnPhFbOzqyPlcYDMNiB2C2/OQnP4nrrrsuvX7EEUfEscceu9u3+apXvSr9uGHDhn7LmBN/+MMf0o+NjY3R2tq62z8TAAAg1yU7AJMNE2PGjFEayYu2aa+94qmbb475l10WW3dQElr70EMx6ZBDounyy6O4n9JhyDcCwAHy85//PO34m9TnH3zwwbvU8bc/SaA3adKk9Ppdd931vK8nweCMGTPS62984xv94gMAAIaVpCQ4CQKTTsHwohQVxZqpU6Nr+vRY+oEPRG9FRf/Duruj8ZvfjEmTJ8fI5PX4MO8iS34TAD4tKa9ds2bN9sszt5EnZwg+82vPbR39yCOPxFVXXZX+++TJk3e6sUjSLfiQQw5JL/058cQT04+/+c1v4vrrr98+t+SQ8Isuuig9BLe2tjbddQgAADBcS4JHjBgx1FMhj/RVV8ey00+PmdOnx5r/+I+M40qXL49xn/pUdBx3XFT+6U9ZnSMMlGFxBuCLkXSRyhTcnXnmmc/6PAnhmpubt3+eNPzYFgomYeAvf/nLjD8n+RlJ9+Gdsc8++6Q7Cm+66aa4995747777ku7/W4LApPr55xzTtTV1e3U7QIAABSKkpKS9Ez0pIHikiVL0uoseDG2jh8f86+6Klb++tfRfMklUfmPf/Q7rurPf46Jxx0Xqw45JJaedVZ0NzVZYPKGAHAAPPMXS9JWfke2bNmySz8j2d23xx57xLRp09KzAJPwr6mpKfbee+848sgjC6adNQAAwO5oaGhIN0nMnz8/tm7dajF50Tbst1/MuvPOGHXHHTH66qujNMPr+/pp06Luxz+OZaeemnYY7stQQgy5pKjP2yI87Yorroi1a9em5cRnn322daFfSen5to7UgmfyQfJrrru7Oz0ovKioaKinAy/I8yz5xvMsuaqnpycWLlyYvsZ55oaN5DGb/E0wcuTIIZ0fua141aoYc801Mer226OopyfjuC1tbbH4Yx+LdQcemJ4tONCSx+u211/+lt11I0eOjHHjxsVwzm6cAQgAAEBBlgQnTRWT45sEJ+ys3vr6WPypT8Wsu+6K9fvtl3Fc+dy50fbhD0fb+94X5U8+aaHJWQJAAAAACrokuKOjQ5dgdsnml7405nzzmzHv6qtjy/jxGceNeOSR6Dz88Gi++OIofoGjwWAoCAABAAAoaJWVldHZ2Rk1NTVDPRXyUVFRrH3rW9NuwUs+/OHorarqf1hPTzTccktMmjw56m+7LalDz/pUIRMBIAAAAAUvOUNtzJgx0djYmF6HnZU0+1j+X/8VXffdF6unTs04rnTVqhj72c/GxCOPjOrf/tZCkxM86wEAADBsjBgxIm1mV15ePtRTIU91t7TEgssui9m33BIbX/7yjOMqn3gi2k86KcafeWaUzp+f1TnCcwkAAQAAGFaS8G/ixIk6AbNbNr7mNTH79ttjwYUXRndjY8ZxdT/8YUw66KAY/eUvR9HGjVadISEABAAAYNhJyoDHjRsXY8eO1SWY3Xkgxeojjoiu+++P5e9+d/SVlvY/bPPmGHPddTFp6tSonTEjoq/PqpNVAkAAAACGrfr6+nQ3YEVFxVBPhTzWW1sbSz7+8Zj5gx/Euje+MeO4skWLovXss6P9xBOj4m9/y+ocGd4EgAAAAAxrSfjX0dGRhoGwO7ZMnBhzv/rVmHPddbG5oyPjuOrf/S4mHnVUtHz601GyYoVFZ9AJAAEAABj2kpLgpBw4KQvWJZjdtf5Nb4qZ99wTiz/2segZMaLfMUV9fTHqjjti0uTJMeqmmyK2brXwDBoBIAAAADxt5MiRSoIZGOXlseLkk9PzAVcdcUT0FRX1O6xk7dpoufTS6DzssKj53/+1+gwKASAAAAA8p0twUhI8atQo68Ju6xk9OhZeeGHM/t73YsM++2QcVzFzZkx43/ui9YMfjLKnnrLyDCgBIAAAADz3xXJxcbS0tMT48eOVBDMgNr385fHULbfE/C98IbY2N2ccV/vgg9F5yCEx5soro3j9eqvPgBAAAgAAQAZ1dXVpSXBlZaU1YvcVFcWagw6KrunTY9mpp0ZveXm/w4q3bo3RN9wQk6ZMifof/CCit9fqs1sEgAAAALADSoIZaH01NbH0Ix+JmdOnx5q3vS3juLJly6L1U5+KiccfH5V/+pM7gl0mAAQAAIAXUFRUlJYEt7a2RklJifViQGxtbY35X/pSPPXNb8aml74047iqP/85Jh53XIw955woXbLE6rPTBIAAAADwItXW1qYlwVVVVdaMAbPh3/4tZn3/+7HoU5+Knrq6jOOScuDOKVOi8frro2jLFvcAL5oAEAAAAHZCWVlZtLe3R2Njo3Vj4JSWxsrjj4+uBx6IFccdF33F/Uc2JRs2RNMXvxidBx8cI37604i+PvcCL0gACAAAALtQEtzU1BRtbW1KghlQPfX1sfi889Idgev33TfjuPK5c6Pt9NOj7X3vi/J//tO9wA4JAAEAAGAXjRgxQkkwg2LznnvGUzfeGHOuvDK2jBuX+TH4yCPRedhh0XzJJVG8erV7g34JAAEAAGA3KAlm0BQVpV2Cu+69N5aefnr0Vlb2P6ynJxpuvjkmTZkS9bffHtHT407hWQSAAAAAsJuUBDOY+iorY9kHPhBd990Xq6dOzTiudOXKGHvBBTHxyCOj6tFH3SlsJwAEAACAASwJ7uzsjOrqamvKgOseOzYWXHZZzL755ti4114Zx1U+8UR0nHhijD/rrCidP989gQAQAAAABlJpaWlMmDAhRo8ebWEZFBv/9V9j9u23x8LPfja6Gxoyjqt74IGYdNBBMfqaa6Jo40b3xjBmByAAAAAMQknwmDFj0iAwCQRhwJWUxKojj4yuGTNi+UknRV+Gx1nx5s0x5itfiUlTp0btjBkRfX3ujGFIAAgAAACDpKamJu0SnHyEwdBbWxtLPvGJmPmDH8S6N7wh47iyRYui9eyzY8JJJ0XF44+7M4YZASAAAABkoSQ42REIg2XLxIkx92tfi7nXXReb29szjqt59NGYeNRR0fKZz0TJihXukGFCAAgAAABZkJwJ2N7eriSYQbXuTW9KdwMu/uhHoyfDztOi3t4Y9b3vxaQpU2LUzTdHbN3qXilwAkAAAADIkqQ7cFISnHQLhkFTXh4r3vOe6Lr//lh12GEZh5WsWRMtl1wSnYcfHjWPPOIOKWACQAAAAMhySXBbW1s0NTWlzUJgsPSMGRMLL7ooZt1+e2zYe++M4yq6umLCKadE6wc/GGVz5rhDCpAAEAAAAIZAY2NjWhJcVlZm/RlUm175ynjqO9+J+ZdeGlubmjKOq33wweg8+OAYc+WVUbx+vXulgAgAAQAAYIhUVVWlJcG1tbXuAwZXUVGsOeSQ6Lrvvlj2/vdHb4bguXjr1hh9ww3ROWVKjPzBDyJ6e90zBUAACAAAAEOopKQkWltbo7m5WUkwg66vpiaWnnFGzJw+PdYeeGDGcWVLl8a4c86JjuOPj8rHHnPP5DkBIAAAAOSAhoYGJcFkzda2tpj35S/HUzfcEJte8pKM46oeeywmHntsjD333ChdutQ9lKcEgAAAAJAjlASTbRv23z9m3XVXLDr33Oipq8s4rv6ee6Jz8uRo+MY3omjLlqzOkd0nAAQAAIAcLAluaWlREkx2lJbGyhNOiK4ZM2LlscdGX3H/cVHJhg3RfMUV0XnIITHiwQcj+vrcQ3lCAAgAAAA5aNSoUdHR0RHl5eVDPRWGiZ5Ro2LR+efHrDvvjPX77ptxXPmcOdH2wQ9G26mnRnlXV1bnyK4RAAIAAECOqqysTLsE1+2gNBMG2uaXvSzmfOtbMe/KK2Pr2LEZx434n/+JzsMOi6ZLL43iNWvcETlMAAgAAAA5rLi4OMaPHx9jx45VEkz2FBXF2re/Pbruuy+WfuhD0VtZ2f+w7u5ovOmmmDRlStTfcUdET497KQcJAAEAACAP1NfXKwkm6/oqK2PZaaelQeDqKVMyjitdsSLGfvrTMfHoo6Pq0UezOkdemAAQAAAA8qwkeOTIkUM9FYaZ7rFjY8Hll8fsm26KTS97WcZxlY8/Hh0nnhjjPvrRKF24MKtzJDMBIAAAAORZSfC4ceOUBDMkNr72tTHrjjti4QUXRPeoURnHjbz//pg0dWqM/spXomjTpqzOkecTAAIAAECelgQnuwErKiqGeioMNyUlseqoo6JrxoxYfuKJ0Vda2u+w4k2bYsw110TnQQdF7Q9/GNHXl/Wp8v8JAAEAACBPJeFfR0dHGgZCtvXW1cWST34yZt59d6w74ICM48oXLIjWM8+MCSefHBVPPJHVOfL/CQABAAAgz0uCkw7BSVlwch2ybcukSTH3a1+LuddeG1va2jKOq/nNb2LiEUdEywUXRMnKlVmd43DnmQEAAAAKQNIYREkwQ6aoKNa9+c0x8957Y/HZZ0dPdXX/w3p7Y9Ttt8ekyZNj1C23RGzdmvWpDkcCQAAAACgQ5eXlaUnwqB00Z4DB1FdeHive+96YOWNGrDr00IzjStasiZaLL47Oww+P6kcecacMMgEgAAAAFJCkDLilpSXGjx+vJJgh0z1mTCy8+OKYddttsfFVr8o4rqKrK9pPOSVaTz89yubOzeochxMBIAAAABSgurq6tCS4srJyqKfCMLbpVa+K2bfeGgsuuSS6R4/OOK72pz9NuwWP+eIXo2j9+qzOcTgQAAIAAECBUhJMTigujtXveEd0zZgRy045JXrLyvoftnVrjL7++pg0dWrUTZsW0deX9akWKgEgAAAAFLCioqK0JLi1tVVJMEOqt6Ymlp51VsycNi3WvvnNGceVLVkS4z/5yWh/5zuj8s9/zuocC5UAEAAAAIaB2tratCS4qqpqqKfCMLe1vT3mXXttzLnhhtjc2ZlxXPUf/xgTjzkmxv73f0fJ0qVZnWOhEQACAADAMCoJbm9vj4aGhqGeCsT6/fePmXffHYvOOSd6amszrkj93XfHpClTouEb34jYssXK7QIBIAAAAAyzkuDm5uZoa2uLkpKSoZ4Ow11ZWax817vS8wFXHn109BUV9TusZP36aL7iiuh8xztixEMPZX2a+U4ACAAAAMPQiBEjlASTM3oaGmLRZz4Ts+68Mzb8679mHFfx1FPR9oEPRNupp0b5zJlZnWM+EwACAADAMFVWVpaWBDc2Ng71VCC1+V/+JZ666aaYd8UVsbWlJeOqjHj44eg89NBo+vzno3jtWqv3AgSAAAAAMMxLgpuampQEkzuKimLt5MnRdd99sfS006K3oqL/Yd3d0fjtb8ekyZOj/s47I3p6sj7VfCEABAAAANKS4M7OzqiurrYa5IS+qqpY9qEPpUHgmre/PeO40hUrYuz550fHMcdE1e9+l9U55gsBIAAAAJAqLS2NCRMmxOjRo60IOaN73LiYf+WV8dS3vx2b9twz47iqv/0tOt71rhj3sY9F6cKFWZ1jrhMAAgAAAM8qCR4zZkwaBOoSTC7ZsO++aZOQhZ/+dHTX12ccN/K++2LSQQfF6Ouui6JNm7I6x1wlAAQAAACep6amJi0JTj5CzigpiVXHHBNdM2bEine9K/pKSvodVrxxY4z58pej86CDonL69Ii+vhjOBIAAAABAxpLgtra2dEcg5JLekSNj8TnnxMy77451+++fcVz5ggXRcOqpEaedFsOZABAAAADYYUlwciZge3t7GghCLtnykpfE3Ouvj7nXXBNb2toyDzzqqBjOBIAAAADAC0q6A0+cOFFJMLmnqCjWveUtMfPee2PJWWdFz3M6WW+cMiXiLW+J4UwACAAAAOxUl+CkJDjZGQi5pK+8PJafckrMvP/+WPWOd6T/1lteHmvOOy+GO3t3AQAAgJ2SlAQnOwLnz58f3d3dVo+c0t3UFAsvuSRWHntsVPzznxETJsRwZwcgAAAAsMslwSNGjLB65KRNr351rD7iiKGeRk4QAAIAAAC71SW4qalJSTDkMAEgAAAAsFsaGxvTLsFlZWVWEnKQABAAAADYbVVVVWlJcG1trdWEHCMABAAAAAZESUlJtLa2RnNzs5JgyCECQAAAAGBANTQ0KAmGHCIABAAAAAackmDIHQJAAAAAYFBLgltaWpQEwxASAAIAAACDatSoUdHR0RHl5eVWGoaAABAAAAAYdJWVlWmX4Lq6OqsNWSYABAAAALKiuLg4xo8fH2PHjlUSDFkkAAQAAACyqr6+XkkwZJEAEAAAABiykuCRI0dafRhkAkAAAABgyEqCx40bpyQYBpkAEAAAABjykuBkN2BFRYV7AgaBABAAAAAYckn419HRoSQYBoEAEAAAAMipkuDkklwHBob/mwAAAICckjQGSXYDKgmGgSEABAAAAHK2JDg5HxDYPQJAAAAAICclZcBjx46N8ePHKwmG3SAABAAAAHJaXV1d2iW4srJyqKcCeUkACAAAAOS88vLyaG9vj1GjRg31VCDvCAABAACAvCkJbmlpURIMO0kACAAAAOQVJcGwcwSAAAAAQF6WBCddghsaGoZ6KpDzBIAAAABAXioqKorm5uZobW2NkpKSoZ4O5CwBIAAAAJDXamtr0y7BVVVVQz0VyEkCQAAAACDvlZWVpV2CGxsbh3oqkHMEgAAAAEDBlAQ3NTVFW1ubkmB4BgEgAAAAUFBGjBihJBieQQAIAAAAFBwlwfB/BIAAAABAQVISDP9f6dMf4Vn6+vqsCP0qKSmJ4uLi9Bepxwn5YNvj1OOVfOF5lnzjeZZ84jl2+KqpqUlLgufPnx8bNmyIfOTv2d1bu75hnnMIAOlXd3e3laFf9fX1HifkpZ6enqGeArwonmfJV55nyQeeYxk3blwsX748veST3t7eoZ5C3v+O6h7mOYcAkP4fGKUeGvRv2bJl6TsnyQ7A0aNHWyZyXvJ4TX7hJ+/4J49byHWeZ8k3nmfJJ55jSbS0tERtbW0sWLAgL0KhJPxLqrDYdSUlJcM+55Dy0C8vkskkCVK2/QLyOCGfJI9Xj1nygedZ8pXnWfKB51ie2SW4s7MzDQHXr1+fswvzzLJVf8vuuiKvBTQBAQAAAIZn5VtbW1uMGTNmqKcCg84eUgAAAGBY2na0UXt7+7AvEaWwCQABAACAYa26ujrtEpx0C4ZCJAAEAAAAhr2kJHjChAlpSbDz9ig0AkAAAACApyUlwUkQWFZWZk0oGAJAAAAAgOeUBHd0dKTdgqEQCAABAAAAMnQJbmpqUhJM3hMAAgAAAGTQ2NiYdglWEkw+EwACAAAA7EBVVVXaJbi2ttY6kZcEgAAAAAAvoKSkJFpbW6O5uVlJMHlHAAgAAADwIjU0NCgJJu8IAAEAAAB2gpJg8o0AEAAAAGAXS4JbWlqUBJPzBIAAAAAAu2jUqFHR0dGhSzA5TQAIAAAAsBsqKyujs7Mz6urqrCM5SQAIAAAAsLsBS3FxjB8/XkkwOUkACAAAADDAJcHl5eXWlJwhAAQAAAAY4JLgiRMnxsiRI60rOUEACAAAADDQgUtxcYwbNy7Gjh2rSzBDTgAIAAAAMEjq6+vT3YAVFRXWmCEjAAQAAAAYREn4l5wLqCSYoSIABAAAAMhSSXByKSoqst5klQAQAAAAIEuSXYBKgsk2ASAAAADAEJQEJ+cDQjYIAAEAAACGoCQ46RCclAQn12EweYQBAAAADBElwWSDABAAAABgCJWXl6clwaNGjXI/MCgEgAAAAABDLCkDbmlpifHjxysJZsAJAAEAAAByRF1dXdoluLKycqinQgERAAIAAADkYElwQ0PDUE+FAiEABAAAAMgxRUVF0dzcnHYJLikpGerpkOcEgAAAAAA5qra2Nt0NWFVVNdRTIY8JAAEAAAByvCS4vb1dSTC7TAAIAAAAkCclwa2trUqC2WkCQAAAAIA8KglOugQrCWZnCAABAAAA8khZWVlaEtzY2DjUUyFPCAABAAAA8rAkuKmpKdra2pQE84IEgAAAAAB5asSIEUqCeUECQAAAAIA8piSYFyIABAAAAMhzSoLZEQEgAAAAQAGVBHd2dkZ1dfVQT4UcIgAEAAAAKCClpaUxYcKEGD169FBPhRwhAAQAAAAowJLgMWPGpEFgEggyvAkAAQAAAApUTU1N2iU4+cjwJQAEAAAAKGDJDsC2trZ0RyDDkwAQAAAAYBiUBCdnAra3tysJHoYEgAAAAADDRNIdWEnw8CMABAAAABiGXYKVBA8fAkAAAACAYUhJ8PAhAAQAAAAY5iXBI0aMGOqpMIgEgAAAAADD2LYuwU1NTWmzEAqPABAAAACAaGxsTLsEl5WVWY0CIwAEAAAAIFVVVaUkuAAJAAEAAADYrqSkJC0Jbm5uVhJcIASAAAAAADxPQ0ODkuACIQAEAAAAYIclwbW1tVYojwkAAQAAANhhSXBra6uS4DwmAAQAAADgRZUEd3R06BKchwSAAAAAALwolZWVSoLzkAAQAAAAgJ0uCW5padElOE8IAAEAAADYaaNGjUpLgsvLy61ejhMAAgAAALBbJcF1dXVWMIcJAAEAAADY9XCpuDjGjx8fY8eOVRKcowSAAAAAAOy2+vp6JcE5SgAIAAAAwICWBI8cOdKK5hABIAAAAAADFzYVF8e4ceOUBOcQASAAAAAAg1ISnOwGrKiosLpDTAAIAAAAwKBIwr+Ojg4lwUNMAAgAAADAoJcEJ5fkOtln1QEAAAAYdEljkGQ3oJLg7BMAAgAAAJDVkuDkfECyRwAIAAAAQNYkZcBjx46N8ePHKwnOEgEgAAAAAFlXV1enS3CWCAABAAAAGBLl5eVpSfCoUaPcA4NIAAgAAADAkJYEt7S0KAkeRAJAAAAAAHKmJLiysnKop1JwBIAAAAAA5AQlwYNDAAgAAABAzigqKkpLgltbW3UJHiACQAAAAAByTm1tbVoSXFVVNdRTyXsCQAAAAABytiS4vb09GhoahnoqeU0ACAAAAEBOlwQ3NzenJcElJSVDPZ28JAAEAAAAIOcpCd51AkAAAAAA8kJZWVlaEtzY2DjUU8krAkAAAAAA8qokuKmpKdra2pQEv0gCQAAAAADyzogRI3QJfpEEgAAAAADkJSXBL44AEAAAAIC8pST4hQkAAQAAACiIkuDOzs6orq4e6qnkHAEgAAAAAAWhtLQ0JkyYEKNHjx7qqeQUASAAAAAABVUSPGbMmDQILCkpGerp5AQBIAAAAAAFp6amRknw0wSAAAAAABRsSXB9fX0MdwJAAAAAAChgAkAAAAAAKGACQAAAAAAoYAJAAAAAAChgAkAAAAAAKGACQAAAAAAoYKVDPYFcsXLlyvjrX/8aTz75ZHR1daWX9evXp1+7/vrro7m5OeP3btmyJR599NH4/e9/n37/okWLYuvWrVFXVxd77LFHvPWtb43Xve51uzy3c889N/7yl7/scMxrX/vaOP/883f5ZwAAAABQmASAT5sxY0bcdtttu7SIF154YfzpT3/6v0UtLY2ysrJYsWJF/OpXv0ovb3jDG+Kss86KkpKSXb6zKisr00t/RowYscu3CwAAAEDhEgA+raioKMaMGROTJk2Kl7zkJVFVVZXu/Hsxenp6oqWlJd72trfFfvvtF21tbentLVu2LL73ve/FAw88EA8//HA0NTXFSSedtMt31qGHHhrHH3/8Ln8/AAAAAMOPAPBpRx99dBx33HHbF2bmzJkvehFPOOGE2HPPPZ+3u2/06NFx2mmnxebNm+PBBx+M6dOnx7HHHhsVFRUDdf8BAAAAwA5pAvK03SnN3WuvvXb4/ckZgIkkCJw3b94u/xwAAAAA2FkCwCxImoFs09vbm40fCQAAAAApJcBZsK2Db9IcZNy4cbt8Ow899FD89Kc/TTsWJ81AWltb0zMHJ0+eHNXV1QM4YwAAAAAKhQBwkG3cuDG+//3vp9df//rXR01NzS7f1sKFC9MQMTlDcP369fH3v/89vdx///3xqU99KiZOnPiCt3HLLbfErbfe2u/X9t577ygvL093KS5atGiX50lh27aL1eMEwPMsQL7xtyyQ73a1slQAOMiuueaatBtwEvztagfgV7ziFek5gvvss0/U19enHYbXrl0bv/jFL+Lmm2+OpUuXxgUXXBBXX331s8qN+5MEh0uWLMnYzXgbpcq8GB4nAIPL8yyA51iAgSAAHETJTruHH344DexOP/30aGpq2qXbOf7445/3b7W1tTF16tS0+/DHP/7xWLFiRdxzzz1x4okn7vC2kiAy0zye2cikuNjxkLzwi1GPE4CB53kWYPB4jgWGq2ERAF588cVpqexzveENb4j3ve99g/Iz77777rjtttvS66eeemrsv//+g/JzXvKSl6T/HQ8++GD89re/fcEA8IQTTkgv/bniiivSnYVJqNPS0jIo8yX/JeXhyR9OHifki76+vuju7k6PUEjekIFc53mWfON5lnziOZZ84zmW59rVjTjDYpvXunXrYtWqVc+7JOWwg2H69Olx4403ptdPPvnkmDJlSgymPfbYI/3o3D4AAAAAhu0OwGx54IEH4utf//r20t3DDjssaz8bAAAAAIblDsBs+clPfhLXXXddev2II46IY489Nis/9x//+Ef6sbm5OSs/DwAAAID8IQAcID//+c/Tjr9Jff7BBx+8yx1/nyu5vR3p6upKG40k9t133wH5mQAAAAAUjmFRAvxiJE0NkrMCt3nm+YDJv1dVVW3/fMSIEc86dPGRRx6Jq666Kr2NyZMn73RjkaRb8LaGIdOmTXvW1+68885YsGBB2ugj6fibdPHdNqck+LvpppvSw+1HjRql3BgAAACA5xEAPm3p0qUZg7szzzzzWZ9ff/31zyq3TRp+bGsnn4SBv/zlLzM+1JKfkYR5L9bWrVvjpz/9aXpJVFdXp+FjElBu2x2YdOw955xzoq6uzkMcAAAAgGcRAA5wme7q1at3OHbLli07ddsHHHBAGi7+/e9/T7v8rl27NjZt2hQjR46M9vb2+Ld/+7c48MADo7KycpfnDwAAAEDhEgA+LdnR99zy2xfrhhtu2K07IekWnFz6M2HChDjhhBN26/YBAAAAGL40AQEAAACAAiYABAAAAIACJgAEAAAAgAImAAQAAACAAiYABAAAAIACJgAEAAAAgAImAAQAAACAAiYABAAAAIACJgAEAAAAgAImAAQAAACAAiYABAAAAIACJgAEAAAAgAJWOtQTIPesW7currjiiqGeBjmqt7d3+/XiYu8hAHieBcgf/pYFCiGz2RUCQJ6nr68v1q5da2UAAAAACoAAkO1GjBhhNXhBy5cvj56enigpKYnGxkYrBjDAPM8CDB7PscBwzXCK+pLtXgAv0pQpU2LJkiXR1NQU999/v3UDGGCeZwEGj+dYYLhygBcAAAAAFDABIAAAAAAUMAEgAAAAABQwASAAAAAAFDABIAAAAAAUsNKhngCQX44//vhYv3591NTUDPVUAAqS51kAz7EAA62or6+vb8BvFQAAAADICUqAAQAAAKCACQABAAAAoIAJAAEAAACggAkAAQAAAKCA6QIM7NDSpUvjl7/8ZTz22GMxe/bsWLFiRZSWlsaYMWNi7733joMPPjhaWlqsIsAA+tznPhe/+c1v0utvectb4owzzrC+ALtp1apVMX369Pjtb38bS5Ysia1bt8aoUaNi4sSJsd9++8WBBx5ojYGCJQAEdhj+nXLKKfHMZuHV1dWxZcuWmDt3bnr54Q9/mL4wPeCAA6wkwAD43//93+3hHwAD49e//nVcddVVsX79+vTz8vLyKCkpicWLF6eX5I1uASBQyASAQEa9vb3px9e85jXpDpRkx19dXV309PTE448/Hl//+tfTP5auvPLKaG1tjY6ODqsJsBuSF6bXX3991NTUpLtS5s2bZz0BdtMf//jH+PznPx/d3d3x5je/OY444oiYMGFC+rV169bFE088EX//+9+tM1DQivqeubUH4DkvRJN3RDs7O/tdl5UrV8aHP/zhWL16dfqO6Uc+8hHrB7Abrr322nRn9amnnpruBPzLX/6iBBhgN2zcuDE++MEPxrJly+Lwww+Pd7/73dYTGJY0AQEySnagZAr/EsnulH/9139Nr3d1dVlJgN3wt7/9LX70ox/FS1/60pg8ebK1BBgAP/3pT9Pwr7GxMd75zndaU2DYEgACuyUpCU4kZcEA7JrkIPprrrkmioqK4rTTToviYn+iAQyEn//85+nH/fffP8rKyiwqMGw5AxDYLUl5WqK9vd1KAuyiO+64Iz3vL+msPmnSJOsIMACSxnUzZ85MryfPrcnz7O233x5/+tOf0rP/kmqWV77ylWlp8LYzAQEKlQAQ2GW/+tWv4p///Gd6Xdc0gF2TdFS/8847o6GhQXkawABasmRJ2vgjsWDBgrjuuuti8+bNaQfg5LJ06dL42c9+Fg8//HCceeaZccABB1h/oGAJAIFdkvzBlBxWn9hvv/22nwUIwIuX9GJLnkuTF6innHJKVFdXWz6AAZLs8tsmeaNl5MiR8YlPfCJe85rXpEctJLsDk+MXkje0r7rqqvTs63Hjxll/oCA5YAbYpT+mLrzwwrT7b0tLS9oJGICdl3T8TZp/JG+i2HkCMPBvsmzT29sbZ5xxRrz2ta/dfs5qEvh96lOfisrKyrRceNq0ae4CoGAJAIGdsnHjxrjgggti9uzZabnaZz/72aitrbWKADtpxYoV8e1vfzstQzv11FOtH8AAq6qq2n69ra0t9tlnn+eNSf6efeMb35heT84GBChUSoCBFy05MyUJ/J544om0hCLZBZjsAARg5910002xfv36OOqoo9Ln1OQNlmdKdqts67K+7WsVFRU6BAO8SEm4t01ra2vGcdu+lhxxA1CoBIDAiw7/ksDvr3/9a4wYMSINApN3UgHY9cPpt3UATi6ZPPTQQ+klse2MKgBeWF1dXdrpd+XKlS9quYqKiiwrULCUAAMvaOvWrXHxxRfHY489lh5Q/5nPfCYmTpxo5QAAyGl77713+nHevHkZx2z7WlNTU9bmBZBtdgACO5R0prz00kvjD3/4Q3pA8vnnnx977LGHVQPYTckbKzty7rnnxl/+8pd4y1vekh5cD8DOS55DH3zwwZg7d278/ve/TzsAP/c81l/84hfp9aRBCEChsgMQyCg5d+ryyy+P3/72t+kh9UmXtL322suKAQCQF1796lenndYTX/rSl+J3v/vd9jNWZ82aFRdddFFs2rQpbWr3jne8Y4hnCzB47AAEMnr88cfjkUceSa/39fWlYeALHWgPAAC55Oyzz07fyJ45c2ZccMEF6RvbpaWlsWHDhvTryfnW55xzzrOahgAUGgEgkFES+j3zHMBVq1ZZLQAA8koS8F122WVx3333peW+8+fPT4+5GT9+fLo78LDDDovGxsahnibAoCrqe+YrfAAAAACgoDgDEAAAAAAKmAAQAAAAAAqYABAAAAAACpgAEAAAAAAKmAAQAAAAAAqYABAAAAAACpgAEAAAAAAKmAAQAAAAAAqYABAAAAAACpgAEAAAAAAKmAAQAAAAAAqYABAAAAAACpgAEAAAAAAKmAAQAAAAAAqYABAAAAAACpgAEAAAAAAKmAAQAAAAAAqYABAAgKyZPXt2FBUVpZd3v/vdVh4AIAsEgAAAAABQwASAAAAAAFDABIAAAAAAUMAEgAAAAABQwASAAAAAAFDABIAAAOSMf//3f9/eJXibu+++O6ZOnRrjx4+PioqKGDduXBxxxBHxi1/8YlDnsm0eyZwSK1eujIsuuihe85rXRENDQ9TU1MRee+0VH/vYx2LRokWDOhcAgN1RulvfDQAAg2TTpk3xrne9K+68885n/fvChQvjrrvuSi9f+MIX0gBusP3lL3+Jgw46KJ566qln/fvjjz+eXm644Ya47bbb4j//8z8HfS4AADtLAAgAQE5673vfm4Z/r3jFK+K4446LSZMmxfr16+Pee++Ne+65Jx3ziU98Il7/+tfHAQccMGjzWL16dbzjHe9Iw783vvGNceSRR0Zzc3PMmTMnvvOd78Qf//jHWLVqVRx66KHprsR999130OYCALArivr6+vp26TsBAGAnzZ49OyZOnJheP+mkk+Jb3/rWs76elNs+9NBD2z8/66yz4rLLLovi4mefXPO5z30uzjvvvPT6wQcfHNOmTRvw++KZZciJz3/+8/Hxj3/8Wf/W09MTZ5xxRlxzzTXp50lJ8J///OfnzRcAYCj5ywQAgJz0pje9KS6//PJ+w7RzzjknPRMw8eMf/zi6u7sHdS6HH37488K/RElJSXzpS1+K1772tennf/vb32L69OmDOhcAgJ0lAAQAICedeeaZz9uF98zg7c1vfvP2swK7uroGdS79hX/bJAHl2Wefvf3z555ZCAAw1ASAAADkpORsvx1pbW3dfj3p0DtY6urq4nWve90Ox7z1rW/dfv03v/nNoM0FAGBXCAABAMhJo0eP3uHXKyoqtl9PdgEOlqT5SKadiM+ca319fXp9wYIFgzYXAIBdIQAEACAn5UojjZqamp0at27dukGeEQDAzsmNv6oAACBHrV+/fqfGjRgxYpBnBACwcwSAAACwA0mDkb6+vh2u0fLly2PVqlXp9XHjxllPACCnCAABAGAH1qxZ84KNPX7yk59sv77ffvtZTwAgpwgAAQDgBVx++eUZv9bb2xtXXnnl9s+PPPJI6wkA5BQBIAAAvIA777zzWSHfM8O/s846a/sOwZe//OUxdepU6wkA5JTSoZ4AAADksr333jstAz777LNj2rRp6Q6/pqammDt3bnznO9+JP/zhD+m4ioqKuPHGG3OmezEAwDYCQAAA2IGRI0fGzTffHAcffHA89NBD6aW/Mbfffnvsu+++1hIAyDnengQAgBfwile8It3pd+GFF8Y+++wT9fX1UVVVFXvuuWe6M/Dxxx+P//zP/7SOAEBOKurr6+sb6kkAAECuKSoqSj++6U1vip///OdDPR0AgF1mByAAAAAAFDABIAAAAAAUMAEgAAAAABQwXYABACgYc+bMid///ve7/P0ve9nL0gsAQCERAAIAUDB+9rOfxcknn7zL3//pT386PvOZzwzonAAAhpoAEAAA+tHX12ddAICCUNTnLxsAAAAAKFiagAAAAABAARMAAgAAAEABEwACAAAAQAETAAIAAABAARMAAgAAAEABEwACAAAAQAETAAIAAABAARMAAgAAAEABEwACAAAAQAETAAIAAABAARMAAgAAAEABEwACAAAAQBSu/weiJojBHzEIEQAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<plotnine.ggplot.ggplot object at 0x0000025EDB4C60F0>"
+            ]
+          },
+          "execution_count": 15,
+          "metadata": {
+            "image/png": {
+              "height": 480,
+              "width": 640
+            }
+          },
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "(p9.ggplot(train_full, p9.aes('ln_p', 'ln_q')) + p9.stat_smooth(color=\"red\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 149
+        },
+        "id": "aZPOUT5SvR4o",
+        "outputId": "5e643056-3955-4e66-f402-43232599b5ff"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Elasticity: -0.22896251098026174, SE: 0.033594430844959035, R2: 0.012083344035079824\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>0</th>\n",
+              "      <th>1</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>Intercept</th>\n",
+              "      <td>-10.662549</td>\n",
+              "      <td>-10.254317</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>ln_p</th>\n",
+              "      <td>-0.294828</td>\n",
+              "      <td>-0.163097</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                   0          1\n",
+              "Intercept -10.662549 -10.254317\n",
+              "ln_p       -0.294828  -0.163097"
+            ]
+          },
+          "execution_count": 16,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "result = sm.ols('ln_q ~ ln_p ', data=train_full).fit()\n",
+        "print('Elasticity: {}, SE: {}, R2: {}'.format(result.params['ln_p'], result.bse['ln_p'], result.rsquared_adj))\n",
+        "result.conf_int(alpha=0.05)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "cr2Ha215l4QK"
+      },
+      "source": [
+        "Let's begin with a simple prediction task. We will discover how well can we explain the price of these products using their textual descriptions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "pGt-G-qpciGd",
+        "outputId": "7918ab23-007c-4af7-d644-196a24997ec1"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Train: 2973, Val: 744, Holdout: 3708\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Split train_full into train and validation sets\n",
+        "train_ind, val_ind = train_test_split(np.arange(train_full.shape[0]), test_size=0.2, random_state=124)\n",
+        "\n",
+        "train = train_full.iloc[train_ind].reset_index(drop=True)\n",
+        "val = train_full.iloc[val_ind].reset_index(drop=True)\n",
+        "\n",
+        "def tokenize_texts(texts, max_length=128):\n",
+        "    \"\"\"Tokenize a list of texts and return dict of pytorch tensors.\"\"\"\n",
+        "    return tokenizer(\n",
+        "        list(texts),\n",
+        "        padding=True,\n",
+        "        truncation=True,\n",
+        "        max_length=max_length,\n",
+        "        return_tensors=\"pt\")\n",
+        "\n",
+        "train_enc = tokenize_texts(train[\"text\"])\n",
+        "val_enc = tokenize_texts(val[\"text\"])\n",
+        "holdout_enc = tokenize_texts(holdout[\"text\"])\n",
+        "\n",
+        "print(f\"Train: {len(train)}, Val: {len(val)}, Holdout: {len(holdout)}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "id": "XQ4DMJQ0drZm"
+      },
+      "outputs": [],
+      "source": [
+        "ln_p = train[\"ln_p\"].values.astype(np.float32)\n",
+        "ln_q = train[\"ln_q\"].values.astype(np.float32)\n",
+        "val_ln_p = val[\"ln_p\"].values.astype(np.float32)\n",
+        "val_ln_q = val[\"ln_q\"].values.astype(np.float32)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gPYEMuKZ7ylj"
+      },
+      "source": [
+        "# Using BERT as Feature Extractor"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "AJu0FlEcu6Zj",
+        "outputId": "418977e7-ad67-43d5-c463-a839f7ec38f3"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Embeddings shape: (2973, 768)\n"
+          ]
+        }
+      ],
+      "source": [
+        "@torch.no_grad()\n",
+        "def get_embeddings(bert_model, encodings, batch_size=256):\n",
+        "    \"\"\"Extract pooled BERT embeddings in batches.\"\"\"\n",
+        "    bert_model.eval()\n",
+        "    all_emb = []\n",
+        "    n = encodings['input_ids'].shape[0]\n",
+        "    for i in range(0, n, batch_size):\n",
+        "        batch = {k: v[i:i+batch_size].to(device) for k, v in encodings.items()}\n",
+        "        out = bert_model(**batch)\n",
+        "        all_emb.append(out.pooler_output.cpu().numpy())\n",
+        "    return np.concatenate(all_emb, axis=0)\n",
+        "\n",
+        "embeddings = get_embeddings(bert, train_enc)\n",
+        "print(f\"Embeddings shape: {embeddings.shape}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 155
+        },
+        "id": "-SSqzkf3vx8I",
+        "outputId": "cbb5abe8-130e-43b8-ac92-d845b2b75457"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<style>#sk-container-id-1 {\n",
+              "  /* Definition of color scheme common for light and dark mode */\n",
+              "  --sklearn-color-text: #000;\n",
+              "  --sklearn-color-text-muted: #666;\n",
+              "  --sklearn-color-line: gray;\n",
+              "  /* Definition of color scheme for unfitted estimators */\n",
+              "  --sklearn-color-unfitted-level-0: #fff5e6;\n",
+              "  --sklearn-color-unfitted-level-1: #f6e4d2;\n",
+              "  --sklearn-color-unfitted-level-2: #ffe0b3;\n",
+              "  --sklearn-color-unfitted-level-3: chocolate;\n",
+              "  /* Definition of color scheme for fitted estimators */\n",
+              "  --sklearn-color-fitted-level-0: #f0f8ff;\n",
+              "  --sklearn-color-fitted-level-1: #d4ebff;\n",
+              "  --sklearn-color-fitted-level-2: #b3dbfd;\n",
+              "  --sklearn-color-fitted-level-3: cornflowerblue;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1.light {\n",
+              "  /* Specific color for light theme */\n",
+              "  --sklearn-color-text-on-default-background: black;\n",
+              "  --sklearn-color-background: white;\n",
+              "  --sklearn-color-border-box: black;\n",
+              "  --sklearn-color-icon: #696969;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1.dark {\n",
+              "  --sklearn-color-text-on-default-background: white;\n",
+              "  --sklearn-color-background: #111;\n",
+              "  --sklearn-color-border-box: white;\n",
+              "  --sklearn-color-icon: #878787;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 {\n",
+              "  color: var(--sklearn-color-text);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 pre {\n",
+              "  padding: 0;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 input.sk-hidden--visually {\n",
+              "  border: 0;\n",
+              "  clip: rect(1px 1px 1px 1px);\n",
+              "  clip: rect(1px, 1px, 1px, 1px);\n",
+              "  height: 1px;\n",
+              "  margin: -1px;\n",
+              "  overflow: hidden;\n",
+              "  padding: 0;\n",
+              "  position: absolute;\n",
+              "  width: 1px;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-dashed-wrapped {\n",
+              "  border: 1px dashed var(--sklearn-color-line);\n",
+              "  margin: 0 0.4em 0.5em 0.4em;\n",
+              "  box-sizing: border-box;\n",
+              "  padding-bottom: 0.4em;\n",
+              "  background-color: var(--sklearn-color-background);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-container {\n",
+              "  /* jupyter's `normalize.less` sets `[hidden] { display: none; }`\n",
+              "     but bootstrap.min.css set `[hidden] { display: none !important; }`\n",
+              "     so we also need the `!important` here to be able to override the\n",
+              "     default hidden behavior on the sphinx rendered scikit-learn.org.\n",
+              "     See: https://github.com/scikit-learn/scikit-learn/issues/21755 */\n",
+              "  display: inline-block !important;\n",
+              "  position: relative;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-text-repr-fallback {\n",
+              "  display: none;\n",
+              "}\n",
+              "\n",
+              "div.sk-parallel-item,\n",
+              "div.sk-serial,\n",
+              "div.sk-item {\n",
+              "  /* draw centered vertical line to link estimators */\n",
+              "  background-image: linear-gradient(var(--sklearn-color-text-on-default-background), var(--sklearn-color-text-on-default-background));\n",
+              "  background-size: 2px 100%;\n",
+              "  background-repeat: no-repeat;\n",
+              "  background-position: center center;\n",
+              "}\n",
+              "\n",
+              "/* Parallel-specific style estimator block */\n",
+              "\n",
+              "#sk-container-id-1 div.sk-parallel-item::after {\n",
+              "  content: \"\";\n",
+              "  width: 100%;\n",
+              "  border-bottom: 2px solid var(--sklearn-color-text-on-default-background);\n",
+              "  flex-grow: 1;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-parallel {\n",
+              "  display: flex;\n",
+              "  align-items: stretch;\n",
+              "  justify-content: center;\n",
+              "  background-color: var(--sklearn-color-background);\n",
+              "  position: relative;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-parallel-item {\n",
+              "  display: flex;\n",
+              "  flex-direction: column;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-parallel-item:first-child::after {\n",
+              "  align-self: flex-end;\n",
+              "  width: 50%;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-parallel-item:last-child::after {\n",
+              "  align-self: flex-start;\n",
+              "  width: 50%;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-parallel-item:only-child::after {\n",
+              "  width: 0;\n",
+              "}\n",
+              "\n",
+              "/* Serial-specific style estimator block */\n",
+              "\n",
+              "#sk-container-id-1 div.sk-serial {\n",
+              "  display: flex;\n",
+              "  flex-direction: column;\n",
+              "  align-items: center;\n",
+              "  background-color: var(--sklearn-color-background);\n",
+              "  padding-right: 1em;\n",
+              "  padding-left: 1em;\n",
+              "}\n",
+              "\n",
+              "\n",
+              "/* Toggleable style: style used for estimator/Pipeline/ColumnTransformer box that is\n",
+              "clickable and can be expanded/collapsed.\n",
+              "- Pipeline and ColumnTransformer use this feature and define the default style\n",
+              "- Estimators will overwrite some part of the style using the `sk-estimator` class\n",
+              "*/\n",
+              "\n",
+              "/* Pipeline and ColumnTransformer style (default) */\n",
+              "\n",
+              "#sk-container-id-1 div.sk-toggleable {\n",
+              "  /* Default theme specific background. It is overwritten whether we have a\n",
+              "  specific estimator or a Pipeline/ColumnTransformer */\n",
+              "  background-color: var(--sklearn-color-background);\n",
+              "}\n",
+              "\n",
+              "/* Toggleable label */\n",
+              "#sk-container-id-1 label.sk-toggleable__label {\n",
+              "  cursor: pointer;\n",
+              "  display: flex;\n",
+              "  width: 100%;\n",
+              "  margin-bottom: 0;\n",
+              "  padding: 0.5em;\n",
+              "  box-sizing: border-box;\n",
+              "  text-align: center;\n",
+              "  align-items: center;\n",
+              "  justify-content: center;\n",
+              "  gap: 0.5em;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 label.sk-toggleable__label .caption {\n",
+              "  font-size: 0.6rem;\n",
+              "  font-weight: lighter;\n",
+              "  color: var(--sklearn-color-text-muted);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 label.sk-toggleable__label-arrow:before {\n",
+              "  /* Arrow on the left of the label */\n",
+              "  content: \"▸\";\n",
+              "  float: left;\n",
+              "  margin-right: 0.25em;\n",
+              "  color: var(--sklearn-color-icon);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 label.sk-toggleable__label-arrow:hover:before {\n",
+              "  color: var(--sklearn-color-text);\n",
+              "}\n",
+              "\n",
+              "/* Toggleable content - dropdown */\n",
+              "\n",
+              "#sk-container-id-1 div.sk-toggleable__content {\n",
+              "  display: none;\n",
+              "  text-align: left;\n",
+              "  /* unfitted */\n",
+              "  background-color: var(--sklearn-color-unfitted-level-0);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-toggleable__content.fitted {\n",
+              "  /* fitted */\n",
+              "  background-color: var(--sklearn-color-fitted-level-0);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-toggleable__content pre {\n",
+              "  margin: 0.2em;\n",
+              "  border-radius: 0.25em;\n",
+              "  color: var(--sklearn-color-text);\n",
+              "  /* unfitted */\n",
+              "  background-color: var(--sklearn-color-unfitted-level-0);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-toggleable__content.fitted pre {\n",
+              "  /* unfitted */\n",
+              "  background-color: var(--sklearn-color-fitted-level-0);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 input.sk-toggleable__control:checked~div.sk-toggleable__content {\n",
+              "  /* Expand drop-down */\n",
+              "  display: block;\n",
+              "  width: 100%;\n",
+              "  overflow: visible;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {\n",
+              "  content: \"▾\";\n",
+              "}\n",
+              "\n",
+              "/* Pipeline/ColumnTransformer-specific style */\n",
+              "\n",
+              "#sk-container-id-1 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {\n",
+              "  color: var(--sklearn-color-text);\n",
+              "  background-color: var(--sklearn-color-unfitted-level-2);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-label.fitted input.sk-toggleable__control:checked~label.sk-toggleable__label {\n",
+              "  background-color: var(--sklearn-color-fitted-level-2);\n",
+              "}\n",
+              "\n",
+              "/* Estimator-specific style */\n",
+              "\n",
+              "/* Colorize estimator box */\n",
+              "#sk-container-id-1 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {\n",
+              "  /* unfitted */\n",
+              "  background-color: var(--sklearn-color-unfitted-level-2);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-estimator.fitted input.sk-toggleable__control:checked~label.sk-toggleable__label {\n",
+              "  /* fitted */\n",
+              "  background-color: var(--sklearn-color-fitted-level-2);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-label label.sk-toggleable__label,\n",
+              "#sk-container-id-1 div.sk-label label {\n",
+              "  /* The background is the default theme color */\n",
+              "  color: var(--sklearn-color-text-on-default-background);\n",
+              "}\n",
+              "\n",
+              "/* On hover, darken the color of the background */\n",
+              "#sk-container-id-1 div.sk-label:hover label.sk-toggleable__label {\n",
+              "  color: var(--sklearn-color-text);\n",
+              "  background-color: var(--sklearn-color-unfitted-level-2);\n",
+              "}\n",
+              "\n",
+              "/* Label box, darken color on hover, fitted */\n",
+              "#sk-container-id-1 div.sk-label.fitted:hover label.sk-toggleable__label.fitted {\n",
+              "  color: var(--sklearn-color-text);\n",
+              "  background-color: var(--sklearn-color-fitted-level-2);\n",
+              "}\n",
+              "\n",
+              "/* Estimator label */\n",
+              "\n",
+              "#sk-container-id-1 div.sk-label label {\n",
+              "  font-family: monospace;\n",
+              "  font-weight: bold;\n",
+              "  line-height: 1.2em;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-label-container {\n",
+              "  text-align: center;\n",
+              "}\n",
+              "\n",
+              "/* Estimator-specific */\n",
+              "#sk-container-id-1 div.sk-estimator {\n",
+              "  font-family: monospace;\n",
+              "  border: 1px dotted var(--sklearn-color-border-box);\n",
+              "  border-radius: 0.25em;\n",
+              "  box-sizing: border-box;\n",
+              "  margin-bottom: 0.5em;\n",
+              "  /* unfitted */\n",
+              "  background-color: var(--sklearn-color-unfitted-level-0);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-estimator.fitted {\n",
+              "  /* fitted */\n",
+              "  background-color: var(--sklearn-color-fitted-level-0);\n",
+              "}\n",
+              "\n",
+              "/* on hover */\n",
+              "#sk-container-id-1 div.sk-estimator:hover {\n",
+              "  /* unfitted */\n",
+              "  background-color: var(--sklearn-color-unfitted-level-2);\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 div.sk-estimator.fitted:hover {\n",
+              "  /* fitted */\n",
+              "  background-color: var(--sklearn-color-fitted-level-2);\n",
+              "}\n",
+              "\n",
+              "/* Specification for estimator info (e.g. \"i\" and \"?\") */\n",
+              "\n",
+              "/* Common style for \"i\" and \"?\" */\n",
+              "\n",
+              ".sk-estimator-doc-link,\n",
+              "a:link.sk-estimator-doc-link,\n",
+              "a:visited.sk-estimator-doc-link {\n",
+              "  float: right;\n",
+              "  font-size: smaller;\n",
+              "  line-height: 1em;\n",
+              "  font-family: monospace;\n",
+              "  background-color: var(--sklearn-color-unfitted-level-0);\n",
+              "  border-radius: 1em;\n",
+              "  height: 1em;\n",
+              "  width: 1em;\n",
+              "  text-decoration: none !important;\n",
+              "  margin-left: 0.5em;\n",
+              "  text-align: center;\n",
+              "  /* unfitted */\n",
+              "  border: var(--sklearn-color-unfitted-level-3) 1pt solid;\n",
+              "  color: var(--sklearn-color-unfitted-level-3);\n",
+              "}\n",
+              "\n",
+              ".sk-estimator-doc-link.fitted,\n",
+              "a:link.sk-estimator-doc-link.fitted,\n",
+              "a:visited.sk-estimator-doc-link.fitted {\n",
+              "  /* fitted */\n",
+              "  background-color: var(--sklearn-color-fitted-level-0);\n",
+              "  border: var(--sklearn-color-fitted-level-3) 1pt solid;\n",
+              "  color: var(--sklearn-color-fitted-level-3);\n",
+              "}\n",
+              "\n",
+              "/* On hover */\n",
+              "div.sk-estimator:hover .sk-estimator-doc-link:hover,\n",
+              ".sk-estimator-doc-link:hover,\n",
+              "div.sk-label-container:hover .sk-estimator-doc-link:hover,\n",
+              ".sk-estimator-doc-link:hover {\n",
+              "  /* unfitted */\n",
+              "  background-color: var(--sklearn-color-unfitted-level-3);\n",
+              "  border: var(--sklearn-color-fitted-level-0) 1pt solid;\n",
+              "  color: var(--sklearn-color-unfitted-level-0);\n",
+              "  text-decoration: none;\n",
+              "}\n",
+              "\n",
+              "div.sk-estimator.fitted:hover .sk-estimator-doc-link.fitted:hover,\n",
+              ".sk-estimator-doc-link.fitted:hover,\n",
+              "div.sk-label-container:hover .sk-estimator-doc-link.fitted:hover,\n",
+              ".sk-estimator-doc-link.fitted:hover {\n",
+              "  /* fitted */\n",
+              "  background-color: var(--sklearn-color-fitted-level-3);\n",
+              "  border: var(--sklearn-color-fitted-level-0) 1pt solid;\n",
+              "  color: var(--sklearn-color-fitted-level-0);\n",
+              "  text-decoration: none;\n",
+              "}\n",
+              "\n",
+              "/* Span, style for the box shown on hovering the info icon */\n",
+              ".sk-estimator-doc-link span {\n",
+              "  display: none;\n",
+              "  z-index: 9999;\n",
+              "  position: relative;\n",
+              "  font-weight: normal;\n",
+              "  right: .2ex;\n",
+              "  padding: .5ex;\n",
+              "  margin: .5ex;\n",
+              "  width: min-content;\n",
+              "  min-width: 20ex;\n",
+              "  max-width: 50ex;\n",
+              "  color: var(--sklearn-color-text);\n",
+              "  box-shadow: 2pt 2pt 4pt #999;\n",
+              "  /* unfitted */\n",
+              "  background: var(--sklearn-color-unfitted-level-0);\n",
+              "  border: .5pt solid var(--sklearn-color-unfitted-level-3);\n",
+              "}\n",
+              "\n",
+              ".sk-estimator-doc-link.fitted span {\n",
+              "  /* fitted */\n",
+              "  background: var(--sklearn-color-fitted-level-0);\n",
+              "  border: var(--sklearn-color-fitted-level-3);\n",
+              "}\n",
+              "\n",
+              ".sk-estimator-doc-link:hover span {\n",
+              "  display: block;\n",
+              "}\n",
+              "\n",
+              "/* \"?\"-specific style due to the `<a>` HTML tag */\n",
+              "\n",
+              "#sk-container-id-1 a.estimator_doc_link {\n",
+              "  float: right;\n",
+              "  font-size: 1rem;\n",
+              "  line-height: 1em;\n",
+              "  font-family: monospace;\n",
+              "  background-color: var(--sklearn-color-unfitted-level-0);\n",
+              "  border-radius: 1rem;\n",
+              "  height: 1rem;\n",
+              "  width: 1rem;\n",
+              "  text-decoration: none;\n",
+              "  /* unfitted */\n",
+              "  color: var(--sklearn-color-unfitted-level-1);\n",
+              "  border: var(--sklearn-color-unfitted-level-1) 1pt solid;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 a.estimator_doc_link.fitted {\n",
+              "  /* fitted */\n",
+              "  background-color: var(--sklearn-color-fitted-level-0);\n",
+              "  border: var(--sklearn-color-fitted-level-1) 1pt solid;\n",
+              "  color: var(--sklearn-color-fitted-level-1);\n",
+              "}\n",
+              "\n",
+              "/* On hover */\n",
+              "#sk-container-id-1 a.estimator_doc_link:hover {\n",
+              "  /* unfitted */\n",
+              "  background-color: var(--sklearn-color-unfitted-level-3);\n",
+              "  color: var(--sklearn-color-background);\n",
+              "  text-decoration: none;\n",
+              "}\n",
+              "\n",
+              "#sk-container-id-1 a.estimator_doc_link.fitted:hover {\n",
+              "  /* fitted */\n",
+              "  background-color: var(--sklearn-color-fitted-level-3);\n",
+              "}\n",
+              "\n",
+              ".estimator-table {\n",
+              "    font-family: monospace;\n",
+              "}\n",
+              "\n",
+              ".estimator-table summary {\n",
+              "    padding: .5rem;\n",
+              "    cursor: pointer;\n",
+              "}\n",
+              "\n",
+              ".estimator-table summary::marker {\n",
+              "    font-size: 0.7rem;\n",
+              "}\n",
+              "\n",
+              ".estimator-table details[open] {\n",
+              "    padding-left: 0.1rem;\n",
+              "    padding-right: 0.1rem;\n",
+              "    padding-bottom: 0.3rem;\n",
+              "}\n",
+              "\n",
+              ".estimator-table .parameters-table {\n",
+              "    margin-left: auto !important;\n",
+              "    margin-right: auto !important;\n",
+              "    margin-top: 0;\n",
+              "}\n",
+              "\n",
+              ".estimator-table .parameters-table tr:nth-child(odd) {\n",
+              "    background-color: #fff;\n",
+              "}\n",
+              "\n",
+              ".estimator-table .parameters-table tr:nth-child(even) {\n",
+              "    background-color: #f6f6f6;\n",
+              "}\n",
+              "\n",
+              ".estimator-table .parameters-table tr:hover {\n",
+              "    background-color: #e0e0e0;\n",
+              "}\n",
+              "\n",
+              ".estimator-table table td {\n",
+              "    border: 1px solid rgba(106, 105, 104, 0.232);\n",
+              "}\n",
+              "\n",
+              "/*\n",
+              "    `table td`is set in notebook with right text-align.\n",
+              "    We need to overwrite it.\n",
+              "*/\n",
+              ".estimator-table table td.param {\n",
+              "    text-align: left;\n",
+              "    position: relative;\n",
+              "    padding: 0;\n",
+              "}\n",
+              "\n",
+              ".user-set td {\n",
+              "    color:rgb(255, 94, 0);\n",
+              "    text-align: left !important;\n",
+              "}\n",
+              "\n",
+              ".user-set td.value {\n",
+              "    color:rgb(255, 94, 0);\n",
+              "    background-color: transparent;\n",
+              "}\n",
+              "\n",
+              ".default td {\n",
+              "    color: black;\n",
+              "    text-align: left !important;\n",
+              "}\n",
+              "\n",
+              ".user-set td i,\n",
+              ".default td i {\n",
+              "    color: black;\n",
+              "}\n",
+              "\n",
+              "/*\n",
+              "    Styles for parameter documentation links\n",
+              "    We need styling for visited so jupyter doesn't overwrite it\n",
+              "*/\n",
+              "a.param-doc-link,\n",
+              "a.param-doc-link:link,\n",
+              "a.param-doc-link:visited {\n",
+              "    text-decoration: underline dashed;\n",
+              "    text-underline-offset: .3em;\n",
+              "    color: inherit;\n",
+              "    display: block;\n",
+              "    padding: .5em;\n",
+              "}\n",
+              "\n",
+              "/* \"hack\" to make the entire area of the cell containing the link clickable */\n",
+              "a.param-doc-link::before {\n",
+              "    position: absolute;\n",
+              "    content: \"\";\n",
+              "    inset: 0;\n",
+              "}\n",
+              "\n",
+              ".param-doc-description {\n",
+              "    display: none;\n",
+              "    position: absolute;\n",
+              "    z-index: 9999;\n",
+              "    left: 0;\n",
+              "    padding: .5ex;\n",
+              "    margin-left: 1.5em;\n",
+              "    color: var(--sklearn-color-text);\n",
+              "    box-shadow: .3em .3em .4em #999;\n",
+              "    width: max-content;\n",
+              "    text-align: left;\n",
+              "    max-height: 10em;\n",
+              "    overflow-y: auto;\n",
+              "\n",
+              "    /* unfitted */\n",
+              "    background: var(--sklearn-color-unfitted-level-0);\n",
+              "    border: thin solid var(--sklearn-color-unfitted-level-3);\n",
+              "}\n",
+              "\n",
+              "/* Fitted state for parameter tooltips */\n",
+              ".fitted .param-doc-description {\n",
+              "    /* fitted */\n",
+              "    background: var(--sklearn-color-fitted-level-0);\n",
+              "    border: thin solid var(--sklearn-color-fitted-level-3);\n",
+              "}\n",
+              "\n",
+              ".param-doc-link:hover .param-doc-description {\n",
+              "    display: block;\n",
+              "}\n",
+              "\n",
+              ".copy-paste-icon {\n",
+              "    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NDggNTEyIj48IS0tIUZvbnQgQXdlc29tZSBGcmVlIDYuNy4yIGJ5IEBmb250YXdlc29tZSAtIGh0dHBzOi8vZm9udGF3ZXNvbWUuY29tIExpY2Vuc2UgLSBodHRwczovL2ZvbnRhd2Vzb21lLmNvbS9saWNlbnNlL2ZyZWUgQ29weXJpZ2h0IDIwMjUgRm9udGljb25zLCBJbmMuLS0+PHBhdGggZD0iTTIwOCAwTDMzMi4xIDBjMTIuNyAwIDI0LjkgNS4xIDMzLjkgMTQuMWw2Ny45IDY3LjljOSA5IDE0LjEgMjEuMiAxNC4xIDMzLjlMNDQ4IDMzNmMwIDI2LjUtMjEuNSA0OC00OCA0OGwtMTkyIDBjLTI2LjUgMC00OC0yMS41LTQ4LTQ4bDAtMjg4YzAtMjYuNSAyMS41LTQ4IDQ4LTQ4ek00OCAxMjhsODAgMCAwIDY0LTY0IDAgMCAyNTYgMTkyIDAgMC0zMiA2NCAwIDAgNDhjMCAyNi41LTIxLjUgNDgtNDggNDhMNDggNTEyYy0yNi41IDAtNDgtMjEuNS00OC00OEwwIDE3NmMwLTI2LjUgMjEuNS00OCA0OC00OHoiLz48L3N2Zz4=);\n",
+              "    background-repeat: no-repeat;\n",
+              "    background-size: 14px 14px;\n",
+              "    background-position: 0;\n",
+              "    display: inline-block;\n",
+              "    width: 14px;\n",
+              "    height: 14px;\n",
+              "    cursor: pointer;\n",
+              "}\n",
+              "</style><body><div id=\"sk-container-id-1\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>Pipeline(steps=[(&#x27;standardscaler&#x27;, StandardScaler()),\n",
+              "                (&#x27;lassocv&#x27;,\n",
+              "                 LassoCV(cv=KFold(n_splits=5, random_state=123, shuffle=True),\n",
+              "                         random_state=123))])</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item sk-dashed-wrapped\"><div class=\"sk-label-container\"><div class=\"sk-label fitted sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-1\" type=\"checkbox\" ><label for=\"sk-estimator-id-1\" class=\"sk-toggleable__label fitted sk-toggleable__label-arrow\"><div><div>Pipeline</div></div><div><a class=\"sk-estimator-doc-link fitted\" rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.pipeline.Pipeline.html\">?<span>Documentation for Pipeline</span></a><span class=\"sk-estimator-doc-link fitted\">i<span>Fitted</span></span></div></label><div class=\"sk-toggleable__content fitted\" data-param-prefix=\"\">\n",
+              "        <div class=\"estimator-table\">\n",
+              "            <details>\n",
+              "                <summary>Parameters</summary>\n",
+              "                <table class=\"parameters-table\">\n",
+              "                  <tbody>\n",
+              "                    \n",
+              "        <tr class=\"user-set\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('steps',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.pipeline.Pipeline.html#:~:text=steps,-list%20of%20tuples\">\n",
+              "            steps\n",
+              "            <span class=\"param-doc-description\">steps: list of tuples<br><br>List of (name of step, estimator) tuples that are to be chained in<br>sequential order. To be compatible with the scikit-learn API, all steps<br>must define `fit`. All non-last steps must also define `transform`. See<br>:ref:`Combining Estimators <combining_estimators>` for more details.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">[(&#x27;standardscaler&#x27;, ...), (&#x27;lassocv&#x27;, ...)]</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('transform_input',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.pipeline.Pipeline.html#:~:text=transform_input,-list%20of%20str%2C%20default%3DNone\">\n",
+              "            transform_input\n",
+              "            <span class=\"param-doc-description\">transform_input: list of str, default=None<br><br>The names of the :term:`metadata` parameters that should be transformed by the<br>pipeline before passing it to the step consuming it.<br><br>This enables transforming some input arguments to ``fit`` (other than ``X``)<br>to be transformed by the steps of the pipeline up to the step which requires<br>them. Requirement is defined via :ref:`metadata routing <metadata_routing>`.<br>For instance, this can be used to pass a validation set through the pipeline.<br><br>You can only set this if metadata routing is enabled, which you<br>can enable using ``sklearn.set_config(enable_metadata_routing=True)``.<br><br>.. versionadded:: 1.6</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">None</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('memory',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.pipeline.Pipeline.html#:~:text=memory,-str%20or%20object%20with%20the%20joblib.Memory%20interface%2C%20default%3DNone\">\n",
+              "            memory\n",
+              "            <span class=\"param-doc-description\">memory: str or object with the joblib.Memory interface, default=None<br><br>Used to cache the fitted transformers of the pipeline. The last step<br>will never be cached, even if it is a transformer. By default, no<br>caching is performed. If a string is given, it is the path to the<br>caching directory. Enabling caching triggers a clone of the transformers<br>before fitting. Therefore, the transformer instance given to the<br>pipeline cannot be inspected directly. Use the attribute ``named_steps``<br>or ``steps`` to inspect estimators within the pipeline. Caching the<br>transformers is advantageous when fitting is time consuming. See<br>:ref:`sphx_glr_auto_examples_neighbors_plot_caching_nearest_neighbors.py`<br>for an example on how to enable caching.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">None</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('verbose',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.pipeline.Pipeline.html#:~:text=verbose,-bool%2C%20default%3DFalse\">\n",
+              "            verbose\n",
+              "            <span class=\"param-doc-description\">verbose: bool, default=False<br><br>If True, the time elapsed while fitting each step will be printed as it<br>is completed.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">False</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "                  </tbody>\n",
+              "                </table>\n",
+              "            </details>\n",
+              "        </div>\n",
+              "    </div></div></div><div class=\"sk-serial\"><div class=\"sk-item\"><div class=\"sk-estimator fitted sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-2\" type=\"checkbox\" ><label for=\"sk-estimator-id-2\" class=\"sk-toggleable__label fitted sk-toggleable__label-arrow\"><div><div>StandardScaler</div></div><div><a class=\"sk-estimator-doc-link fitted\" rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.preprocessing.StandardScaler.html\">?<span>Documentation for StandardScaler</span></a></div></label><div class=\"sk-toggleable__content fitted\" data-param-prefix=\"standardscaler__\">\n",
+              "        <div class=\"estimator-table\">\n",
+              "            <details>\n",
+              "                <summary>Parameters</summary>\n",
+              "                <table class=\"parameters-table\">\n",
+              "                  <tbody>\n",
+              "                    \n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('copy',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.preprocessing.StandardScaler.html#:~:text=copy,-bool%2C%20default%3DTrue\">\n",
+              "            copy\n",
+              "            <span class=\"param-doc-description\">copy: bool, default=True<br><br>If False, try to avoid a copy and do inplace scaling instead.<br>This is not guaranteed to always work inplace; e.g. if the data is<br>not a NumPy array or scipy.sparse CSR matrix, a copy may still be<br>returned.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">True</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('with_mean',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.preprocessing.StandardScaler.html#:~:text=with_mean,-bool%2C%20default%3DTrue\">\n",
+              "            with_mean\n",
+              "            <span class=\"param-doc-description\">with_mean: bool, default=True<br><br>If True, center the data before scaling.<br>This does not work (and will raise an exception) when attempted on<br>sparse matrices, because centering them entails building a dense<br>matrix which in common use cases is likely to be too large to fit in<br>memory.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">True</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('with_std',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.preprocessing.StandardScaler.html#:~:text=with_std,-bool%2C%20default%3DTrue\">\n",
+              "            with_std\n",
+              "            <span class=\"param-doc-description\">with_std: bool, default=True<br><br>If True, scale the data to unit variance (or equivalently,<br>unit standard deviation).</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">True</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "                  </tbody>\n",
+              "                </table>\n",
+              "            </details>\n",
+              "        </div>\n",
+              "    </div></div></div><div class=\"sk-item\"><div class=\"sk-estimator fitted sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-3\" type=\"checkbox\" ><label for=\"sk-estimator-id-3\" class=\"sk-toggleable__label fitted sk-toggleable__label-arrow\"><div><div>LassoCV</div></div><div><a class=\"sk-estimator-doc-link fitted\" rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html\">?<span>Documentation for LassoCV</span></a></div></label><div class=\"sk-toggleable__content fitted\" data-param-prefix=\"lassocv__\">\n",
+              "        <div class=\"estimator-table\">\n",
+              "            <details>\n",
+              "                <summary>Parameters</summary>\n",
+              "                <table class=\"parameters-table\">\n",
+              "                  <tbody>\n",
+              "                    \n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('eps',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=eps,-float%2C%20default%3D1e-3\">\n",
+              "            eps\n",
+              "            <span class=\"param-doc-description\">eps: float, default=1e-3<br><br>Length of the path. ``eps=1e-3`` means that<br>``alpha_min / alpha_max = 1e-3``.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">0.001</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('n_alphas',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=n_alphas,-int%2C%20default%3D100\">\n",
+              "            n_alphas\n",
+              "            <span class=\"param-doc-description\">n_alphas: int, default=100<br><br>Number of alphas along the regularization path.<br><br>.. deprecated:: 1.7<br>    `n_alphas` was deprecated in 1.7 and will be removed in 1.9. Use `alphas`<br>    instead.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">&#x27;deprecated&#x27;</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('alphas',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=alphas,-int%2C%20default%3D100\">\n",
+              "            alphas\n",
+              "            <span class=\"param-doc-description\">alphas: array-like or int, default=None<br><br>Values of alphas to test along the regularization path.<br>If int, `alphas` values are generated automatically.<br>If array-like, list of alpha values to use.<br><br>.. versionchanged:: 1.7<br>    `alphas` accepts an integer value which removes the need to pass<br>    `n_alphas`.<br><br>.. deprecated:: 1.7<br>    `alphas=None` was deprecated in 1.7 and will be removed in 1.9, at which<br>    point the default value will be set to 100.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">&#x27;warn&#x27;</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('fit_intercept',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=fit_intercept,-bool%2C%20default%3DTrue\">\n",
+              "            fit_intercept\n",
+              "            <span class=\"param-doc-description\">fit_intercept: bool, default=True<br><br>Whether to calculate the intercept for this model. If set<br>to false, no intercept will be used in calculations<br>(i.e. data is expected to be centered).</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">True</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('precompute',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=precompute,-%27auto%27%2C%20bool%20or%20array-like%20of%20shape%20%20%20%20%20%20%20%20%20%20%20%20%20%28n_features%2C%20n_features%29%2C%20default%3D%27auto%27\">\n",
+              "            precompute\n",
+              "            <span class=\"param-doc-description\">precompute: 'auto', bool or array-like of shape             (n_features, n_features), default='auto'<br><br>Whether to use a precomputed Gram matrix to speed up<br>calculations. If set to ``'auto'`` let us decide. The Gram<br>matrix can also be passed as argument.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">&#x27;auto&#x27;</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('max_iter',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=max_iter,-int%2C%20default%3D1000\">\n",
+              "            max_iter\n",
+              "            <span class=\"param-doc-description\">max_iter: int, default=1000<br><br>The maximum number of iterations.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">1000</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('tol',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=tol,-float%2C%20default%3D1e-4\">\n",
+              "            tol\n",
+              "            <span class=\"param-doc-description\">tol: float, default=1e-4<br><br>The tolerance for the optimization: if the updates are smaller or equal to<br>``tol``, the optimization code checks the dual gap for optimality and continues<br>until it is smaller or equal to ``tol``.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">0.0001</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('copy_X',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=copy_X,-bool%2C%20default%3DTrue\">\n",
+              "            copy_X\n",
+              "            <span class=\"param-doc-description\">copy_X: bool, default=True<br><br>If ``True``, X will be copied; else, it may be overwritten.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">True</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"user-set\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('cv',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=cv,-int%2C%20cross-validation%20generator%20or%20iterable%2C%20default%3DNone\">\n",
+              "            cv\n",
+              "            <span class=\"param-doc-description\">cv: int, cross-validation generator or iterable, default=None<br><br>Determines the cross-validation splitting strategy.<br>Possible inputs for cv are:<br><br>- None, to use the default 5-fold cross-validation,<br>- int, to specify the number of folds.<br>- :term:`CV splitter`,<br>- An iterable yielding (train, test) splits as arrays of indices.<br><br>For int/None inputs, :class:`~sklearn.model_selection.KFold` is used.<br><br>Refer :ref:`User Guide <cross_validation>` for the various<br>cross-validation strategies that can be used here.<br><br>.. versionchanged:: 0.22<br>    ``cv`` default value if None changed from 3-fold to 5-fold.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">KFold(n_split... shuffle=True)</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('verbose',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=verbose,-bool%20or%20int%2C%20default%3DFalse\">\n",
+              "            verbose\n",
+              "            <span class=\"param-doc-description\">verbose: bool or int, default=False<br><br>Amount of verbosity.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">False</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('n_jobs',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=n_jobs,-int%2C%20default%3DNone\">\n",
+              "            n_jobs\n",
+              "            <span class=\"param-doc-description\">n_jobs: int, default=None<br><br>Number of CPUs to use during the cross validation.<br>``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.<br>``-1`` means using all processors. See :term:`Glossary <n_jobs>`<br>for more details.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">None</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('positive',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=positive,-bool%2C%20default%3DFalse\">\n",
+              "            positive\n",
+              "            <span class=\"param-doc-description\">positive: bool, default=False<br><br>If positive, restrict regression coefficients to be positive.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">False</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"user-set\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('random_state',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=random_state,-int%2C%20RandomState%20instance%2C%20default%3DNone\">\n",
+              "            random_state\n",
+              "            <span class=\"param-doc-description\">random_state: int, RandomState instance, default=None<br><br>The seed of the pseudo random number generator that selects a random<br>feature to update. Used when ``selection`` == 'random'.<br>Pass an int for reproducible output across multiple function calls.<br>See :term:`Glossary <random_state>`.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">123</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "\n",
+              "        <tr class=\"default\">\n",
+              "            <td><i class=\"copy-paste-icon\"\n",
+              "                 onclick=\"copyToClipboard('selection',\n",
+              "                          this.parentElement.nextElementSibling)\"\n",
+              "            ></i></td>\n",
+              "            <td class=\"param\">\n",
+              "        <a class=\"param-doc-link\"\n",
+              "            rel=\"noreferrer\" target=\"_blank\" href=\"https://scikit-learn.org/1.8/modules/generated/sklearn.linear_model.LassoCV.html#:~:text=selection,-%7B%27cyclic%27%2C%20%27random%27%7D%2C%20default%3D%27cyclic%27\">\n",
+              "            selection\n",
+              "            <span class=\"param-doc-description\">selection: {'cyclic', 'random'}, default='cyclic'<br><br>If set to 'random', a random coefficient is updated every iteration<br>rather than looping over features sequentially by default. This<br>(setting to 'random') often leads to significantly faster convergence<br>especially when tol is higher than 1e-4.</span>\n",
+              "        </a>\n",
+              "    </td>\n",
+              "            <td class=\"value\">&#x27;cyclic&#x27;</td>\n",
+              "        </tr>\n",
+              "    \n",
+              "                  </tbody>\n",
+              "                </table>\n",
+              "            </details>\n",
+              "        </div>\n",
+              "    </div></div></div></div></div></div></div><script>function copyToClipboard(text, element) {\n",
+              "    // Get the parameter prefix from the closest toggleable content\n",
+              "    const toggleableContent = element.closest('.sk-toggleable__content');\n",
+              "    const paramPrefix = toggleableContent ? toggleableContent.dataset.paramPrefix : '';\n",
+              "    const fullParamName = paramPrefix ? `${paramPrefix}${text}` : text;\n",
+              "\n",
+              "    const originalStyle = element.style;\n",
+              "    const computedStyle = window.getComputedStyle(element);\n",
+              "    const originalWidth = computedStyle.width;\n",
+              "    const originalHTML = element.innerHTML.replace('Copied!', '');\n",
+              "\n",
+              "    navigator.clipboard.writeText(fullParamName)\n",
+              "        .then(() => {\n",
+              "            element.style.width = originalWidth;\n",
+              "            element.style.color = 'green';\n",
+              "            element.innerHTML = \"Copied!\";\n",
+              "\n",
+              "            setTimeout(() => {\n",
+              "                element.innerHTML = originalHTML;\n",
+              "                element.style = originalStyle;\n",
+              "            }, 2000);\n",
+              "        })\n",
+              "        .catch(err => {\n",
+              "            console.error('Failed to copy:', err);\n",
+              "            element.style.color = 'red';\n",
+              "            element.innerHTML = \"Failed!\";\n",
+              "            setTimeout(() => {\n",
+              "                element.innerHTML = originalHTML;\n",
+              "                element.style = originalStyle;\n",
+              "            }, 2000);\n",
+              "        });\n",
+              "    return false;\n",
+              "}\n",
+              "\n",
+              "document.querySelectorAll('.copy-paste-icon').forEach(function(element) {\n",
+              "    const toggleableContent = element.closest('.sk-toggleable__content');\n",
+              "    const paramPrefix = toggleableContent ? toggleableContent.dataset.paramPrefix : '';\n",
+              "    const paramName = element.parentElement.nextElementSibling\n",
+              "        .textContent.trim().split(' ')[0];\n",
+              "    const fullParamName = paramPrefix ? `${paramPrefix}${paramName}` : paramName;\n",
+              "\n",
+              "    element.setAttribute('title', fullParamName);\n",
+              "});\n",
+              "\n",
+              "\n",
+              "/**\n",
+              " * Adapted from Skrub\n",
+              " * https://github.com/skrub-data/skrub/blob/403466d1d5d4dc76a7ef569b3f8228db59a31dc3/skrub/_reporting/_data/templates/report.js#L789\n",
+              " * @returns \"light\" or \"dark\"\n",
+              " */\n",
+              "function detectTheme(element) {\n",
+              "    const body = document.querySelector('body');\n",
+              "\n",
+              "    // Check VSCode theme\n",
+              "    const themeKindAttr = body.getAttribute('data-vscode-theme-kind');\n",
+              "    const themeNameAttr = body.getAttribute('data-vscode-theme-name');\n",
+              "\n",
+              "    if (themeKindAttr && themeNameAttr) {\n",
+              "        const themeKind = themeKindAttr.toLowerCase();\n",
+              "        const themeName = themeNameAttr.toLowerCase();\n",
+              "\n",
+              "        if (themeKind.includes(\"dark\") || themeName.includes(\"dark\")) {\n",
+              "            return \"dark\";\n",
+              "        }\n",
+              "        if (themeKind.includes(\"light\") || themeName.includes(\"light\")) {\n",
+              "            return \"light\";\n",
+              "        }\n",
+              "    }\n",
+              "\n",
+              "    // Check Jupyter theme\n",
+              "    if (body.getAttribute('data-jp-theme-light') === 'false') {\n",
+              "        return 'dark';\n",
+              "    } else if (body.getAttribute('data-jp-theme-light') === 'true') {\n",
+              "        return 'light';\n",
+              "    }\n",
+              "\n",
+              "    // Guess based on a parent element's color\n",
+              "    const color = window.getComputedStyle(element.parentNode, null).getPropertyValue('color');\n",
+              "    const match = color.match(/^rgb\\s*\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)\\s*$/i);\n",
+              "    if (match) {\n",
+              "        const [r, g, b] = [\n",
+              "            parseFloat(match[1]),\n",
+              "            parseFloat(match[2]),\n",
+              "            parseFloat(match[3])\n",
+              "        ];\n",
+              "\n",
+              "        // https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness\n",
+              "        const luma = 0.299 * r + 0.587 * g + 0.114 * b;\n",
+              "\n",
+              "        if (luma > 180) {\n",
+              "            // If the text is very bright we have a dark theme\n",
+              "            return 'dark';\n",
+              "        }\n",
+              "        if (luma < 75) {\n",
+              "            // If the text is very dark we have a light theme\n",
+              "            return 'light';\n",
+              "        }\n",
+              "        // Otherwise fall back to the next heuristic.\n",
+              "    }\n",
+              "\n",
+              "    // Fallback to system preference\n",
+              "    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';\n",
+              "}\n",
+              "\n",
+              "\n",
+              "function forceTheme(elementId) {\n",
+              "    const estimatorElement = document.querySelector(`#${elementId}`);\n",
+              "    if (estimatorElement === null) {\n",
+              "        console.error(`Element with id ${elementId} not found.`);\n",
+              "    } else {\n",
+              "        const theme = detectTheme(estimatorElement);\n",
+              "        estimatorElement.classList.add(theme);\n",
+              "    }\n",
+              "}\n",
+              "\n",
+              "forceTheme('sk-container-id-1');</script></body>"
+            ],
+            "text/plain": [
+              "Pipeline(steps=[('standardscaler', StandardScaler()),\n",
+              "                ('lassocv',\n",
+              "                 LassoCV(cv=KFold(n_splits=5, random_state=123, shuffle=True),\n",
+              "                         random_state=123))])"
+            ]
+          },
+          "execution_count": 20,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "lcv = make_pipeline(StandardScaler(), LassoCV(cv=KFold(n_splits=5, shuffle=True, random_state=123), random_state=123))\n",
+        "lcv.fit(embeddings, ln_p)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {
+        "id": "hLEZ1JL2weU9"
+      },
+      "outputs": [],
+      "source": [
+        "embeddings_val = get_embeddings(bert, val_enc)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "4Aez3Il1wp4x",
+        "outputId": "8c85dc7f-de8b-447b-b3dc-9d837ca8d12b"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "RSS: 183.89578247070312, TSS + MEAN^2: 6959.14697265625, TSS: 263.9436340332031, R^2: 0.30327630043029785\n"
+          ]
+        }
+      ],
+      "source": [
+        "get_r2(val_ln_p, lcv.predict(embeddings_val))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "metadata": {
+        "id": "u1aRxiWsBO-V"
+      },
+      "outputs": [],
+      "source": [
+        "embeddings_holdout = get_embeddings(bert, holdout_enc)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "899QoDe0BVId",
+        "outputId": "92bfaee0-b75f-445e-96b3-278a95bb35a1"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "RSS: 962.0865381353693, TSS + MEAN^2: 35339.645940839924, TSS: 1430.211075358892, R^2: 0.32731150337795645\n"
+          ]
+        }
+      ],
+      "source": [
+        "get_r2(holdout['ln_p'], lcv.predict(embeddings_holdout))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {
+        "id": "RwzWK34wBY9I"
+      },
+      "outputs": [],
+      "source": [
+        "ln_p_hat_holdout = lcv.predict(embeddings_holdout)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mOc1_C5p7ta7"
+      },
+      "source": [
+        "# Linear Probing: Training Only Final Layer after BERT"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Ck1xqRIrmx8I",
+        "outputId": "62b00105-3f0f-4a2f-9015-e8afb7ce91bf"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Training infrastructure ready.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- Shared training infrastructure ---\n",
+        "\n",
+        "class BertRegressor(nn.Module):\n",
+        "    \"\"\"BERT + linear head for regression.\"\"\"\n",
+        "    def __init__(self, bert_model, l2=1e-3):\n",
+        "        super().__init__()\n",
+        "        self.bert = bert_model\n",
+        "        self.head = nn.Linear(bert_model.config.hidden_size, 1)\n",
+        "        self.l2 = l2\n",
+        "\n",
+        "    def forward(self, input_ids, attention_mask, token_type_ids):\n",
+        "        out = self.bert(input_ids=input_ids,\n",
+        "                        attention_mask=attention_mask,\n",
+        "                        token_type_ids=token_type_ids)\n",
+        "        return self.head(out.pooler_output).squeeze(-1)\n",
+        "\n",
+        "    def l2_penalty(self):\n",
+        "        return self.l2 * self.head.weight.pow(2).sum()\n",
+        "\n",
+        "\n",
+        "def make_loader(encodings, targets, batch_size=64, shuffle=True):\n",
+        "    ds = TensorDataset(encodings['input_ids'],\n",
+        "                       encodings['attention_mask'],\n",
+        "                       encodings['token_type_ids'],\n",
+        "                       torch.tensor(targets, dtype=torch.float32))\n",
+        "    return DataLoader(ds, batch_size=batch_size, shuffle=shuffle)\n",
+        "\n",
+        "\n",
+        "def train_model(model, train_loader, val_loader, optimizer, epochs,\n",
+        "                patience=5, save_path=None):\n",
+        "    \"\"\"Train with early stopping. Returns training history.\"\"\"\n",
+        "    best_val_loss = float('inf')\n",
+        "    patience_counter = 0\n",
+        "    history = {'train_loss': [], 'val_loss': []}\n",
+        "\n",
+        "    for epoch in range(epochs):\n",
+        "        # Train\n",
+        "        model.train()\n",
+        "        train_losses = []\n",
+        "        for ids, mask, tids, y in train_loader:\n",
+        "            ids, mask, tids, y = ids.to(device), mask.to(device), tids.to(device), y.to(device)\n",
+        "            optimizer.zero_grad()\n",
+        "            pred = model(ids, mask, tids)\n",
+        "            loss = nn.functional.mse_loss(pred, y) + model.l2_penalty()\n",
+        "            loss.backward()\n",
+        "            optimizer.step()\n",
+        "            train_losses.append(loss.item())\n",
+        "\n",
+        "        # Validate\n",
+        "        model.eval()\n",
+        "        val_losses = []\n",
+        "        with torch.no_grad():\n",
+        "            for ids, mask, tids, y in val_loader:\n",
+        "                ids, mask, tids, y = ids.to(device), mask.to(device), tids.to(device), y.to(device)\n",
+        "                pred = model(ids, mask, tids)\n",
+        "                val_losses.append(nn.functional.mse_loss(pred, y).item())\n",
+        "\n",
+        "        t_loss = np.mean(train_losses)\n",
+        "        v_loss = np.mean(val_losses)\n",
+        "        history['train_loss'].append(t_loss)\n",
+        "        history['val_loss'].append(v_loss)\n",
+        "        print(f\"  Epoch {epoch+1}/{epochs} — train_loss: {t_loss:.4f}, val_loss: {v_loss:.4f}\")\n",
+        "\n",
+        "        if v_loss < best_val_loss:\n",
+        "            best_val_loss = v_loss\n",
+        "            patience_counter = 0\n",
+        "            if save_path:\n",
+        "                torch.save(model.state_dict(), save_path)\n",
+        "        else:\n",
+        "            patience_counter += 1\n",
+        "            if patience_counter >= patience:\n",
+        "                print(f\"  Early stopping at epoch {epoch+1}\")\n",
+        "                break\n",
+        "\n",
+        "    # Restore best weights\n",
+        "    if save_path and os.path.exists(save_path):\n",
+        "        model.load_state_dict(torch.load(save_path, weights_only=True))\n",
+        "    return history\n",
+        "\n",
+        "\n",
+        "@torch.no_grad()\n",
+        "def predict(model, encodings, batch_size=128):\n",
+        "    model.eval()\n",
+        "    preds = []\n",
+        "    n = encodings['input_ids'].shape[0]\n",
+        "    for i in range(0, n, batch_size):\n",
+        "        ids = encodings['input_ids'][i:i+batch_size].to(device)\n",
+        "        mask = encodings['attention_mask'][i:i+batch_size].to(device)\n",
+        "        tids = encodings['token_type_ids'][i:i+batch_size].to(device)\n",
+        "        preds.append(model(ids, mask, tids).cpu().numpy())\n",
+        "    return np.concatenate(preds)\n",
+        "\n",
+        "\n",
+        "print(\"Training infrastructure ready.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "XhTREb3NcZhH",
+        "outputId": "4ff41515-c441-417b-959e-ec4c1578f500"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Linear probing — price prediction:\n",
+            "  Epoch 1/5 — train_loss: 1.3978, val_loss: 0.6227\n",
+            "  Epoch 2/5 — train_loss: 0.4630, val_loss: 0.4552\n",
+            "  Epoch 3/5 — train_loss: 0.4167, val_loss: 0.3789\n",
+            "  Epoch 4/5 — train_loss: 0.4160, val_loss: 0.3590\n",
+            "  Epoch 5/5 — train_loss: 0.4157, val_loss: 0.3625\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Linear probing: freeze BERT, train only the head\n",
+        "torch.manual_seed(123)\n",
+        "\n",
+        "price_model = BertRegressor(bert).to(device)\n",
+        "for p in price_model.bert.parameters():\n",
+        "    p.requires_grad = False\n",
+        "\n",
+        "optimizer = torch.optim.Adam(price_model.head.parameters(), lr=1e-3)\n",
+        "train_loader = make_loader(train_enc, ln_p)\n",
+        "val_loader = make_loader(val_enc, val_ln_p, shuffle=False)\n",
+        "\n",
+        "print(\"Linear probing — price prediction:\")\n",
+        "p_hist1 = train_model(price_model, train_loader, val_loader, optimizer,\n",
+        "                       epochs=5, save_path=os.path.join(weights_folder, \"pweights.pt\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MyFxR5GC8C3K"
+      },
+      "source": [
+        "# Fine Tuning starting from the Linear Probing Trained Weights\n",
+        "\n",
+        "Now we train the whole network, initializing the weights based on the result of the linear probing phase in the previous section."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "NzWCkTY87luH",
+        "outputId": "5bd47038-6013-452e-d79c-d98d313d52a0"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Fine-tuning — price prediction:\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Fine-tuning: unfreeze BERT and train end-to-end with lower LR\n",
+        "for p in price_model.bert.parameters():\n",
+        "    p.requires_grad = True\n",
+        "\n",
+        "optimizer = torch.optim.Adam(price_model.parameters(), lr=1e-5)\n",
+        "print(\"Fine-tuning — price prediction:\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "PWauCl0T7nUo",
+        "outputId": "72c1f0b6-ef07-4659-8e6e-36e3fd516b73"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "<All keys matched successfully>"
+            ]
+          },
+          "execution_count": 29,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Load best linear probing weights as starting point\n",
+        "price_model.load_state_dict(torch.load(os.path.join(weights_folder, \"pweights.pt\"), weights_only=True))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 495
+        },
+        "id": "iDSBZWAe8nhE",
+        "outputId": "9534e36a-71e6-4188-8616-9ceb5cd93c75"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "  Epoch 1/5 — train_loss: 0.3451, val_loss: 0.2480\n",
+            "  Epoch 2/5 — train_loss: 0.2467, val_loss: 0.2092\n",
+            "  Epoch 3/5 — train_loss: 0.2026, val_loss: 0.1903\n",
+            "  Epoch 4/5 — train_loss: 0.1645, val_loss: 0.1800\n",
+            "  Epoch 5/5 — train_loss: 0.1382, val_loss: 0.1809\n"
+          ]
+        }
+      ],
+      "source": [
+        "torch.manual_seed(123)\n",
+        "p_hist2 = train_model(price_model, train_loader, val_loader, optimizer,\n",
+        "                       epochs=5, save_path=os.path.join(weights_folder, \"pweights.pt\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 31,
+      "metadata": {
+        "id": "wchpbXoqBAJu"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "<All keys matched successfully>"
+            ]
+          },
+          "execution_count": 31,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "price_model.load_state_dict(torch.load(os.path.join(weights_folder, \"pweights.pt\"), weights_only=True))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 32,
+      "metadata": {
+        "id": "jpUmDHYfkJEZ"
+      },
+      "outputs": [],
+      "source": [
+        "# Compute predictions on holdout\n",
+        "ln_p_hat_holdout = predict(price_model, holdout_enc)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 33,
+      "metadata": {
+        "id": "g_XK81hpkQMN"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Neural Net R^2, Price Prediction:\n",
+            "RSS: 698.5716678630592, TSS + MEAN^2: 35339.645940839924, TSS: 1430.211075358892, R^2: 0.5115604403442602\n"
+          ]
+        }
+      ],
+      "source": [
+        "print('Neural Net R^2, Price Prediction:')\n",
+        "get_r2(holdout['ln_p'].values, ln_p_hat_holdout)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 34,
+      "metadata": {
+        "id": "GR4QP4DJPQk0"
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjAAAAGdCAYAAAAMm0nCAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAHVBJREFUeJzt3QuwVlX9P+DvOYCgKAfQABlvTDkJiZfEFLUrJCY1MVFmkWEx2JiYeA3KKNSCyLylQTfFGXUsm9EK88LAJKWoiFpIilYqmAE1CggOCPL+Z63fvOfPIbyd3uNhnfd5Zvbss/de7373WWx4P6y91nobKpVKJQAACtLY3hcAAPBWCTAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxekcHdTWrVvj+eefjz322CMaGhra+3IAgDchza/70ksvRf/+/aOxsbH+AkwKL/vuu297XwYA0AorVqyIffbZp/4CTGp5qVZAjx492vtyAIA3Yd26dbkBovo5XncBpvrYKIUXAQYAyvJG3T904gUAiiPAAADFEWAAgOIIMABAcQQYAKA4AgwAUBwBBgAojgADABRHgAEAiiPAAADFEWAAgOIIMABAcQQYAKA4AgwAUJzO7X0B0NEcMOn2KM0z00e29yUAvCVaYACA4ggwAEBxBBgAoDgCDABQHAEGACiOAAMAFEeAAQCKI8AAAMURYACA4ggwAEBxBBgAoDgCDABQHAEGACiOAAMAFEeAAQCKI8AAAB0/wCxYsCA+8YlPRP/+/aOhoSFuu+22FscrlUpMmTIl9t5779h1111j+PDh8dRTT7Uo88ILL8SYMWOiR48e0bNnzxg3blysX7++RZm//OUv8f73vz+6desW++67b8yYMaO1vyMAUO8BZsOGDXHooYfGNddcs8PjKWhcddVVMWvWrHjggQeie/fuMWLEiNi4cWNzmRReli5dGnPnzo05c+bkUHTaaac1H1+3bl0cf/zxsf/++8fixYvjBz/4QXznO9+Jn/70p639PQGADqShkppMWvvihoa49dZbY9SoUXk7nSq1zJx77rlx3nnn5X1r166Nvn37xuzZs+Pkk0+Oxx9/PAYNGhSLFi2KIUOG5DJ33nlnnHjiifHcc8/l18+cOTO++c1vxsqVK2OXXXbJZSZNmpRbe5544ok3dW0pBDU1NeX3Ty098HY5YNLtxVX2M9NHtvclALylz++a9oF5+umnc+hIj42q0kUcddRRsXDhwryd1umxUTW8JKl8Y2NjbrGplvnABz7QHF6S1IqzbNmyePHFF3f43ps2bcq/9LYLANAx1TTApPCSpBaXbaXt6rG07tOnT4vjnTt3jt69e7cos6NzbPse25s2bVoOS9Ul9ZsBADqmDjMKafLkybm5qbqsWLGivS8JACghwPTr1y+vV61a1WJ/2q4eS+vVq1e3OL5ly5Y8MmnbMjs6x7bvsb2uXbvmZ2XbLgBAx1TTADNgwIAcMObNm9e8L/VFSX1bhg4dmrfTes2aNXl0UdX8+fNj69atua9MtUwambR58+bmMmnE0rvf/e7o1atXLS8ZAKiHAJPma3n00UfzUu24m35evnx5HpU0ceLEuOSSS+K3v/1tLFmyJL74xS/mkUXVkUoDBw6ME044IcaPHx8PPvhg3HvvvTFhwoQ8QimVSz7/+c/nDrxpfpg03PqXv/xlXHnllXHOOefU+vcHAArU+a2+4KGHHooPf/jDzdvVUDF27Ng8VPqCCy7Ic8WkeV1SS8txxx2Xh0mnCemqbrzxxhxahg0blkcfjR49Os8dU5U64d59991xxhlnxBFHHBF77bVXnhxv27liAID69T/NA7MzMw8M7cU8MACFzQMDAPB2EGAAgOIIMABAcQQYAKA4AgwAUBwBBgAojgADABRHgAEAiiPAAADFEWAAgOIIMABAcQQYAKA4AgwAUBwBBgAojgADABRHgAEAiiPAAADFEWAAgOIIMABAcQQYAKA4AgwAUBwBBgAojgADABRHgAEAiiPAAADFEWAAgOIIMABAcQQYAKA4AgwAUBwBBgAojgADABRHgAEAiiPAAADFEWAAgOIIMABAcQQYAKA4AgwAUBwBBgAojgADABRHgAEAiiPAAADFEWAAgOIIMABAcQQYAKA4AgwAUBwBBgAojgADABRHgAEAiiPAAADFEWAAgOIIMABAcTq39wXA6zlg0u0qCID/ogUGACiOAAMAFEeAAQCKU/MA8+qrr8a3vvWtGDBgQOy6667xzne+My6++OKoVCrNZdLPU6ZMib333juXGT58eDz11FMtzvPCCy/EmDFjokePHtGzZ88YN25crF+/vtaXCwAUqOYB5vvf/37MnDkzrr766nj88cfz9owZM+JHP/pRc5m0fdVVV8WsWbPigQceiO7du8eIESNi48aNzWVSeFm6dGnMnTs35syZEwsWLIjTTjut1pcLABSoobJt00gNfPzjH4++ffvGL37xi+Z9o0ePzi0tN9xwQ2596d+/f5x77rlx3nnn5eNr167Nr5k9e3acfPLJOfgMGjQoFi1aFEOGDMll7rzzzjjxxBPjueeey69/I+vWrYumpqZ87tSKQ5mMQnp7PDN95Nv0TgC1+fyueQvMMcccE/PmzYsnn3wyb//5z3+OP/3pT/Gxj30sbz/99NOxcuXK/NioKl3oUUcdFQsXLszbaZ0eG1XDS5LKNzY25habHdm0aVP+pbddAICOqebzwEyaNCmHh4MOOig6deqU+8R897vfzY+EkhRektTisq20XT2W1n369Gl5oZ07R+/evZvLbG/atGkxderUWv86AMBOqOYtML/61a/ixhtvjJtuuikefvjhuP766+PSSy/N67Y0efLk3NxUXVasWNGm7wcAdKAWmPPPPz+3wqS+LMngwYPj2WefzS0kY8eOjX79+uX9q1atyqOQqtL2YYcdln9OZVavXt3ivFu2bMkjk6qv317Xrl3zAgB0fDVvgXn55ZdzX5VtpUdJW7duzT+n4dUphKR+MlXpkVPq2zJ06NC8ndZr1qyJxYsXN5eZP39+PkfqKwMA1Leat8B84hOfyH1e9ttvv3jPe94TjzzySFx22WXx5S9/OR9vaGiIiRMnxiWXXBIHHnhgDjRp3pg0smjUqFG5zMCBA+OEE06I8ePH56HWmzdvjgkTJuRWnTczAgkA6NhqHmDSfC8pkHz1q1/Nj4FS4PjKV76SJ66ruuCCC2LDhg15XpfU0nLcccflYdLdunVrLpP60aTQMmzYsNyik4Zip7ljAABqPg/MzsI8MB2DeWDeHuaBAUr7/K55CwxQnhKDotAF9c2XOQIAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKE6bBJh//vOf8YUvfCH23HPP2HXXXWPw4MHx0EMPNR+vVCoxZcqU2HvvvfPx4cOHx1NPPdXiHC+88EKMGTMmevToET179oxx48bF+vXr2+JyAYB6DzAvvvhiHHvssdGlS5e444474q9//Wv88Ic/jF69ejWXmTFjRlx11VUxa9aseOCBB6J79+4xYsSI2LhxY3OZFF6WLl0ac+fOjTlz5sSCBQvitNNOq/XlAgAFaqik5pAamjRpUtx7773xxz/+cYfH09v1798/zj333DjvvPPyvrVr10bfvn1j9uzZcfLJJ8fjjz8egwYNikWLFsWQIUNymTvvvDNOPPHEeO655/Lr38i6deuiqakpnzu14lCmAybd3t6XwE7qmekj2/sSgDbwZj+/a94C89vf/jaHjs985jPRp0+fOPzww+NnP/tZ8/Gnn346Vq5cmR8bVaULPeqoo2LhwoV5O63TY6NqeElS+cbGxtxiAwDUt5oHmH/84x8xc+bMOPDAA+Ouu+6K008/Pb72ta/F9ddfn4+n8JKkFpdtpe3qsbRO4WdbnTt3jt69ezeX2d6mTZtyatt2AQA6ps61PuHWrVtzy8n3vve9vJ1aYB577LHc32Xs2LHRVqZNmxZTp05ts/MDAB24BSaNLEr9V7Y1cODAWL58ef65X79+eb1q1aoWZdJ29Vhar169usXxLVu25JFJ1TLbmzx5cn5eVl1WrFhR098LAOjAASaNQFq2bFmLfU8++WTsv//++ecBAwbkEDJv3rzm4+lxT+rbMnTo0Lyd1mvWrInFixc3l5k/f35u3Ul9ZXaka9euubPPtgsA0DHV/BHS2WefHcccc0x+hHTSSSfFgw8+GD/96U/zkjQ0NMTEiRPjkksuyf1kUqD51re+lUcWjRo1qrnF5oQTTojx48fnR0+bN2+OCRMm5BFKb2YEEgDQsdU8wBx55JFx66235kc6F110UQ4oV1xxRZ7XpeqCCy6IDRs25HldUkvLcccdl4dJd+vWrbnMjTfemEPLsGHD8uij0aNH57ljAABqPg/MzsI8MB2DeWB4LeaBgY6p3eaBAQBoawIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIDiCDAAQHHaPMBMnz49GhoaYuLEic37Nm7cGGeccUbsueeesfvuu8fo0aNj1apVLV63fPnyGDlyZOy2227Rp0+fOP/882PLli1tfbkAQL0HmEWLFsVPfvKTOOSQQ1rsP/vss+N3v/td3HLLLXHPPffE888/H5/61Keaj7/66qs5vLzyyitx3333xfXXXx+zZ8+OKVOmtOXlAgD1HmDWr18fY8aMiZ/97GfRq1ev5v1r166NX/ziF3HZZZfFRz7ykTjiiCPiuuuuy0Hl/vvvz2Xuvvvu+Otf/xo33HBDHHbYYfGxj30sLr744rjmmmtyqAEA6lubBZj0iCi1ogwfPrzF/sWLF8fmzZtb7D/ooINiv/32i4ULF+bttB48eHD07du3ucyIESNi3bp1sXTp0h2+36ZNm/LxbRcAoGPq3BYnvfnmm+Phhx/Oj5C2t3Llythll12iZ8+eLfansJKOVctsG16qx6vHdmTatGkxderUGv4WAEDdtMCsWLEizjrrrLjxxhujW7du8XaZPHlyfjxVXdJ1AAAdU81bYNIjotWrV8d73/veFp1yFyxYEFdffXXcdddduR/LmjVrWrTCpFFI/fr1yz+n9YMPPtjivNVRStUy2+vatWtegPpwwKTbozTPTB/Z3pcAHUbNW2CGDRsWS5YsiUcffbR5GTJkSO7QW/25S5cuMW/evObXLFu2LA+bHjp0aN5O63SOFISq5s6dGz169IhBgwbV+pIBgHpvgdljjz3i4IMPbrGve/fuec6X6v5x48bFOeecE717986h5Mwzz8yh5eijj87Hjz/++BxUTjnllJgxY0bu93LhhRfmjsFaWQCANunE+0Yuv/zyaGxszBPYpdFDaYTRj3/84+bjnTp1ijlz5sTpp5+eg00KQGPHjo2LLrrInxgAEA2VSqXSEeshDaNuamrKHXpTKw9lKrGfA7wWfWCgdp/fvgsJACiOAAMAFEeAAQCKI8AAAMURYACA4ggwAEBxBBgAoDgCDABQHAEGACiOAAMAFEeAAQCKI8AAAMURYACA4ggwAEBxBBgAoDgCDABQHAEGACiOAAMAFEeAAQCKI8AAAMURYACA4ggwAEBxBBgAoDgCDABQHAEGACiOAAMAFEeAAQCKI8AAAMURYACA4ggwAEBxBBgAoDgCDABQHAEGACiOAAMAFEeAAQCKI8AAAMURYACA4nRu7wvg7XHApNtVNQAdhhYYAKA4AgwAUBwBBgAojgADABRHgAEAiiPAAADFEWAAgOIIMABAcQQYAKA4AgwAUBwBBgAojgADABRHgAEAiiPAAADFEWAAgOIIMABAcQQYAKA4NQ8w06ZNiyOPPDL22GOP6NOnT4waNSqWLVvWoszGjRvjjDPOiD333DN23333GD16dKxatapFmeXLl8fIkSNjt912y+c5//zzY8uWLbW+XACgQDUPMPfcc08OJ/fff3/MnTs3Nm/eHMcff3xs2LChuczZZ58dv/vd7+KWW27J5Z9//vn41Kc+1Xz81VdfzeHllVdeifvuuy+uv/76mD17dkyZMqXWlwsAFKihUqlU2vIN/v3vf+cWlBRUPvCBD8TatWvjHe94R9x0003x6U9/Opd54oknYuDAgbFw4cI4+uij44477oiPf/zjOdj07ds3l5k1a1Z8/etfz+fbZZdd3vB9161bF01NTfn9evToEfXugEm3t/clQN17ZvrIuq8DqNXnd5v3gUkXkPTu3TuvFy9enFtlhg8f3lzmoIMOiv322y8HmCStBw8e3BxekhEjRuRfaunSpTt8n02bNuXj2y4AQMfUpgFm69atMXHixDj22GPj4IMPzvtWrlyZW1B69uzZomwKK+lYtcy24aV6vHrstfrepMRWXfbdd982+q0AgA4dYFJfmMceeyxuvvnmaGuTJ0/OrT3VZcWKFW3+ngBA++jcVieeMGFCzJkzJxYsWBD77LNP8/5+/frlzrlr1qxp0QqTRiGlY9UyDz74YIvzVUcpVctsr2vXrnkBADq+mrfApD7BKbzceuutMX/+/BgwYECL40cccUR06dIl5s2b17wvDbNOw6aHDh2at9N6yZIlsXr16uYyaURT6swzaNCgWl8yAFDvLTDpsVEaYfSb3/wmzwVT7bOS+qXsuuuueT1u3Lg455xzcsfeFErOPPPMHFrSCKQkDbtOQeWUU06JGTNm5HNceOGF+dxaWQCAmgeYmTNn5vWHPvShFvuvu+66OPXUU/PPl19+eTQ2NuYJ7NLooTTC6Mc//nFz2U6dOuXHT6effnoONt27d4+xY8fGRRdd5E8MAGj7eWDai3lgWjIPDLQ/88BAQfPAAADUmgADABRHgAEAiiPAAADFEWAAgOK02Uy8AJQ/GtDIKXZWWmAAgOIIMABAcQQYAKA4AgwAUBwBBgAojgADABRHgAEAiiPAAADFEWAAgOIIMABAcQQYAKA4AgwAUBxf5lgnX8gGAB2JFhgAoDgCDABQHAEGACiOAAMAFEeAAQCKI8AAAMURYACA4ggwAEBxBBgAoDgCDABQHAEGACiOAAMAFEeAAQCKI8AAAMURYACA4ggwAEBxOrf3BQCw8zpg0u1Rmmemj2zvS+BtoAUGACiOAAMAFEeAAQCKI8AAAMURYACA4ggwAEBxBBgAoDgCDABQHAEGACiOAAMAFEeAAQCKI8AAAMURYACA4ggwAEBxBBgAoDgCDABQHAEGACiOAAMAFEeAAQCK0zl2Ytdcc0384Ac/iJUrV8ahhx4aP/rRj+J973tfe18WADuxAybdHqV5ZvrI9r6E4uy0LTC//OUv45xzzolvf/vb8fDDD+cAM2LEiFi9enV7XxoA0M522gBz2WWXxfjx4+NLX/pSDBo0KGbNmhW77bZbXHvtte19aQBAO9spHyG98sorsXjx4pg8eXLzvsbGxhg+fHgsXLhwh6/ZtGlTXqrWrl2b1+vWrav59W3d9HLNzwlA/drv7FuiNI9NHdEm561+blcqlfICzH/+85949dVXo2/fvi32p+0nnnhih6+ZNm1aTJ069b/277vvvm12nQBQr5quaNvzv/TSS9HU1FRWgGmN1FqT+sxUbd26NV544YXYc889o6GhIXYGKVWmQLVixYro0aNHe19OMdSbOnOv7bz8/VRvtZZaXlJ46d+//+uW2ykDzF577RWdOnWKVatWtdiftvv167fD13Tt2jUv2+rZs2fsjFJ4EWDUm3tt5+XvqDpzr7Wv12t52ak78e6yyy5xxBFHxLx581q0qKTtoUOHtuu1AQDtb6dsgUnS46CxY8fGkCFD8twvV1xxRWzYsCGPSgIA6ttOG2A++9nPxr///e+YMmVKnsjusMMOizvvvPO/OvaWJD3iSvPabP+oC/XmXts5+Duqztxr5WiovNE4JQCAncxO2QcGAOD1CDAAQHEEGACgOAIMAFAcAaZG0lcZHHnkkbHHHntEnz59YtSoUbFs2bI3fN0tt9wSBx10UHTr1i0GDx4cv//976OetKbeZs+enWdX3nZJ9VcvZs6cGYccckjzZGtpbqQ77rjjdV9T7/dZa+qt3u+zHZk+fXquh4kTJ75uOffbW6sz91rrCDA1cs8998QZZ5wR999/f8ydOzc2b94cxx9/fJ675rXcd9998bnPfS7GjRsXjzzySP7wTstjjz0W9aI19ZakD6B//etfzcuzzz4b9WKfffbJ/yimLzx96KGH4iMf+Uh88pOfjKVLl+6wvPusdfVW7/fZ9hYtWhQ/+clPcgh8Pe63t15niXutFdIwampv9erVaXh65Z577nnNMieddFJl5MiRLfYdddRRla985St1+0fyZurtuuuuqzQ1Nb2t17Wz69WrV+XnP//5Do+5z1pXb+6z/++ll16qHHjggZW5c+dWPvjBD1bOOuus16xT99tbrzP3WutogWkja9euzevevXu/ZpmFCxfG8OHDW+wbMWJE3l+v3ky9JevXr4/9998/fznmG/0vuiNL39p+88035xar1/qaDfdZ6+otcZ/9n9RKOnLkyP/698r9Vps6c691sJl4S5a+tyk97zz22GPj4IMPfs1yaYbh7WcWTttpfz16s/X27ne/O6699trcLJsCz6WXXhrHHHNMDjHpMUE9WLJkSf7g3bhxY+y+++5x6623xqBBg3ZY1n3Wunpzn/2fFPQefvjh/DjkzXC/vfU6c6+1jgDTRsk79WP505/+1Banj3qvt/QBtO3/mlN4GThwYH7WfPHFF0c9SP/gPfrooznA/frXv87fG5b6E73WhzFvvd7cZxErVqyIs846K/dPq/cOzG1ZZ+611hFgamzChAkxZ86cWLBgwRu2BvTr1y9WrVrVYl/aTvvrzVupt+116dIlDj/88Pjb3/4W9SJ9Y/u73vWu/HP65vb0P70rr7wyh7jtuc9aV2/bq8f7LHV4Xr16dbz3ve9t8fgt/T29+uqrY9OmTdGpU6cWr6n3+601dba9erzXWkMfmBpJXymVPoRTk/T8+fNjwIABbyp1z5s3r8W+lNpf75l8R9Oaette+schPRrYe++9o16lx2/pH8YdcZ+1rt62V4/32bBhw/LvnFqtqsuQIUNizJgx+ecdfRDX+/3WmjrbXj3ea63Sys6/bOf000/PI2P+8Ic/VP71r381Ly+//HJzmVNOOaUyadKk5u1777230rlz58qll15aefzxxyvf/va3K126dKksWbKkbuq3NfU2derUyl133VX5+9//Xlm8eHHl5JNPrnTr1q2ydOnSSj1IdZFGaT399NOVv/zlL3m7oaGhcvfdd+fj7rPa1Fu932evZfsRNe63/73O3Gut4xFSDSfJSj70oQ+12H/dddfFqaeemn9evnx5NDY2tui7cdNNN8WFF14Y3/jGN+LAAw+M22677XU7sHY0ram3F198McaPH587C/bq1Ss/CkhzT9RL/4/UPP3FL34xz0vS1NSUOzPfdddd8dGPfjQfd5/Vpt7q/T57s9xv/3ududdapyGlmFa+FgCgXegDAwAUR4ABAIojwAAAxRFgAIDiCDAAQHEEGACgOAIMAFAcAQYAKI4AAwAUR4ABAIojwAAAxRFgAIAozf8DIEBjmXNKBmcAAAAASUVORK5CYII=",
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "plt.hist(ln_p_hat_holdout)\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bafy9ftcoBed"
+      },
+      "source": [
+        "Now, let's go one step further and construct a DML estimator of the price elasticity in a partially linear model. In particular, we will model market share $q_i$ as\n",
+        "$$\\ln q_i = \\alpha + \\beta \\ln p_i + \\psi(d_i) + \\epsilon_i,$$\n",
+        "where $d_i$ denotes the description of product $i$ and $\\psi$ is the composition of text embedding and a linear layer."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 35,
+      "metadata": {
+        "id": "Qiteu6FaoctV"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Quantity model parameters: 109,483,009\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Build the quantity prediction network with a fresh BERT\n",
+        "torch.manual_seed(123)\n",
+        "bert2 = BertModel.from_pretrained(\"bert-base-uncased\").to(device)\n",
+        "quantity_model = BertRegressor(bert2).to(device)\n",
+        "\n",
+        "optimizer_q = torch.optim.Adam(quantity_model.parameters(), lr=1e-4)\n",
+        "\n",
+        "train_loader_q = make_loader(train_enc, ln_q)\n",
+        "val_loader_q = make_loader(val_enc, val_ln_q, shuffle=False)\n",
+        "\n",
+        "print(f\"Quantity model parameters: {sum(p.numel() for p in quantity_model.parameters()):,}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 36,
+      "metadata": {
+        "id": "aaxHV0gGMqpw"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Fine-tuning — quantity prediction:\n",
+            "  Epoch 1/10 — train_loss: 23.3276, val_loss: 1.4931\n",
+            "  Epoch 2/10 — train_loss: 1.6898, val_loss: 1.4781\n",
+            "  Epoch 3/10 — train_loss: 1.6010, val_loss: 1.2122\n",
+            "  Epoch 4/10 — train_loss: 1.4284, val_loss: 1.1663\n",
+            "  Epoch 5/10 — train_loss: 1.0752, val_loss: 1.4320\n",
+            "  Epoch 6/10 — train_loss: 0.9267, val_loss: 1.3791\n",
+            "  Epoch 7/10 — train_loss: 0.7150, val_loss: 1.1749\n",
+            "  Epoch 8/10 — train_loss: 0.4602, val_loss: 1.3660\n",
+            "  Epoch 9/10 — train_loss: 0.3245, val_loss: 1.1064\n",
+            "  Epoch 10/10 — train_loss: 0.2991, val_loss: 1.1642\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Fit the quantity prediction network\n",
+        "torch.manual_seed(123)\n",
+        "print(\"Fine-tuning — quantity prediction:\")\n",
+        "q_hist = train_model(quantity_model, train_loader_q, val_loader_q, optimizer_q,\n",
+        "                      epochs=10, save_path=os.path.join(weights_folder, \"qweights.pt\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 37,
+      "metadata": {
+        "id": "TfyQV3lw-xf2"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "<All keys matched successfully>"
+            ]
+          },
+          "execution_count": 37,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "quantity_model.load_state_dict(torch.load(os.path.join(weights_folder, \"qweights.pt\"), weights_only=True))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 38,
+      "metadata": {
+        "id": "YADpNj0jMygZ"
+      },
+      "outputs": [],
+      "source": [
+        "# Predict in the holdout sample\n",
+        "ln_q_hat_holdout = predict(quantity_model, holdout_enc)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 39,
+      "metadata": {
+        "id": "jh4criU1hGIP"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Neural Net R^2, Quantity Prediction:\n",
+            "RSS: 4397.048338576194, TSS + MEAN^2: 466060.5970448292, TSS: 6256.519275035675, R^2: 0.2972053396972677\n"
+          ]
+        }
+      ],
+      "source": [
+        "print('Neural Net R^2, Quantity Prediction:')\n",
+        "get_r2(holdout['ln_q'].values, ln_q_hat_holdout)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 40,
+      "metadata": {
+        "id": "ir-_yAfkPM6f"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Elasticity of Demand with Respect to Price: -0.2391674419230554\n",
+            "Standard Error: 0.04616531105993252\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Compute residuals\n",
+        "r_p = holdout[\"ln_p\"].values - ln_p_hat_holdout\n",
+        "r_q = holdout[\"ln_q\"].values - ln_q_hat_holdout\n",
+        "\n",
+        "# Regress to obtain elasticity estimate\n",
+        "beta = np.mean(r_p * r_q) / np.mean(r_p * r_p)\n",
+        "\n",
+        "# standard error on elasticity estimate\n",
+        "se = np.sqrt(np.mean((r_p * r_q)**2) / (np.mean(r_p * r_p)**2) / len(r_p))\n",
+        "\n",
+        "print('Elasticity of Demand with Respect to Price: {}'.format(beta))\n",
+        "print('Standard Error: {}'.format(se))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VCqeRTB_BNEH"
+      },
+      "source": [
+        "# Heterogeneous Elasticities within Major Product Categories\n",
+        "\n",
+        "We now look at the major product categories that have many products, and we investigate whether the \"within group\" price elasticities vary."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 41,
+      "metadata": {
+        "id": "XRUZEXqc8HPG"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "category\n",
+              "Cars & Race Cars    1168\n",
+              "Trucks               688\n",
+              "Residual             594\n",
+              "Skateboards          336\n",
+              "Train Sets           332\n",
+              "Airplanes            122\n",
+              "Trains & Trams       117\n",
+              "Vehicle Playsets     113\n",
+              "Motor Vehicles        92\n",
+              "Race Tracks           80\n",
+              "Name: count, dtype: int64"
+            ]
+          },
+          "execution_count": 41,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Category is already set from prepare_data\n",
+        "holdout['category'].value_counts().head(10)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 42,
+      "metadata": {
+        "id": "ymWJv4Ej7lt9"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>category</th>\n",
+              "      <th>COUNT(*)</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Cars &amp; Race Cars</td>\n",
+              "      <td>1168</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Trucks</td>\n",
+              "      <td>688</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Residual</td>\n",
+              "      <td>594</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Skateboards</td>\n",
+              "      <td>336</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Train Sets</td>\n",
+              "      <td>332</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>Airplanes</td>\n",
+              "      <td>122</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>Trains &amp; Trams</td>\n",
+              "      <td>117</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>7</th>\n",
+              "      <td>Vehicle Playsets</td>\n",
+              "      <td>113</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "           category  COUNT(*)\n",
+              "0  Cars & Race Cars      1168\n",
+              "1            Trucks       688\n",
+              "2          Residual       594\n",
+              "3       Skateboards       336\n",
+              "4        Train Sets       332\n",
+              "5         Airplanes       122\n",
+              "6    Trains & Trams       117\n",
+              "7  Vehicle Playsets       113"
+            ]
+          },
+          "execution_count": 42,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Elasticity within the main product categories\n",
+        "sql.run(\"\"\"\n",
+        "  SELECT category, COUNT(*)\n",
+        "  FROM holdout\n",
+        "  GROUP BY 1\n",
+        "  HAVING COUNT(*)>=100\n",
+        "  ORDER BY 2 desc\n",
+        "\"\"\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 43,
+      "metadata": {
+        "id": "E3ncPtwt8nJi"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>point</th>\n",
+              "      <th>se</th>\n",
+              "      <th>lower</th>\n",
+              "      <th>upper</th>\n",
+              "      <th>category</th>\n",
+              "      <th>N</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>0.604588</td>\n",
+              "      <td>0.066321</td>\n",
+              "      <td>0.474599</td>\n",
+              "      <td>0.734578</td>\n",
+              "      <td>Airplanes</td>\n",
+              "      <td>122</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>-0.211099</td>\n",
+              "      <td>0.051773</td>\n",
+              "      <td>-0.312574</td>\n",
+              "      <td>-0.109624</td>\n",
+              "      <td>Cars &amp; Race Cars</td>\n",
+              "      <td>1168</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>-0.258203</td>\n",
+              "      <td>0.037745</td>\n",
+              "      <td>-0.332184</td>\n",
+              "      <td>-0.184223</td>\n",
+              "      <td>Residual</td>\n",
+              "      <td>594</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>-0.150147</td>\n",
+              "      <td>0.033312</td>\n",
+              "      <td>-0.215438</td>\n",
+              "      <td>-0.084855</td>\n",
+              "      <td>Skateboards</td>\n",
+              "      <td>336</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>-0.032831</td>\n",
+              "      <td>0.037197</td>\n",
+              "      <td>-0.105738</td>\n",
+              "      <td>0.040075</td>\n",
+              "      <td>Train Sets</td>\n",
+              "      <td>332</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>-0.899201</td>\n",
+              "      <td>0.056901</td>\n",
+              "      <td>-1.010727</td>\n",
+              "      <td>-0.787676</td>\n",
+              "      <td>Trains &amp; Trams</td>\n",
+              "      <td>117</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>-0.321574</td>\n",
+              "      <td>0.051594</td>\n",
+              "      <td>-0.422698</td>\n",
+              "      <td>-0.220450</td>\n",
+              "      <td>Trucks</td>\n",
+              "      <td>688</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>-0.310637</td>\n",
+              "      <td>0.037479</td>\n",
+              "      <td>-0.384096</td>\n",
+              "      <td>-0.237178</td>\n",
+              "      <td>Vehicle Playsets</td>\n",
+              "      <td>113</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "      point        se     lower     upper          category     N\n",
+              "0  0.604588  0.066321  0.474599  0.734578         Airplanes   122\n",
+              "0 -0.211099  0.051773 -0.312574 -0.109624  Cars & Race Cars  1168\n",
+              "0 -0.258203  0.037745 -0.332184 -0.184223          Residual   594\n",
+              "0 -0.150147  0.033312 -0.215438 -0.084855       Skateboards   336\n",
+              "0 -0.032831  0.037197 -0.105738  0.040075        Train Sets   332\n",
+              "0 -0.899201  0.056901 -1.010727 -0.787676    Trains & Trams   117\n",
+              "0 -0.321574  0.051594 -0.422698 -0.220450            Trucks   688\n",
+              "0 -0.310637  0.037479 -0.384096 -0.237178  Vehicle Playsets   113"
+            ]
+          },
+          "execution_count": 43,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "main_cats = sql.run(\"\"\"\n",
+        "  SELECT category\n",
+        "  FROM holdout\n",
+        "  GROUP BY 1\n",
+        "  HAVING COUNT(*)>=100\n",
+        "\"\"\")['category']\n",
+        "\n",
+        "dfs = []\n",
+        "for cat in main_cats:\n",
+        "    mask = holdout['category'].values == cat\n",
+        "    r_p_c = r_p[mask]\n",
+        "    r_q_c = r_q[mask]\n",
+        "    # Regress to obtain elasticity estimate\n",
+        "    beta = np.mean(r_p_c * r_q_c) / np.mean(r_p_c * r_p_c)\n",
+        "\n",
+        "    # standard error on elasticity estimate\n",
+        "    se = np.sqrt(np.mean((r_p_c * r_q_c)**2) / (np.mean(r_p_c * r_p_c)**2) / len(r_p))\n",
+        "\n",
+        "    df = pd.DataFrame({'point': beta, 'se': se, 'lower': beta - 1.96 * se, 'upper': beta + 1.96 * se}, index=[0])\n",
+        "    df['category'] = cat\n",
+        "    df['N'] = mask.sum()\n",
+        "    dfs.append(df)\n",
+        "\n",
+        "df = pd.concat(dfs)\n",
+        "df"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QFTjf9vP6Zfu"
+      },
+      "source": [
+        "## Clustering Products\n",
+        "\n",
+        "In this final part of the notebook, we'll illustrate how the BERT text embeddings can be used to cluster products based on their  descriptions.\n",
+        "\n",
+        "Intiuitively, our neural network has now learned which aspects of the text description are relevant to predict prices and market shares.\n",
+        "We can therefore use the embeddings produced by our network to cluster products, and we might expect that the clusters reflect market-relevant information.\n",
+        "\n",
+        "In the following block of cells, we compute embeddings using our learned models and cluster them using $k$-means clustering with $k=10$. Finally, we will explore how the estimated price elasticity differs across clusters.\n",
+        "\n",
+        "### Overview of **$k$-means clustering**\n",
+        "The $k$-means clustering algorithm seeks to divide $n$ data vectors into $k$ groups, each of which contain points that are \"close together.\"\n",
+        "\n",
+        "In particular, let $C_1, \\ldots, C_k$ be a partitioning of the data into $k$ disjoint, nonempty subsets (clusters), and define\n",
+        "$$\\bar{C_i}=\\frac{1}{\\#C_i}\\sum_{x \\in C_i} x$$\n",
+        "to be the *centroid* of the cluster $C_i$. The $k$-means clustering score $\\mathrm{sc}(C_1 \\ldots C_k)$ is defined to be\n",
+        "$$\\mathrm{sc}(C_1 \\ldots C_k) = \\sum_{i=1}^k \\sum_{x \\in C_i} \\left(x - \\bar{C_i}\\right)^2.$$\n",
+        "\n",
+        "The $k$-means clustering is then defined to be any partitioning $C^*_1 \\ldots C^*_k$ that minimizes the score $\\mathrm{sc}(-)$.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 44,
+      "metadata": {
+        "id": "Mc7I00JPK6wJ"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Combined embeddings shape: (3708, 1536)\n"
+          ]
+        }
+      ],
+      "source": [
+        "# STEP 1: Compute embeddings from both fine-tuned BERT models\n",
+        "emb1 = get_embeddings(price_model.bert, holdout_enc)\n",
+        "emb2 = get_embeddings(quantity_model.bert, holdout_enc)\n",
+        "embeddings = np.concatenate([emb1, emb2], axis=1)\n",
+        "print(f\"Combined embeddings shape: {embeddings.shape}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hCG2MunU6iF-"
+      },
+      "source": [
+        "### Dimension reduction and the **Johnson-Lindenstrauss transform**\n",
+        "\n",
+        "Our learned embeddings have dimension in the $1000$s, and $k$-means clustering is often an expensive operation. To improve the situation, we will use a neat trick that is used extensively in machine learning applications: the *Johnson-Lindenstrauss transform*.\n",
+        "\n",
+        "This trick involves finding a low-dimensional linear projection of the embeddings that approximately preserves pairwise distances.\n",
+        "\n",
+        "In fact, Johnson and Lindenstrauss proved a much more interesting statement: a Gaussian random matrix will *almost always* approximately preserve pairwise distances.\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 45,
+      "metadata": {
+        "id": "afGiLR7v6ecJ"
+      },
+      "outputs": [],
+      "source": [
+        "# STEP 2 Make low-dimensional projections\n",
+        "from sklearn.random_projection import GaussianRandomProjection\n",
+        "\n",
+        "jl = GaussianRandomProjection(eps=.25)\n",
+        "embeddings_lowdim = jl.fit_transform(embeddings)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 46,
+      "metadata": {
+        "id": "9Tl9AM3J6j3X"
+      },
+      "outputs": [],
+      "source": [
+        "# STEP 3 Compute clusters\n",
+        "from sklearn.cluster import KMeans\n",
+        "\n",
+        "k_means = KMeans(n_clusters=10)\n",
+        "k_means.fit(embeddings_lowdim)\n",
+        "cluster_ids = k_means.labels_"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 47,
+      "metadata": {
+        "id": "0l7De-Do6mD0"
+      },
+      "outputs": [],
+      "source": [
+        "# STEP 4 Regress within each cluster\n",
+        "\n",
+        "betas = np.zeros(10)\n",
+        "ses = np.zeros(10)\n",
+        "\n",
+        "r_p = holdout[\"ln_p\"] - ln_p_hat_holdout.reshape((-1,))\n",
+        "r_q = holdout[\"ln_q\"] - ln_q_hat_holdout.reshape((-1,))\n",
+        "\n",
+        "for c in range(10):\n",
+        "\n",
+        "    r_p_c = r_p[cluster_ids == c]\n",
+        "    r_q_c = r_q[cluster_ids == c]\n",
+        "\n",
+        "    # Regress to obtain elasticity estimate\n",
+        "    betas[c] = np.mean(r_p_c * r_q_c) / np.mean(r_p_c * r_p_c)\n",
+        "\n",
+        "    # standard error on elastiticy estimate\n",
+        "    ses[c] = np.sqrt(np.mean((r_p_c * r_q_c)**2) / (np.mean(r_p_c * r_p_c)**2) / r_p_c.size)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 48,
+      "metadata": {
+        "id": "oXoe98f06njT"
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAksAAAHHCAYAAACvJxw8AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAPklJREFUeJzt3Qd4U+Xbx/G7BcpoWRXKUJApBZmC8AdRUBAKKIIIgiBDhD8oIEMQVPbeviAyHAxluBUR2UvZMhQQEGTvJQWKtEDzXvfjm7xJx6EtCW2S7+e6jklOTpKTk0h+fZ77eU6AzWazCQAAABIUmPBqAAAAEJYAAADugJYlAAAAC4QlAAAAC4QlAAAAC4QlAAAAC4QlAAAAC4QlAAAAC4QlAAAAC4QlwEMCAgJk0KBBXvG6a9asMY/TS18wa9Ys836OHDki/qRmzZpSunRpSUv0u6ifBeDNCEtACn6EE1s2bdp0T47n4sWLPR7E5s2bJ++9957bn9fq+HXq1ClZzzVixAj57rvvJC3ZsGGD+WwuX74svuzGjRsyceJEqVKlimTPnl0yZcokDz30kHTp0kX+/PPPe7YfnvqeAs7Su9wCkCRDhgyRwoULx1tfrFixexaWpkyZkmBg+ueffyR9+uT9r/3EE0+YxwUFBbn8CO3evVu6d+8u7vb0009L69at463XH9vkhqUXXnhBGjVq5LL+5ZdflubNm0vGjBklNcLS4MGDpW3btpIjRw7xRRcuXJCIiAjZtm2bPPPMM/LSSy9JSEiI7N+/XxYsWCAzZsyQmJiYe7IvnvyeAnaEJSAF6tWrJ5UqVUqTx07/wk+uwMDAFD0upTQUtWrVymPPny5dOrPAMzQI7tixQ7766itp0qSJy31Dhw6Vd955x6sPfWxsrAl79/L/CaRtdMMB98jRo0fltddekxIlSkjmzJnlvvvuk6ZNm8arq7l586ZpmShevLj5x1q3q169uixfvtzxQ6WtSsq5C8uqZunkyZPSvn17yZ8/v2lt0Vaxzp07O/76j1uzpLUvP/74o9ln+/MXKlRIrl27JsHBwfLGG2/Ee38nTpwwAWXkyJFuOV4HDhwwP8R58+Y1x+GBBx4wrUWRkZGO9xkVFSWzZ8927KMem8RqlnT/tRVE36MGXf0MypQp43jP33zzjbmtr1WxYkUTBpz9/vvv5vmLFClittH9euWVV+TixYuObfS49+7d21zXY2zfL+f9+Oyzz8zz6+uHhoaa93T8+PFkvfc70RafatWqmdfQ/Zg2bZrjvrv9DDdv3my+G/p9ihuUlH6/xo0bl+jj9VjoMdHPKK64392rV6+aFiP97PR5w8LCTKvk9u3bLb+ndtHR0TJw4EDT4quPL1CggPTp08esj/u62n04d+5cefjhh822S5YsSfQ9wP/QsgSkgP5oaVdE3H9wNdgkZuvWraaLRn/09MdPfzSmTp1q/sH/448/JEuWLGY7/bHQH6tXX31VKleuLFeuXJFff/3V/EDoD8V///tfOXXqlAlPn3766R33VbfV59Eamo4dO0p4eLgJT9oqcP36dZeuNzttGdD3qD+eWpeitJtFl8aNG8vnn38uEyZMcGm9mT9/vthsNmnZsmWS6l3iHj+VLVs2sz8a4urWrWt+1Lp27WpCg+7zokWLzPvQGhl97/ZjpO9LFS1a1PJ1Dx48aLqM9Bhqy5b+qD/77LMmTLz99tsmzCo9/s2aNTPdStrqpvR4Hzp0SNq1a2f2Z8+ePaa7SS+1Vk0//+eff97U6+ix0OOWK1cu89jcuXOby+HDh0v//v3Nc+u+nz9/XiZPnmy6QTWcabddUt67lb///lvq169vXqNFixbyxRdfmGCsx1XD3d1+hgsXLnR0dXqa1rDp91SDTKlSpUww/eWXX2Tv3r3yyCOPJPo9tbcONWzY0Gyv34+SJUvKrl27zHb6GcWtdVu1apU5Vvpa+rk5hy5A/8cAkEQzZ860iUiCS8aMGV221XUDBw503L5+/Xq859u4caPZbs6cOY515cqVszVo0MByP15//XXzuITEfd3WrVvbAgMDbVu3bo23bWxsrLlcvXq1eZxe2uk+PPjgg/Ees3TpUrPtTz/95LK+bNmytho1aljut33/Elvmz59vttmxY4e5/eWXX1o+V3BwsK1NmzaJfk6HDx92rNP3ous2bNgQ771kzpzZdvToUcf66dOnxzseCX1+ur+63bp16xzrxo4dG++11ZEjR2zp0qWzDR8+3GX9rl27bOnTp3esT+p7T4gef33s+PHjHeuio6Nt5cuXt4WFhdliYmLu+jNs3Lixeezff/+dpH3S76Lzd1WPi97Wz+hO393s2bOb77qVxL6nn376qfne//zzzy7rp02bZl5n/fr1Lq+r2+7ZsydJ7wn+h244IAW0G0xbGpyXn376yfIx2iXi3NWmfyVr94C2Jti7FZTe1tYK7Yq5W/rXtf4Fra0nCdVYpWRId+3atU13nnZZ2GmBrXZTJbUO6bnnnot3/HR58sknzf321pOlS5ea1i930daJqlWrOm7rSC711FNPScGCBeOt15akhD4/e8vYf/7zH3Pb+fNLjHbz6eehLT76WPuiLUfa5bp69Wq3vHct7teWMzttUdLb586dM91zd/sZakunypo1q3ia/r+g3X7aOppcX375pWlN0pZU5+Otn7WyH2+7GjVqmO8HkBC64YAU0K6f5BZ462gz7d6ZOXOm6Vb59w/afznXouhIOw0TWgStc+boqCPt8ihbtmyy91O7efTHzZ1z72i3lHbTaBei/phr96H+6GptjdZgJYV2Q+oPdmK0zqZnz56mm0if+/HHHzddKvpDfqduKCvOgUjZn0trWRJar11adpcuXTK1ZDraS4OHs6TUEmn41c9cg1FCMmTI4Jb3riFIa5ISGmWoXb8a8O7mM9SuUns9kadH+40ZM0batGljPh+t89LuRR1FqXVjSTne2l1n7wKNK+5nmNDoVsCOliXgHtH6E61Z0ZYFrY1YtmyZaU3ROidtcbDT+pW//vpLPvnkExNyPvroI1OfoZdphf5gaaGwtlppANDh21o8fTdBJq7x48eblg6tJdKg2a1bN1N8q/UpKZXYCLnE1jsHWv3cPvzwQ1NHo61E+vnZi4CdP7/E6DbakqePSahVbfr06R597+76DLWlRmn9T0ok1pp5+/bteOv0mGvrntZ1aQgcO3asOQ53asW1H28t2E/oWOtir09LqOUQiIuWJeAe0UJV/StZfwidu3MSmrxQR0lpIbEu+oOmAUoLv7UoODndZ/pXtbYEaBdLclm9hoa4ChUqmNYIbSU6duyY+UFzN/2x0+Xdd981xfGPPfaYKcYeNmzYHffRnbSFaeXKlaZlacCAAY71CXWVJrZPWnyuoURbMJIyn9Sd3ntitMtKRwk6ty7ZJ4l0LlpO6WeoXbraQqqj+rTVK7ly5sxpLuN+73VEW0Ly5ctngo0u2hqkfzjoHx06fcedjvdvv/0mtWrVYgZx3DValoB7RFsvnFsqlP44xf2L2nkoun10j9Y2OQ93tv8Q3mmWaO1u0Qkbf/jhBzOiLq64++NMX8Oqe0m7BrV1RWdP1tYx+4+XO2jX4a1bt1zWaXDQ9xP3ONyLmbLtLU9xj1dCM0cn9tnoSDl9Hg1ccZ9Hb9s/96S+98ToY51bqXR0nd7W4KxdWXf7GWrNl3YNa0tnQrOn6+u9+eabiT5ew7uONlu3bp3L+g8++MDltv5/Eff7p1MHaAtT3O9AQt9TbZXS7m5tDYxLW+s0UAJJRcsSkALaDbBv375463Vum8TqKbSLQ4e7azeHFpJu3LhRVqxYEW+6Ab1PpxPQHzZtYdKQYx8+bWf/0dPuGR1mrj/COiVBYrNc6w+iFrDah1CfPn3aFMDqsOrE6k70NXR4udbPPProoya0aauCnQ7B1zlrvv32WzM03V5zkxTa0qEtE3HlyZPHTI+gw7j1/Wr9jLbCaADQY6fv03luH91HPYZa36M/otpqYy/Odif9gdfWPa2h0eL8+++/3xzTw4cPx9vW/tnosHb9TPS46HHTlg5tFerXr5+pHdIQq0XS+hx6DPWz0ZCR1PeeGD0Oo0ePNq+hj9fPcOfOnWaag7ifUUo/wzlz5kidOnVMANT3pq03Glq0pU1ruvT7ZTXXkraQjho1ylxq7Z8Gp7inSNGaKG3x0hnay5UrZ75/+lnrFBzOrbOJfU81CGp3t3abajG3tsxpANP/b3W9FtCn1YllkQal9nA8wFemDog7HDruMGgdat2uXTtbrly5bCEhIba6deva9u3bZ4Y9Ow9/HzZsmK1y5cq2HDlymCHt4eHhZli5fdi3unXrlq1r16623Llz2wICAlyGZsd9XaXD4nUKAd1epzgoUqSIGZKtw8oTmzrg2rVrtpdeesnsh96X0PDs+vXrxxuOfydWx88+bP3QoUO2V155xVa0aFFbpkyZbKGhobYnn3zStmLFCpfn0uP3xBNPmOOkj7cfx8SmDkhoSgbdLu7wdPvwdp0GwO7EiRNm2LweDx3S3rRpU9upU6cSPN5Dhw613X///WY4etz9+Prrr23Vq1c30x7oop+vvv7+/fuT9d4Tosfv4Ycftv3666+2qlWrmsfr+37//fcTfUxKPkP7VArjxo2zPfroo+b7HBQUZCtevLj5Xh48eDDRqQPsj23fvr05jlmzZrU1a9bMdu7cOZdjqd/N3r17m6k0dBs9Vnr9gw8+cHkuq++p/j8zevRoc0z0e58zZ05bxYoVbYMHD7ZFRkZafgcAZwH6n9QObAC8k05uqIW+OtkjvBOfIXBn1CwBSBHtatFTTdyLmZzhGXyGQNJQswQgWbTGZv369abAV2tcnCdAhHfgMwSSh5YlAMmydu1a05qkP7h6EludgRrehc8QSB5qlgAAACzQsgQAAGCBsAQAAGCBAm830HMQ6SkGdIK5e3X6BQAAcHd09iSdAFUnc9VZ8hNDWHIDDUpxz1oOAAC8w/Hjx82M8YkhLLmBtijZD7aeFgEAAKR9ei5Gbeyw/44nhrDkBvauNw1KhCUAALzLnUpoKPAGAACwQFgCAACwQFgCAACwQFgCAACwQFgCAACwQFgCAACwQFgCAACwQFgCAACwQFgCAACwQFgCAACwQFgCAACwQFgCAACwQFgCAACwQFgCAACwQFgCACCNioqKkoCAALPodaQOwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAFwhIAAIAvhaUpU6ZIoUKFJFOmTFKlShXZsmVLott++OGH8vjjj0vOnDnNUrt27Xjbt23bVgICAlyWiIiIe/BOAACAN/CqsPT5559Lz549ZeDAgbJ9+3YpV66c1K1bV86dO5fg9mvWrJEWLVrI6tWrZePGjVKgQAGpU6eOnDx50mU7DUenT592LPPnz79H7wgAAN8TFRXlaIDQ694uwGaz2cRLaEvSo48+Ku+//765HRsbawJQ165dpW/fvnd8/O3bt00Lkz6+devWjpaly5cvy3fffZfi/bpy5Ypkz55dIiMjJVu2bCl+HgAAnGnQCAkJMdevXbsmwcHBXnGAorxkv5P6++01LUsxMTGybds205VmFxgYaG5rq1FSXL9+XW7evCmhoaHxWqDCwsKkRIkS0rlzZ7l48aLl80RHR5sD7LwAAADf5DVh6cKFC6ZlKE+ePC7r9faZM2eS9BxvvfWW5M+f3yVwaRfcnDlzZOXKlTJ69GhZu3at1KtXz7xWYkaOHGmSqH3R1i0AAOCb0oufGDVqlCxYsMC0ImlxuF3z5s0d18uUKSNly5aVokWLmu1q1aqV4HP169fP1E7ZacsSgQkAAN/kNS1LuXLlknTp0snZs2dd1uvtvHnzWj523LhxJiwtW7bMhCErRYoUMa918ODBRLfJmDGj6dt0XgAAgG/ymrAUFBQkFStWNN1ldlrgrberVq2a6OPGjBkjQ4cOlSVLlkilSpXu+DonTpwwNUv58uUTX+FroxIAALiXvCYsKe360rmTZs+eLXv37jXF2Prj365dO3O/jnDTLjI7rUHq37+/fPLJJ2ZuJq1t0kUr85Ve9u7dWzZt2iRHjhwxweu5556TYsWKmSkJAAAAvKpm6cUXX5Tz58/LgAEDTOgpX768aTGyF30fO3bMjJCzmzp1qhlF98ILL7g8j87TNGjQINOt9/vvv5vwpdMHaPG3zsOkLVHa1QYAAOBV8yylVWl9niVvme8CAOAb/35Hecl++9w8SwAAAKmBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsATAq0VFRUlAQIBZ9DoAuBthCQAAwEJ6qzsBAIB/KdT3x7t+jtiYG47rJfsvkcCgTHf1fEdGNZDURMsSAACABcISAACABcIS0iwKdwEAaQFhCQAAwAJhCXAzWsQAwLcQlgAAACwQlgAAACwQlgAAACwQlgAAAHwpLE2ZMkUKFSokmTJlkipVqsiWLVsst//yyy8lPDzcbF+mTBlZvHixy/02m00GDBgg+fLlk8yZM0vt2rXlwIEDHn4XAADAW3hVWPr888+lZ8+eMnDgQNm+fbuUK1dO6tatK+fOnUtw+w0bNkiLFi2kffv2smPHDmnUqJFZdu/e7dhmzJgxMmnSJJk2bZps3rxZgoODzXPeuPH/U7UDAAD/5VVhacKECdKhQwdp166dlCpVygScLFmyyCeffJLg9v/zP/8jERER0rt3bylZsqQMHTpUHnnkEXn//fcdrUrvvfeevPvuu/Lcc89J2bJlZc6cOXLq1Cn57rvv7vG7AwAAaZHXhKWYmBjZtm2b6SazCwwMNLc3btyY4GN0vfP2SluN7NsfPnxYzpw547JN9uzZTfdeYs+poqOj5cqVKy4LAADwTenFS1y4cEFu374tefLkcVmvt/ft25fgYzQIJbS9rrffb1+X2DYJGTlypAwePFjuBW89+zP77X3H2934nvju8T4+8QVzvUCPr/h+34Pjfa//PUnKNkmZnDdk4r/X9w6NMCUu3sxrWpbSkn79+klkZKRjOX78eGrvEgAA8PeWpVy5ckm6dOnk7NmzLuv1dt68eRN8jK632t5+qet0NJzzNuXLl090XzJmzGiWe4GEDwBA6vKalqWgoCCpWLGirFy50rEuNjbW3K5atWqCj9H1ztur5cuXO7YvXLiwCUzO22j9kY6KS+w5AQCAf/GaliWl0wa0adNGKlWqJJUrVzYj2bRfVEfHqdatW8v9999vaorUG2+8ITVq1JDx48dLgwYNZMGCBfLrr7/KjBkzzP0BAQHSvXt3GTZsmBQvXtyEp/79+0v+/PnNFAMAAKQUPQO+w6vC0osvvijnz583k0hqAbZ2lS1ZssRRoH3s2DEzQs6uWrVqMm/ePDM1wNtvv20CkU4JULp0acc2ffr0MYGrY8eOcvnyZalevbp5Tp3EEgAAwKvCkurSpYtZErJmzZp465o2bWqWxGjr0pAhQ8wCAADgtTVLAAAAqYGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBADwebExN+To6GfMoteB5EifrK0BAADuIDg4WGw2m/gKWpYAAAAsEJYAAAAs0A0HODkyqsFdH4+oqCgJmfjv9b1DI0xzNADAe9GyBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIGwBAAAYIF5luARzFcEAPAVtCwBAAB4KizduMGZmwEAgG9LdliKjY2VoUOHyv333y8hISFy6NAhs75///7y8ccfe2IfAQAAvCcsDRs2TGbNmiVjxoyRoKAgx/rSpUvLRx995O79AwAA8K6wNGfOHJkxY4a0bNlS0qVL51hfrlw52bdvn7v3DwAAwLvC0smTJ6VYsWIJds/dvHnTXfsFAADgnWGpVKlS8vPPP8db/9VXX0mFChXctV8AAADeOc/SgAEDpE2bNqaFSVuTvvnmG9m/f7/pnlu0aJFn9hIAAMBbWpaee+45+eGHH2TFihUSHBxswtPevXvNuqefftozewkAAOBNM3g//vjjsnz5cvfvDQAAgLe3LBUpUkQuXrwYb/3ly5fNfZ5y6dIlMwIvW7ZskiNHDmnfvr1cu3bNcvuuXbtKiRIlJHPmzFKwYEHp1q2bREZGumwXEBAQb1mwYIHH3gcAAPDxlqUjR47I7du3462Pjo42dUyeokHp9OnTpkVLR921a9dOOnbsKPPmzUtw+1OnTpll3Lhxpij96NGj0qlTJ7NOi9GdzZw5UyIiIhy3NYwB/iY25oYcn/iCuV6gx1cSGJQptXcJALwrLC1cuNBxfenSpZI9e3bHbQ1PK1eulEKFCrl/D0VMTdSSJUtk69atUqlSJbNu8uTJUr9+fROG8ufPH+8xOknm119/7bhdtGhRGT58uLRq1Upu3bol6dOndwlHefPm9ci+AwAAPwlLjRo1MpfaTaWj4ZxlyJDBBKXx48e7fw9FZOPGjSbQ2IOSql27tgQGBsrmzZulcePGSXoe7YLTbjznoKRef/11efXVV003orY+aauVvs/EaCuaLnZXrlyRtEwL8W02W2rvBgAAvh2WdJoAVbhwYdPCkytXLrlXzpw5I2FhYS7rNPCEhoaa+5LiwoUL5px22nXnbMiQIfLUU09JlixZZNmyZfLaa6+ZWiitb0rMyJEjZfDgwSl8NwAAwKcLvA8fPuy2oNS3b98EC6ydF3ecQkVbfho0aGBqlwYNGuRyn54A+LHHHjMTar711lvSp08fGTt2rOXz9evXz7RS2Zfjx4/f9T4CAAAfmjogKipK1q5dK8eOHZOYmBiX+6xaZOLq1auXtG3b1nIb7RrTeqJz5865rNe6Ix3xdqdao6tXr5ri7axZs8q3335rugytVKlSxbRAaTdbxowZE9xG1yd2HwAA8POwtGPHDlNYff36dROatCtMu7i0G0u7ypITlnLnzm2WO6lataqZmmDbtm1SsWJFs27VqlWma1DDjVWLUt26dU2w0QL1TJnuPLpn586dkjNnTsIQAABIWTdcjx495Nlnn5W///7bzF+0adMmMyxfQ4yOTPOEkiVLmtahDh06yJYtW2T9+vXSpUsXad68uWMknE5bEB4ebu63B6U6deqYQPfxxx+b21rfpIt96gOddfyjjz6S3bt3y8GDB2Xq1KkyYsQIMz8TAABAilqWtOVl+vTpZiRaunTpTHeVdpWNGTPGjJJ7/vnnPXJk586dawJSrVq1zGs3adJEJk2a5Lhf517Sc9Rpi5favn27GSmnihUrFq/uSkfvaZfclClTTADU0WK63YQJE0woAwAASFFY0oChYUVpt5vWLWnLj8675MlCZ+3uS2wCSqXhx3l4fM2aNe84XF5bq5wnowQAALjrsKSjxnTqgOLFi0uNGjXMiXS1ZunTTz81E0ECAAD4dc2S1vTky5fPXNcZsbUYunPnznL+/HmZMWOGJ/YRAADAe1qWnGfR1m44PQ0JgP/HjOlJd2RUg7v+6uggjpCJ/17fOzTCHH8ASNWWJQAAAH+S7Jalixcvmjql1atXm4ki7adBsdOJIgEAAPw2LL388stmTqL27dtLnjx5LE84CwAA4Hdh6eeff5ZffvlFypUr55k9AgAA8OaaJZ0l+59//vHM3gAAAHh7WPrggw/knXfeMSfS1folPY2I8wIAAODX3XA5cuQwoeipp55yWa+zZWv9kv28awAAAH4Zllq2bGlOeaKnHqHAGwAA+Lpkh6Xdu3fLjh07pESJEp7ZIwAAAG+uWdIZvD15wlwAAACvblnq2rWrvPHGG9K7d28pU6aM6ZJzVrZsWXfuHwDAz3FaHHhdWHrxxRfN5SuvvOJYp4XdFHgDAABflOywdPjwYc/sCQAAgC+EpQcffNAzewIAAOCtYWnhwoVSr149U5+k1600bNjQXfsGAADgHWGpUaNGcubMGQkLCzPXE8OklAAAwC/DUmxsbILXAQAAfF2y51maM2eOREdHx1sfExNj7gMAAPDrsNSuXTuJjIyMt/7q1avmPgAAAL8eDWefTymuEydOSPbs2d21X4AEBweb7xsAAF4RlipUqGBCki61atWS9On//6G3b9828y9FRER4aj8BAADSdliyj4LbuXOn1K1bV0JCQhz3BQUFSaFChaRJkyae2UsAAIC0HpYGDhxoLjUUNW/eXDJmzOjJ/QIAwO9RjuClBd5PPfWUnD9/3nF7y5Yt0r17d5kxY4a79w0AAMD7wtJLL70kq1evNtd1osratWubwPTOO+/IkCFDPLGPAAAA3hOWdu/eLZUrVzbXv/jiCylTpoxs2LBB5s6dK7NmzfLEPgIAAHhPWLp586ajXmnFihWOc8GFh4fL6dOn3b+HAAAA3hSWHn74YZk2bZr8/PPPsnz5csd0AadOnZL77rvPE/sIAADgPWFp9OjRMn36dKlZs6a0aNFCypUrZ9YvXLjQ0T0HAADgtzN4a0i6cOGCXLlyRXLmzOlY37FjR8mSJYu79w8AfFJszA05PvEFc71Aj68kMChTau8SgLttWTp37pzjerp06VyCknrggQfkyJEjSX06AAAA3wpL+fLlcwlMOgru+PHjjtsXL16UqlWrun8PAQAAvCEsxT2hqbYi6cg4q23c6dKlS9KyZUvJli2b5MiRQ9q3by/Xrl27Y5eh/Xx29qVTp04u2xw7dkwaNGhguhDDwsKkd+/ecuvWLY+9DwAA4OM1S1Y0jHiKBiWdmkBH4GlIa9eunamTmjdvnuXjOnTo4DJZpnNdlZ4AWINS3rx5zVxR+vytW7eWDBkyyIgRIzz2XgAAgJ+GJU/Zu3evLFmyRLZu3SqVKlUy6yZPniz169eXcePGSf78+RN9rIYjDUMJWbZsmfzxxx9mvqg8efJI+fLlZejQofLWW2/JoEGDzAmCAQCAfwtMTqvR1atXzSi4yMhIc1u7wfS2ffGUjRs3mq43e1BSepqVwMBA2bx5s+VjdWbxXLlySenSpaVfv35y/fp1l+fV2isNSnZ169Y172XPnj2JPmd0dLTL+/bkewcAAF7SsqT1SA899JDL7QoVKrjc9lQ3nJ6DTuuJnKVPn15CQ0PNfVbnsXvwwQdNy9Pvv/9uWoz2798v33zzjeN5nYOSst+2et6RI0fK4MGD7/JdAQAAnwpL9pPnulPfvn3NJJd36oJLKa1pstMWJB3RV6tWLfnrr7+kaNGiKX5ebaHq2bOn47a2LBUoUCDFzwcAAHwgLNWoUcPtL96rVy9p27at5TZFihQxNUfO0xYoHbGmI+QSq0dKSJUqVczlwYMHTVjSx27ZssVlm7Nnz5pLq+fVc+PZz48HAAB8W6oWeOfOndssd6LzN12+fFm2bdsmFStWNOtWrVolsbGxjgCUFDt37jSX2sJkf97hw4ebIGbv5tPRdjo9QalSpVL4rgAAgF+fGy41lCxZ0pywV6cB0Jag9evXS5cuXaR58+aOkXAnT56U8PBwR0uRdrXpyDYNWDonlJ67TqcFeOKJJ6Rs2bJmmzp16phQ9PLLL8tvv/0mS5culXfffVdef/11Wo4AAID3hCX7qDYNQ1pzpFMGVK9eXWbMmOG4X+de0uJt+2g3HfavUwJoINLHaZdfkyZN5IcffnA5bcuiRYvMpbYytWrVygQq53mZAACAf/OKeZaUjnyzmoCyUKFCLjOIa8H12rVr7/i8Olpu8eLFbttPAADg5y1LM2fOdJmrCAAAwJcFpmS4v44U03Oz6SlCAAAAfFmyw5IWUs+ePVsuXLhgTlSr9UA6V5LVJI4AAAB+E5Z05uzGjRvL999/L8ePHzcj1LT4umDBgtKwYUOzXof0AwAAiL+PhtNTg+ioNB1Jpudp27Vrl7Rp08ZM+LhmzRr37SUAAIA3hSWd5XrcuHHy8MMPm644Pd2HDsE/fPiw6aZr1qyZCU0AAAB+F5aeffZZMyx/1qxZpgtOw9H8+fOldu3a5v7g4GAzp5F20QEAAPjdPEt6WhCdv0i73hKjpzDRViYAAAC/a1nSE+o+8sgj8dbHxMTInDlzzPWAgAAz2SMAAIDfhaV27dpJZGRkvPVXr1419wEAAPh1WNJTimjLUVwnTpyQ7Nmzu2u/AAAAvKtmqUKFCiYk6aIns9X5luxu375tapQiIiI8tZ8AAABpOyw1atTIXO7cuVPq1q0rISEhjvuCgoLMiWybNGnimb0EAABI62Fp4MCB5lJD0YsvviiZMmXy5H4BAAB459QBTDYJAPA2Ogeg1twCHgtLoaGh8ueff0quXLkkZ86cCRZ42126dClFOwIAAOC1YWnixImSNWtWx3WrsAQAAOB3Ycm5661t27ae3B8AAADvrllavHixpEuXzoyIc7Zs2TIzhUC9evXcuX8AkuDIqAZ3fZyioqIkZOK/1/cOjTA1HgCAFExK2bdvXxOK4oqNjTX3AQAA+HVYOnDggJQqVSre+vDwcDl48KC79gsAAMA7w5Ke0uTQoUPx1mtQotkeAACIv4el5557Trp37y5//fWXS1Dq1auXNGzY0N37BwAA4F1hacyYMaYFSbvdChcubJaSJUvKfffdJ+PGjfPMXgIAAHjLaDjthtuwYYMsX75cfvvtN8mcObOULVtWnnjiCc/sIQAAgDeFJaWTUtapU8csAAAA4u9hadKkSdKxY0dz8ly9bqVbt27u2jcAAADvOd1Jy5YtTVjS61YtToQlAADgd2Hp8OHDCV4HgNTG2eQBpLnRcEOGDJHr16/HW//PP/+Y+wAAAPw6LA0ePFiuXbsWb70GKL0PAADAlyQ7LNlsNlObFJdOIxAaGuqu/QIAAPCuqQNy5sxpQpIuDz30kEtg0hPramtTp06dPLWfAAAAaTssvffee6ZV6ZVXXjHdbTo5pV1QUJAUKlRIqlat6qn9BADcpSOjGtz1MYyKipKQ/xsUvXdoBOcEhV9Iclhq06aNudTTmzz22GOSPn2K5rMEAADw7ZqlrFmzyt69ex23v//+e2nUqJG8/fbbEhMTI55y6dIlM9dTtmzZJEeOHNK+ffsEC83tjhw54ug2jLt8+eWXju0Sun/BggUeex8AAMDHw9J///tf+fPPP831Q4cOyYsvvihZsmQxAaRPnz7iKRqU9uzZY85Jt2jRIlm3bp2ZVTwxBQoUkNOnT7ss2n0YEhIi9erVc9l25syZLttp+AMAAFDJ7kvToFS+fHlzXQNSjRo1ZN68ebJ+/Xpp3ry5qW1yN23JWrJkiWzdulUqVapk1k2ePFnq168v48aNk/z588d7TLp06SRv3rwu67799ltp1qyZCUzOtKUq7rYAAAApnjogNjbWXF+xYoUJLPaWnAsXLnjkqG7cuNEEGntQUrVr15bAwEDZvHlzkp5j27ZtsnPnTtN9F9frr78uuXLlksqVK8snn3xi3iMAAECKWpY0sAwbNsyElbVr18rUqVMdp0HJkyePR47qmTNnJCwszGWdFpjrvE56X1J8/PHHUrJkSalWrZrLep11/KmnnjJdicuWLZPXXnvN1EJZneMuOjraLHZXrlxJ9nsCAAA+2rKk3Wzbt2+XLl26yDvvvCPFihUz67/66qt4QeRO+vbtm2gRtn3Zt2+f3C09FYt2FSbUqtS/f38zuq9ChQry1ltvmbqrsWPHWj7fyJEjzdQJ9kVb1QAAgG9KdstS2bJlZdeuXfHWa8DQOqHk6NWrl7Rt29ZymyJFiph6onPnzrmsv3Xrlhkhl5RaIw1yejqW1q1b33HbKlWqyNChQ03LUcaMGRPcpl+/ftKzZ0+XliUCEwAAvsltkyVlypQp2Y/JnTu3We5EJ7u8fPmyqTuqWLGiWbdq1SpTO6XhJildcA0bNkzSa2ldk85WnlhQUnqf1f0AAMCPw5Ke2mTixInyxRdfyLFjx+LNraStPe6mtUYRERHSoUMHmTZtmty8edN0A+roO/tIuJMnT0qtWrVkzpw5plDb7uDBg2aagcWLF8d73h9++EHOnj0r//nPf0zY02kJRowYIW+++abb3wMAAPCTmiWdq2jChAlmfqXIyEjTHfX888+bkWmDBg3yzF6KyNy5cyU8PNwEIh2BV716dZkxY4bjfg1Q+/fvN91tznR02wMPPCB16tSJ95wZMmSQKVOmmJYrnQ5h+vTp5r0NHDjQY+8DAAB4lwBbMsfJFy1aVCZNmiQNGjQws3lrt5V93aZNm0whtb/RmiUt9NbwqDOMA97InPPr/+Yg0xGhwcHBqb1LaVahvj/e9XPExtyQ4xNfMNcL9PhKAoOSX8rg7vO+JQXfE/jj73eyW5Z0qH6ZMmXMdf2HVV9APfPMM/Ljj3f/DwgAAEBakuywpF1aekoQpS1KOjeR0tm1KXoGAADi7wXejRs3lpUrV5pRaF27dpVWrVqZ0WZa7N2jRw/P7CUApCHu6PIy3VkT/72+d2gE3Z6AL4WlUaNGOa5rkXfBggXN6UiKFy8uzz77rLv3DwAAwLvnWdKRZLoAAAD4bVhauHBhkp9QJ38EAADwq7DUqFGjJD2ZnstNJ60EAADwq7CkpxUBAADwR8meOgAAAMCfJDks6SlG7BNQ2kfF6clt7S5evCilSpVy/x4CAAB4Q1haunSpREdHO27rCWedT5p769Ytc242AAAAvwxLcU8hl8xTygEAAHglapYAAADcEZZ0WgBd4q4DAADwZUmewVu73dq2bes4We6NGzekU6dOjvMZOdczAQAA+F1YatOmjcttPYFuXK1bt3bPXgEAAHhbWJo5c6Zn9wQAACANosAbAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAAmEJAADAF8LS8OHDpVq1apIlSxbJkSNHkh5js9lkwIABki9fPsmcObPUrl1bDhw44LLNpUuXpGXLlpItWzbzvO3bt5dr16556F0AAABv4zVhKSYmRpo2bSqdO3dO8mPGjBkjkyZNkmnTpsnmzZslODhY6tatKzdu3HBso0Fpz549snz5clm0aJGsW7dOOnbs6KF3AQAAvE2ATZtfvMisWbOke/fucvnyZcvt9G3lz59fevXqJW+++aZZFxkZKXny5DHP0bx5c9m7d6+UKlVKtm7dKpUqVTLbLFmyROrXry8nTpwwj0+KK1euSPbs2c3zawsV4I2ioqIkJCTEXNfWVf3jAhxvvifwZUn9/faalqXkOnz4sJw5c8Z0vdnpAalSpYps3LjR3NZL7XqzByWl2wcGBpqWqMRER0ebA+y8AAAA3+SzYUmDktKWJGd6236fXoaFhbncnz59egkNDXVsk5CRI0ea4GVfChQo4JH3AAAA/Dws9e3bVwICAiyXffv2SVrTr18/02RnX44fP57auwQAADwkvaQirSdq27at5TZFihRJ0XPnzZvXXJ49e9aMhrPT2+XLl3dsc+7cOZfH3bp1y4yQsz8+IRkzZjQLAADwfakalnLnzm0WTyhcuLAJPCtXrnSEI60t0lok+4i6qlWrmkLxbdu2ScWKFc26VatWSWxsrKltAgAA8JqapWPHjsnOnTvN5e3bt811XZznRAoPD5dvv/3WXNcuPB01N2zYMFm4cKHs2rVLWrdubUa4NWrUyGxTsmRJiYiIkA4dOsiWLVtk/fr10qVLFzNSLqkj4QAAgG9L1Zal5NDJJWfPnu24XaFCBXO5evVqqVmzprm+f/9+U0Nk16dPHzMcWudN0hak6tWrm6kBMmXK5Nhm7ty5JiDVqlXLjIJr0qSJmZsJ8Dc6VYCXzSQCAPeE182zlBYxzxIAf5nXylv3G0iI38+zBAAA4Fc1SwAAAKmBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGCBsAQAAGAhvdWdAADPCA4OFpvNxuEFvAAtSwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAAL4QloYPHy7VqlWTLFmySI4cOe64/c2bN+Wtt96SMmXKSHBwsOTPn19at24tp06dctmuUKFCEhAQ4LKMGjXKg+8EAAB4E68JSzExMdK0aVPp3Llzkra/fv26bN++Xfr3728uv/nmG9m/f780bNgw3rZDhgyR06dPO5auXbt64B0AAABvlF68xODBg83lrFmzkrR99uzZZfny5S7r3n//falcubIcO3ZMChYs6FifNWtWyZs3r5v3GAAA+AKvaVlyh8jISNPNFrcbT7vd7rvvPqlQoYKMHTtWbt26lWr7CAAA0havaVm6Wzdu3DA1TC1atJBs2bI51nfr1k0eeeQRCQ0NlQ0bNki/fv1MV9yECRMSfa7o6Giz2F25csXj+w8AAPywZalv377xiqvjLvv27bvr19Fi72bNmonNZpOpU6e63NezZ0+pWbOmlC1bVjp16iTjx4+XyZMnu4ShuEaOHGm6+exLgQIF7nofAQBA2pSqLUu9evWStm3bWm5TpEgRtwSlo0ePyqpVq1xalRJSpUoV0w135MgRKVGiRILbaOuThiznliUCEwAAvilVw1Lu3LnN4in2oHTgwAFZvXq1qUu6k507d0pgYKCEhYUluk3GjBnNAgAAfJ/X1CzpCLZLly6Zy9u3b5tQo4oVKyYhISHmenh4uOkia9y4sQlKL7zwgpk2YNGiReYxZ86cMdtpfVJQUJBs3LhRNm/eLE8++aQZEae3e/ToIa1atZKcOXOm6vsFAABpg9eEpQEDBsjs2bMdt3XkmtIWI605UjqPko54UydPnpSFCxea6+XLl3d5LvtjtHVowYIFMmjQIFOjVLhwYROWnLvYAACAfwuwadUz7orWLGmhtwa1O9VEAYA3i4qKcrTmX7t2zZwhAfD132+/mmcJAAAguQhLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFghLAAAAFtJb3QkAgLPg4GCx2WwcFPgVWpYAAAAsEJYAAAAsEJYAAAAsEJYAAAAsEJYAAAAsEJYAAAAsEJYAAAAsEJYAAAAsEJYAAAB8ISwNHz5cqlWrJlmyZJEcOXIk6TFt27aVgIAAlyUiIsJlm0uXLknLli0lW7Zs5nnbt28v165d89C7AAAA3sZrwlJMTIw0bdpUOnfunKzHaTg6ffq0Y5k/f77L/RqU9uzZI8uXL5dFixbJunXrpGPHjm7eewAA4K285txwgwcPNpezZs1K1uMyZswoefPmTfC+vXv3ypIlS2Tr1q1SqVIls27y5MlSv359GTdunOTPn98New4AALyZ17QspdSaNWskLCxMSpQoYVqlLl686Lhv48aNpuvNHpRU7dq1JTAwUDZv3pzoc0ZHR8uVK1dcFgAA4Jt8OixpF9ycOXNk5cqVMnr0aFm7dq3Uq1dPbt++be4/c+aMCVLO0qdPL6Ghoea+xIwcOVKyZ8/uWAoUKODx9wIAAPwwLPXt2zdeAXbcZd++fSl+/ubNm0vDhg2lTJky0qhRI1OTpF1u2tp0N/r16yeRkZGO5fjx43f1fAAAIO1K1ZqlXr16mRFrVooUKeK219PnypUrlxw8eFBq1aplapnOnTvnss2tW7fMCLnE6pzsdVC62NlsNnNJdxwAAN7D/rtt/x1Pk2Epd+7cZrlXTpw4YWqW8uXLZ25XrVpVLl++LNu2bZOKFSuadatWrZLY2FipUqVKkp/36tWr5pLuOAAAvI/+jmtZjdePhjt27Jhp8dFLrTnauXOnWV+sWDEJCQkx18PDw009UePGjc1cSTqCrkmTJqaV6K+//pI+ffqY7evWrWu2L1mypKlr6tChg0ybNk1u3rwpXbp0Md13yRkJp9tqV1zWrFlN12FaTc8a5nQ/dU4pcLx9Cd9vjrcv4/vtOdqipEHpTr/5XhOWBgwYILNnz3bcrlChgrlcvXq11KxZ01zfv3+/qSFS6dKlk99//908RluP9EDUqVNHhg4d6tKFNnfuXBOQtFtOR8FpuJo0aVKy9k0f98ADD4g30KBEWOJ4+yq+3xxvX8b32zOsWpTsAmx36qiDz/xlol8IDZOEJY63r+H7zfH2ZXy/U59PTx0AAABwtwhLfkK7HgcOHOjSBQmOt6/g+83x9mV8v1Mf3XAAAAAWaFkCAACwQFgCAACwQFgCAACwQFgCAACwQFjyA1OmTJFChQpJpkyZzGlctmzZktq75JN09vhHH33UzOQeFhZmTt6sE6Xi3hg1apSZQb979+4ccg85efKktGrVSu677z7JnDmzOUn5r7/+yvH2AD1TRf/+/aVw4cLmWBctWtRMqszUiKmDsOTjPv/8c+nZs6eZNmD79u1Srlw5c7qXuCcQxt1bu3atvP7667Jp0yZZvny5OX2OzhofFRXF4fWwrVu3yvTp06Vs2bIcaw/5+++/5bHHHpMMGTLITz/9JH/88YeMHz9ecubMyTH3gNGjR8vUqVPl/fffl71795rbY8aMkcmTJ3O8UwFTB/g4bUnS1g79H07pSYL1HHFdu3aVvn37pvbu+bTz58+bFiYNUU888URq747P0vNAPvLII/LBBx/IsGHDpHz58vLee++l9m75HP33Yv369fLzzz+n9q74hWeeeUby5MkjH3/8sWOdno5LW5k+++yzVN03f0TLkg+LiYmRbdu2Se3atV3OY6e3N27cmKr75g/s5ykMDQ1N7V3xadqa16BBA5fvOdxv4cKFUqlSJWnatKn5I0DPz/nhhx9yqD2kWrVqsnLlSvnzzz/N7d9++01++eUXqVevHsc8FXjNiXSRfBcuXDD93vrXiTO9vW/fPg6pB2kLntbOaLdF6dKlOdYesmDBAtO9rN1w8KxDhw6ZbiHt1n/77bfNMe/WrZsEBQVJmzZtOPweaMnTc8KFh4ebE8Prv+XDhw+Xli1bcqxTAWEJ8FBrx+7du81fgvCM48ePyxtvvGHqw3TwAjz/B4C2LI0YMcLc1pYl/Y5PmzaNsOQBX3zxhcydO1fmzZsnDz/8sOzcudP8AZY/f36OdyogLPmwXLlymb9Izp4967Jeb+fNmzfV9svXdenSRRYtWiTr1q2TBx54ILV3x2dpF7MOVNB6JTv961uPu9boRUdHm+8/3CNfvnxSqlQpl3UlS5aUr7/+mkPsAb179zatS82bNze3deTh0aNHzahbWvLuPWqWfJg2j1esWNH0ezv/dai3q1atmqr75ot0SK8GpW+//VZWrVplhvzCc2rVqiW7du0yf3HbF2350G4KvU5Qci/tUo47FYbW0zz44INufiWo69evmxpTZ/qd1n/Dce/RsuTjtL5A/wrRH5HKlSubUUI6lL1du3apvWs+2fWmTebff/+9mWvpzJkzZn327NnNCBa4lx7juPVgwcHBZg4g6sTcr0ePHqboWLvhmjVrZuZrmzFjhlngfs8++6ypUSpYsKDphtuxY4dMmDBBXnnlFQ53KmDqAD+gXRJjx441P946rHrSpElmSgG4l06ImJCZM2dK27ZtOdz3QM2aNZk6wIO0e7lfv35y4MAB03Kqf4x16NDBky/pt65evWompdSWau1u1lqlFi1ayIABA0yvAe4twhIAAIAFapYAAAAsEJYAAAAsEJYAAAAsEJYAAAAsEJYAAAAsEJYAAAAsEJYAAAAsEJYA+NXEod99911q7wYAL0NYAuAzdJb6rl27SpEiRSRjxoxSoEABc9oI5/MjusuaNWtM+Lp8+bLbnxtA2sK54QD4hCNHjpiTvebIkcOc3kfP0n7z5k1ZunSpOW/fvn37JK2egPn27duSPj3/HANpFS1LAHzCa6+9Zlp69ASvTZo0kYceesicgFTPX7Zp06YktQzt3LnTrNPgpY4ePWpapnLmzGlO0qvPt3jxYnP/k08+abbR+/Qx9vP/6VnhR44cac6dpidQLleunHz11VfxXvenn36SihUrmhawX3755R4cIQApxZ8yALzepUuXZMmSJeYs7Rpq4tLWppTQFqmYmBhZt26ded4//vhDQkJCTPfe119/bULZ/v37JVu2bCYYKQ1Kn332mUybNk2KFy9uHtuqVSvJnTu31KhRw/Hcffv2lXHjxpkuQw1cANIuwhIAr3fw4EHTnRUeHu7W5z127JgJRNqlpzTY2IWGhprLsLAwRxiLjo6WESNGyIoVK6Rq1aqOx2jL0fTp013C0pAhQ+Tpp5926/4C8AzCEgCvp0HJE7p16yadO3eWZcuWSe3atU1wKlu2rGVou379erwQpK1TFSpUcFlXqVIlj+wzAPcjLAHwetrdpXVAySniDgwMjBe0tCDc2auvvip169aVH3/80QQm7WIbP368GXGXkGvXrplL3f7+++93uU9rk5wl1F0IIG2iwBuA19MuMQ01U6ZMkaioqHj3JzS8X2uI1OnTp10KvOPS+qROnTrJN998I7169ZIPP/zQrA8KCjKXOpLNrlSpUiYUafddsWLFXBZ9HgDeibAEwCdoUNLgUrlyZVN8feDAAdm7d69MmjTJUT/kzB5gBg0aZLbV1iBtNXLWvXt3M/XA4cOHZfv27bJ69WopWbKkue/BBx80rVmLFi2S8+fPm1alrFmzyptvvik9evSQ2bNny19//WUeN3nyZHMbgHciLAHwCVpIrcFEh/RrC1Dp0qVN7ZBOSDl16tR422fIkEHmz59vuu60Dmn06NEybNgwl200fOmIOA1IERERZjqCDz74wNyn3WyDBw82o9ry5MkjXbp0MeuHDh0q/fv3N1129sdpENOpBAB4pwCbpyojAQAAfAAtSwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAABYISwAAAJK4/wX50DIJH4A+ewAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "# STEP 5 Plot\n",
+        "from matplotlib import pyplot as plt\n",
+        "\n",
+        "plt.bar(range(10), betas, yerr=1.96 * ses)\n",
+        "plt.xlabel(\"Cluster\")\n",
+        "plt.ylabel(\"Elasticity Estimate\")\n",
+        "plt.title(\"Elasticity Estimates by Cluster\")\n",
+        "plt.show()"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuClass": "premium",
+      "gpuType": "T4",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "PM5",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.12"
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "0d455b129aa94e66acf068b361832e10": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "5827d74baf2a42888a162f8f6eb0f374": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "65881a1554d84ee6b898b5e7a91f5049": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "6cb6486d94a6441dbfbbe2d7f8406522": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_ce0b6b372d7d4a1bb7470218cb9d5ad1",
+            "placeholder": "​",
+            "style": "IPY_MODEL_b27378c804464461ab2529474e62fdb0",
+            "value": "Loading weights: 100%"
+          }
+        },
+        "a526a69c96d143778f9d2e166676d54e": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "b27378c804464461ab2529474e62fdb0": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "ce0b6b372d7d4a1bb7470218cb9d5ad1": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "d199dafd23444e40aa47a1fa0c79d7e4": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_a526a69c96d143778f9d2e166676d54e",
+            "placeholder": "​",
+            "style": "IPY_MODEL_5827d74baf2a42888a162f8f6eb0f374",
+            "value": " 199/199 [00:00&lt;00:00, 292.60it/s, Materializing param=pooler.dense.weight]"
+          }
+        },
+        "dc01248927d74c138456e3cab92d47b4": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "f36b2f4a6b1e416d80b480c4e928b3b4": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HBoxModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_6cb6486d94a6441dbfbbe2d7f8406522",
+              "IPY_MODEL_fc0c558eaf1f4713b5f58fdf20f501c4",
+              "IPY_MODEL_d199dafd23444e40aa47a1fa0c79d7e4"
+            ],
+            "layout": "IPY_MODEL_dc01248927d74c138456e3cab92d47b4"
+          }
+        },
+        "fc0c558eaf1f4713b5f58fdf20f501c4": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_0d455b129aa94e66acf068b361832e10",
+            "max": 199,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_65881a1554d84ee6b898b5e7a91f5049",
+            "value": 199
+          }
+        }
+      }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
### Background
The current version uses TensorFlow and other dependencies that are incompatible with the latest versions of Python. As a result, the notebook cannot be run in current environments (e.g. on Colab). 

This PR rewrites `DoubleML_and_Feature_Engineering_with_BERT.ipynb` to use PyTorch instead of TensorFlow/Keras, and switches the data source to a HuggingFace dataset. The pedagogical content and overall structure (feature extraction → linear probing → fine-tuning → DML elasticity estimation → clustering) are preserved. 

### Changes

#### Framework migration: TensorFlow → PyTorch
- Replaces `TFBertModel`, `tensorflow`, `tensorflow_addons`, and `livelossplot` with `torch`, `torch.nn`, and standard PyTorch training patterns.
- Removes Keras functional API (`Input`, `Dense`, `Model`, `model.fit()` with callbacks) in favour of a `BertRegressor(nn.Module)` class and a custom `train_model()` loop with early stopping.
- GPU detection changes from `tf.test.gpu_device_name()` to `torch.cuda.is_available()`.
- Model weights saved as `.pt` (PyTorch) instead of `.hdf5` (Keras).

#### Data source
- Replaces the local `amazon_toys.csv` (scraped number-of-reviews proxy) with the HuggingFace dataset `janteichertkluge/demand-analysis-repro`, which provides cleaner log-price (`P_bb_t`) and log-quantity (`Q_t`) variables and a pre-defined train/test split.
- The product category column is now sourced from `subcat_aggregated` directly, rather than being parsed from `amazon_category_and_sub_category`.

#### Code structure improvements
- Tokenization is refactored into a `tokenize_texts()` helper (returns `pt` tensors instead of `tf` tensors).
- Embedding extraction is encapsulated in `get_embeddings()` with `@torch.no_grad()` and explicit batching.
- A `predict()` utility handles batched inference throughout.
- The linear probing and fine-tuning phases are more clearly separated: BERT parameters are explicitly frozen/unfrozen, and the best linear-probing checkpoint is loaded as the fine-tuning starting point.
- The `make_loader()` helper replaces manual Keras input dict construction.
